### PR TITLE
Get occlusion and depthmap demos working on Quest 3.

### DIFF
--- a/samples/depthmap/DepthVisualizationPass.js
+++ b/samples/depthmap/DepthVisualizationPass.js
@@ -18,7 +18,9 @@ export class DepthVisualizationPass extends xb.XRPass {
       uAlpha: {value: 1.0},
       tDiffuse: {value: null},
       uView: {value: 0},
-      uIsTextureArray: {value: 0}
+      uIsTextureArray: {value: 0},
+      // Used to interpret Quest 3 depth.
+      uDepthNear: {value: 0}
     };
     this.depthMapQuad = new FullScreenQuad(new THREE.ShaderMaterial({
       name: 'DepthMapShader',
@@ -37,21 +39,21 @@ export class DepthVisualizationPass extends xb.XRPass {
     this.depthTextures[1] = xrDepth.getTexture(1);
     this.uniforms.uRawValueToMeters.value = xrDepth.rawValueToMeters;
     if (this.depthTextures[0]) {
-      this.uniforms.uIsTextureArray.value = this.depthTextures[0].isExternalTexture ? 1.0 : 0;
+      this.uniforms.uIsTextureArray.value =
+          this.depthTextures[0].isExternalTexture ? 1.0 : 0;
     }
   }
 
   render(renderer, writeBuffer, readBuffer, deltaTime, maskActive, viewId) {
-    // Fuse the rendered image and the occlusion map.
     const texture = this.depthTextures[viewId];
-
-    if (!texture)
-      return;
-
-    if (texture.isExternalTexture) 
+    if (!texture) return;
+    if (texture.isExternalTexture) {
       this.uniforms.uDepthTextureArray.value = texture;
-    else
+      const depthNear = xb.core.depth.gpuDepthData[0].depthNear;
+      this.uniforms.uDepthNear.value = depthNear;
+    } else {
       this.uniforms.uDepthTexture.value = texture;
+    }
     this.uniforms.tDiffuse.value = readBuffer.texture;
     this.uniforms.uView.value = viewId;
     renderer.setRenderTarget(this.renderToScreen ? null : writeBuffer);

--- a/samples/depthmap/depthmap.glsl.js
+++ b/samples/depthmap/depthmap.glsl.js
@@ -22,6 +22,7 @@ export const DepthMapShader = {
   uniform float uAlpha;
   uniform float uIsTextureArray;
   uniform int uView;
+  uniform float uDepthNear;
 
   uniform sampler2D tDiffuse;
   uniform float cameraNear;
@@ -35,7 +36,8 @@ export const DepthMapShader = {
   }
 
   float DepthArrayGetMeters(in sampler2DArray depth_texture, in vec2 depth_uv) {
-    return uRawValueToMeters * texture(depth_texture, vec3 (depth_uv.x, depth_uv.y, uView)).r;
+    float textureValue = texture(depth_texture, vec3(depth_uv.x, depth_uv.y, uView)).r;
+    return uRawValueToMeters * uDepthNear / (1.0 - textureValue);
   }
 
   vec3 TurboColormap(in float x) {

--- a/src/depth/Depth.ts
+++ b/src/depth/Depth.ts
@@ -300,12 +300,16 @@ export class Depth {
     const leftDepthTexture = this.getTexture(0);
     if (leftDepthTexture) {
       this.occlusionPass!.setDepthTexture(
-          leftDepthTexture, this.rawValueToMeters, 0);
+          leftDepthTexture, this.rawValueToMeters, 0,
+          (this.gpuDepthData[0] as unknown as {depthNear: number} | undefined)
+              ?.depthNear);
     }
     const rightDepthTexture = this.getTexture(1);
     if (rightDepthTexture) {
       this.occlusionPass!.setDepthTexture(
-          rightDepthTexture, this.rawValueToMeters, 1);
+          rightDepthTexture, this.rawValueToMeters, 1,
+          (this.gpuDepthData[1] as unknown as {depthNear: number} | undefined)
+              ?.depthNear);
     }
     const xrIsPresenting = this.renderer.xr.isPresenting;
     this.renderer.xr.isPresenting = false;


### PR DESCRIPTION
For Quest 3, apparently the depth texture value needs to be interpreted using depthNear. Fixes #16

![xrblocks_quest3_occlusion_20251020](https://github.com/user-attachments/assets/63396d09-4878-4663-8e21-11404c4ea554)
![xrblocks_quest3_depthmap_20251020](https://github.com/user-attachments/assets/a570721b-2e6d-4e4a-9ce4-34e74e84eed1)
