### PR TITLE
Clean up unnecessary `material.needsUpdate = true`

### DIFF
--- a/src/depth/DepthMesh.ts
+++ b/src/depth/DepthMesh.ts
@@ -157,7 +157,6 @@ export class DepthMesh extends MeshScript {
           this.depthTextures!.depthData.length ?
           this.depthTextures!.depthData[0].rawValueToMeters :
           1.0;
-      (this.material as THREE.Material).needsUpdate = true;
     }
 
     if (this.options.updateVertexNormals) {

--- a/src/ui/components/ImageView.ts
+++ b/src/ui/components/ImageView.ts
@@ -62,7 +62,6 @@ export class ImageView extends View {
       // If no source, ensure no texture is displayed.
       if (this.material.map) {
         this.material.map = null;
-        this.material.needsUpdate = true;
       }
       this.texture?.dispose();
       this.texture = undefined;
@@ -73,7 +72,6 @@ export class ImageView extends View {
     this.texture = this.textureLoader.load(this.src, (loadedTexture) => {
       loadedTexture.colorSpace = THREE.SRGBColorSpace;
       this.material.map = loadedTexture;
-      this.material.needsUpdate = true;
       // Updates layout after the image has loaded to get correct dimensions.
       this.updateLayout();
     });

--- a/src/ui/components/TextView.ts
+++ b/src/ui/components/TextView.ts
@@ -357,7 +357,6 @@ export class TextView extends View<TextViewEventMap> {
           texture.offset.x = this.imageOffsetX;
           const textObj = this.textObj as unknown as TroikaThreeText.Text;
           textObj.material.map = texture;
-          textObj.material.needsUpdate = true;
           textObj.sync();
         });
       }

--- a/src/ui/components/VideoView.ts
+++ b/src/ui/components/VideoView.ts
@@ -184,7 +184,6 @@ export class VideoView extends View {
 
     this.texture = videoTextureInstance;  // Update internal texture reference
     this.material.map = this.texture;
-    this.material.needsUpdate = true;
 
     const onLoadedMetadata = () => {
       if (this.video!.videoWidth && this.video!.videoHeight) {
@@ -212,7 +211,6 @@ export class VideoView extends View {
   loadFromVideoTexture(videoTextureInstance: THREE.VideoTexture) {
     this.texture = videoTextureInstance;
     this.material.map = this.texture;
-    this.material.needsUpdate = true;
     this.video = this.texture.image;  // Underlying HTMLVideoElement
 
     if (this.video && this.video.videoWidth && this.video.videoHeight) {


### PR DESCRIPTION
Based on [three.js docs](https://threejs.org/docs/#api/en/materials/Material.needsUpdate), needsUpdate signals for the material to be recompiled. Setting uniforms doesn't require recompiling the material.