### PR TITLE
Make AI.startLiveSession take a GoogleGenAITypes.LiveConnectConfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@dimforge/rapier3d": "^0.19.2",
         "@eslint/js": "^9.35.0",
-        "@google/genai": "^1.15.0",
+        "@google/genai": "^1.28.0",
         "@rollup/plugin-inject": "^5.0.5",
         "@rollup/plugin-node-resolve": "^16.0.1",
         "@rollup/plugin-replace": "^6.0.2",
@@ -223,9 +223,9 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.27.0.tgz",
-      "integrity": "sha512-sveeQqwyzO/U5kOjo3EflF1rf7v0ZGprrjPGmeT6V5u22IUTcA4wBFxW+q1n7hOX0M1iWR3944MImoNPOM+zsA==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.28.0.tgz",
+      "integrity": "sha512-0pfZ1EWQsM9kINsL+mFKJvpzM6NRHS9t360S1MzKq4JtIwTj/RbsPpC/K5wpKiPy9PC+J+bsz/9gvaL51++KrA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@dimforge/rapier3d": "^0.19.2",
     "@eslint/js": "^9.35.0",
-    "@google/genai": "^1.15.0",
+    "@google/genai": "^1.28.0",
     "@rollup/plugin-inject": "^5.0.5",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-replace": "^6.0.2",

--- a/src/addons/ai/GeminiManager.ts
+++ b/src/addons/ai/GeminiManager.ts
@@ -48,7 +48,7 @@ export class GeminiManager extends xb.Script<GeminiManagerEventMap> {
     liveParams,
     model,
   }: {
-    liveParams?: xb.GeminiStartLiveSessionParams;
+    liveParams?: GoogleGenAITypes.LiveConnectConfig;
     model?: string;
   } = {}) {
     if (this.isAIRunning || !this.ai) {
@@ -58,9 +58,9 @@ export class GeminiManager extends xb.Script<GeminiManagerEventMap> {
 
     liveParams = liveParams || {};
     liveParams.tools = liveParams.tools || [];
-    for (const tool of this.tools) {
-      liveParams.tools.push(tool.toJSON());
-    }
+    liveParams.tools.push({
+      functionDeclarations: this.tools.map((tool) => tool.toJSON()),
+    });
     try {
       await this.setupAudioCapture();
       await this.startLiveAI(liveParams, model);
@@ -130,7 +130,10 @@ export class GeminiManager extends xb.Script<GeminiManagerEventMap> {
     this.processorNode.connect(this.audioContext.destination);
   }
 
-  async startLiveAI(params: xb.GeminiStartLiveSessionParams, model?: string) {
+  async startLiveAI(
+    params: GoogleGenAITypes.LiveConnectConfig,
+    model?: string
+  ) {
     return new Promise<void>((resolve, reject) => {
       this.ai.setLiveCallbacks({
         onopen: () => {

--- a/src/agent/SkyboxAgent.ts
+++ b/src/agent/SkyboxAgent.ts
@@ -119,7 +119,7 @@ export class SkyboxAgent extends Agent {
     };
 
     await this.ai.startLiveSession({
-      tools: functionDeclarations,
+      tools: [{functionDeclarations}],
       systemInstruction: systemInstruction,
     });
 

--- a/src/ai/AI.ts
+++ b/src/ai/AI.ts
@@ -5,7 +5,7 @@ import {getUrlParameter} from '../utils/utils';
 
 import {AIOptions, GeminiOptions, OpenAIOptions} from './AIOptions';
 import {GeminiResponse} from './AITypes';
-import {Gemini, GeminiStartLiveSessionParams} from './Gemini';
+import {Gemini} from './Gemini';
 import {OpenAI} from './OpenAI';
 
 export type ModelClass = Gemini | OpenAI;
@@ -188,7 +188,7 @@ export class AI extends Script {
   }
 
   async startLiveSession(
-    config: GeminiStartLiveSessionParams = {},
+    config: GoogleGenAITypes.LiveConnectConfig = {},
     model?: string
   ) {
     if (!this.model) {

--- a/src/ai/Gemini.ts
+++ b/src/ai/Gemini.ts
@@ -54,11 +54,6 @@ export interface GeminiQueryInput {
   data?: GoogleGenAITypes.LiveSendRealtimeInputParameters;
 }
 
-export type GeminiStartLiveSessionParams = {
-  tools?: GoogleGenAITypes.FunctionDeclaration[];
-  systemInstruction?: GoogleGenAITypes.ContentUnion | string;
-};
-
 export class Gemini extends BaseAIModel {
   inited = false;
   liveSession?: GoogleGenAITypes.Session;
@@ -90,7 +85,7 @@ export class Gemini extends BaseAIModel {
   }
 
   async startLiveSession(
-    params: GeminiStartLiveSessionParams = {},
+    params: GoogleGenAITypes.LiveConnectConfig = {},
     model = 'gemini-2.5-flash-native-audio-preview-09-2025'
   ) {
     if (!this.isLiveAvailable()) {
@@ -110,20 +105,8 @@ export class Gemini extends BaseAIModel {
       },
       outputAudioTranscription: {},
       inputAudioTranscription: {},
+      ...params,
     };
-
-    if (params.tools && params.tools.length > 0) {
-      defaultConfig.tools = [{functionDeclarations: params.tools}];
-    }
-    if (params.systemInstruction) {
-      if (typeof params.systemInstruction === 'string') {
-        defaultConfig.systemInstruction = createUserContent!(
-          params.systemInstruction
-        );
-      } else {
-        defaultConfig.systemInstruction = params.systemInstruction;
-      }
-    }
 
     const callbacks: GoogleGenAITypes.LiveCallbacks = {
       onopen: () => {


### PR DESCRIPTION
Currently, we can only pass in function declarations so we can't enable googleSearch. This moves the `[{functionDeclarations}]` part of out Gemini.ts and lets us pass in other tools like googleSearch.