### PR TITLE
Delete onDesktopUserAgent, show Enter XR if webxr is available.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xrblocks",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "XR Blocks SDK",
   "main": "build/xrblocks.js",
   "types": "build/xrblocks.d.ts",

--- a/src/core/Options.ts
+++ b/src/core/Options.ts
@@ -121,10 +121,8 @@ export class Options {
     invalidText: 'XR Not Supported',
     startSimulatorText: 'Enter Simulator',
     enableSimulator: true,
-    showSimulatorButtonOnMobile: false,
-    autostartSimulatorOnDesktop: true,
-    // Whether to always autostart the simulator.
-    autostartSimulator: false,
+    // Whether to autostart the simulator even if WebXR is available.
+    alwaysAutostartSimulator: false,
   };
 
   /**

--- a/src/core/components/XRButton.ts
+++ b/src/core/components/XRButton.ts
@@ -1,5 +1,3 @@
-import {onDesktopUserAgent} from '../../utils/BrowserUtils';
-
 import {
   WebXRSessionEventType,
   WebXRSessionManager,
@@ -20,16 +18,12 @@ export class XRButton {
     private invalidText = 'XR NOT SUPPORTED',
     private startSimulatorText = 'START SIMULATOR',
     enableSimulator = false,
-    showSimulatorButtonOnMobile = false,
     public startSimulator = () => {}
   ) {
     this.domElement.id = XRBUTTON_WRAPPER_ID;
     this.createXRButtonElement();
 
-    if (
-      enableSimulator &&
-      (onDesktopUserAgent() || showSimulatorButtonOnMobile)
-    ) {
+    if (enableSimulator) {
       this.createSimulatorButton();
     }
 

--- a/src/depth/Depth.ts
+++ b/src/depth/Depth.ts
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 
 import {Registry} from '../core/components/Registry';
-import {onDesktopUserAgent} from '../utils/BrowserUtils';
 import type {Shader} from '../utils/Types';
 import {clamp} from '../utils/utils';
 
@@ -244,9 +243,9 @@ export class Depth {
     return this.depthTextures?.get(view_id);
   }
 
-  update(frame: XRFrame) {
+  update(frame?: XRFrame) {
     if (!this.options.enabled) return;
-
+    if (!frame) return;
     this.updateLocalDepth(frame);
     if (this.options.occlusion.enabled) {
       this.renderOcclusionPass();
@@ -254,17 +253,12 @@ export class Depth {
   }
 
   updateLocalDepth(frame: XRFrame) {
-    if (onDesktopUserAgent()) {
-      return;
-    }
-
     const leftCamera = this.renderer.xr?.getCamera?.()?.cameras?.[0];
     if (leftCamera && this.depthMesh && this.depthMesh.parent != leftCamera) {
       leftCamera.add(this.depthMesh);
       this.scene.add(leftCamera);
     }
 
-    if (!frame) return;
     const session = frame.session;
     const binding = this.renderer.xr.getBinding();
 

--- a/src/utils/BrowserUtils.ts
+++ b/src/utils/BrowserUtils.ts
@@ -1,3 +1,0 @@
-export function onDesktopUserAgent() {
-  return !/Mobi|Android|iPhone/i.test(navigator.userAgent);
-}

--- a/src/xrblocks.ts
+++ b/src/xrblocks.ts
@@ -99,7 +99,6 @@ export * from './ui/layouts/SpatialPanel';
 export * from './ui/layouts/TextScrollerState';
 export * from './ui/layouts/VerticalPager';
 export * from './ui/UI';
-export * from './utils/BrowserUtils';
 export * from './utils/DependencyInjection';
 export * from './utils/HelperConstants';
 export * from './utils/Keycodes';


### PR DESCRIPTION
The useragent on Moohan is Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/[138.0.0.0](http://138.0.0.0/) Safari/537.36

Previously, we had a hack to just check Linux. However this isn't great because it prevents the simulator from starting on linux desktop machines. Now, we always show "Enter XR" and "Enter Simulator" buttons if WebXR is supported.