### PR TITLE
Run build in `prepare` lifecycle script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "rollup -c -w",
     "build": "echo \"Building xrblocks.js...\" && rollup -c",
-    "prepublishOnly": "npm run build"
+    "prepare": "npm run build"
   },
   "files": [
     "build"


### PR DESCRIPTION
The benefit is that `prepare` runs when installing xrblocks using a git url. The prepare step also runs when publishing so we can remove the prepublishOnly step.

See https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts