### PR TITLE
Fix: sized Description text and graph

### DIFF
--- a/demos/math3d/Math3D.js
+++ b/demos/math3d/Math3D.js
@@ -69,7 +69,7 @@ export class Math3D extends xb.Script {
           new xb.TextButton({
             text: initialFunction,
             fontColor: '#ffffff',
-            fontSize: 0.06,
+            fontSize: 0.2,
             backgroundColor: '#00000000', // Make background transparent
           })
         );
@@ -193,7 +193,7 @@ export class Math3D extends xb.Script {
     );
     // Rotate 90 degrees around X so that the Z axis points upwards.
     graphGeometry.rotateX(-Math.PI / 2);
-    graphGeometry.scale(0.025, 0.025, 0.025);
+    graphGeometry.scale(0.015, 0.015, 0.015);
     const textureLoader = new THREE.TextureLoader();
     const texture = textureLoader.load('images/gradient.png');
     const material = new THREE.MeshBasicMaterial({


### PR DESCRIPTION
### Changes made
1) Increased font size of the description text
2) Shrunk the graph


<img width="631" height="811" alt="image" src="https://github.com/user-attachments/assets/e650287e-af6b-448d-9188-5a7cdb5002e4" />


### Open issue
There is a static dark box in the back of the room that is extraneous, and probably can be removed.
