### PR TITLE
Allow specifying live model through startLiveSession()

### DIFF
--- a/src/ai/AI.ts
+++ b/src/ai/AI.ts
@@ -187,7 +187,10 @@ export class AI extends Script {
     return await this.model!.query(input, tools);
   }
 
-  async startLiveSession(config: GeminiStartLiveSessionParams = {}) {
+  async startLiveSession(
+    config: GeminiStartLiveSessionParams = {},
+    model?: string
+  ) {
     if (!this.model) {
       throw new Error('AI model is not initialized.');
     }
@@ -196,7 +199,7 @@ export class AI extends Script {
     }
     this.lock = true;
     try {
-      const session = await this.model.startLiveSession(config);
+      const session = await this.model.startLiveSession(config, model);
       return session;
     } catch (error) {
       this.lock = false;

--- a/src/ai/Gemini.ts
+++ b/src/ai/Gemini.ts
@@ -89,7 +89,10 @@ export class Gemini extends BaseAIModel {
     return this.isAvailable() && EndSensitivity && StartSensitivity && Modality;
   }
 
-  async startLiveSession(params: GeminiStartLiveSessionParams = {}) {
+  async startLiveSession(
+    params: GeminiStartLiveSessionParams = {},
+    model = 'gemini-2.5-flash-native-audio-preview-09-2025'
+  ) {
     if (!this.isLiveAvailable()) {
       throw new Error(
         'Live API not available. Make sure @google/genai module is loaded.'
@@ -156,7 +159,7 @@ export class Gemini extends BaseAIModel {
     };
     try {
       const connectParams: GoogleGenAITypes.LiveConnectParameters = {
-        model: 'gemini-2.5-flash-preview-native-audio-dialog',
+        model: model,
         callbacks: callbacks,
         config: defaultConfig,
       };


### PR DESCRIPTION
The existing model is now deprecated so this is necessary for startLiveSession to work.

Replace gemini-2.5-flash-preview-native-audio-dialog with gemini-2.5-flash-native-audio-preview-09-2025