### PR TITLE
ScreenshotSynthesizer: Render at a smaller 640 resolution

### DIFF
--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -79,8 +79,10 @@ export class Core {
   /** Manages all (spatial) audio playback. */
   sound = new CoreSound();
 
+  private renderSceneBound = this.renderScene.bind(this);
+
   /** Manages the desktop XR simulator. */
-  simulator = new Simulator(this.renderScene.bind(this));
+  simulator = new Simulator(this.renderSceneBound);
 
   /** Manages drag-and-drop interactions. */
   dragManager = new DragManager();
@@ -400,7 +402,8 @@ export class Core {
     }
 
     this.renderSimulatorAndScene();
-    this.screenshotSynthesizer.onAfterRender(this.renderer, this.deviceCamera);
+    this.screenshotSynthesizer.onAfterRender(
+        this.renderer, this.renderSceneBound, this.deviceCamera);
     if (this.simulatorRunning) {
       this.simulator.renderSimulatorScene();
     }


### PR DESCRIPTION
The ScreenshotSynthesizer creates dataurls of the current viewport in order to sent to Gemini in demos like Gemini Icebreakers.

Previously, we would take the existing render texture and get a dataurl from it. This is slow and takes up a bunch of memory because the full viewport resolution can be very large. So instead we should get a smaller resolution to save on encoding time and memory usage. On Quest 3, we can't seem to reuse the render target as a texture so I'm now doing an actual render pass of the main scene into a new render texture.

This PR also fixes an issue where the image we were sending to Gemini was very dark.

Example image from quest 3:
<img width="640" height="670" alt="download (1)" src="https://github.com/user-attachments/assets/0f69295c-7f41-490e-a837-b5c0f76a53a9" />

Performance before, where toDataURL would take 100-300 ms on Quest 3
<img width="1180" height="995" alt="Screenshot 2025-10-15 at 2 19 07 PM" src="https://github.com/user-attachments/assets/24314886-50eb-4860-a674-de1c4410ddff" />
<img width="1180" height="995" alt="Screenshot 2025-10-15 at 2 18 58 PM" src="https://github.com/user-attachments/assets/80e8a0d6-300e-4287-93ef-011c722e58e2" />

Performance after on Quest 3:
<img width="1180" height="995" alt="Screenshot 2025-10-15 at 2 17 03 PM" src="https://github.com/user-attachments/assets/5769cab1-5e93-4053-b6a5-34585066dfdc" />
<img width="1180" height="995" alt="Screenshot 2025-10-15 at 2 17 07 PM" src="https://github.com/user-attachments/assets/4fa69a95-0dcb-4b18-954e-086a47abf363" />

Tested on Quest 3, desktop simulator, and Moohan.