### PR TITLE
Docs: Add a tip on how to load a fixed version of XR Blocks.

### DIFF
--- a/docs/docs/manual/Intro.mdx
+++ b/docs/docs/manual/Intro.mdx
@@ -33,6 +33,12 @@ To use an importmap, simply add the following importmap to your `index.html` pag
 </script>
 ```
 
+:::tip
+Using `xrblocks@build` loads the latest version of XR Blocks every time your web app loads.
+To pin a build of XR Blocks, replace `build` with an SHA from the [build branch](https://github.com/google/xrblocks/commits/build/).
+Alternatively, you can use version from the [xrblocks npm package](https://www.npmjs.com/package/xrblocks?activeTab=versions) using a URL such as https://cdn.jsdelivr.net/npm/xrblocks@0.1.0/build/xrblocks.js.
+:::
+
 Upon importing, XR Blocks automatically creates an `Core` singleton which will initialize a basic renderer and manage the lifecycle of the app.
 
 ## Setting up the scene.


### PR DESCRIPTION
<img width="3456" height="1916" alt="image" src="https://github.com/user-attachments/assets/610ba14c-a3f9-4259-b600-bc45617df13d" />
