### PR TITLE
Change the default audio schedule ahead time to 1 second and make it …

### DIFF
--- a/src/addons/ai/GeminiManager.ts
+++ b/src/addons/ai/GeminiManager.ts
@@ -3,6 +3,8 @@ import * as THREE from 'three';
 import * as xb from 'xrblocks';
 import {AUDIO_CAPTURE_PROCESSOR_CODE} from './AudioCaptureProcessorCode';
 
+const DEFAULT_SCHEDULE_AHEAD_TIME = 1.0;
+
 export interface GeminiManagerEventMap extends THREE.Object3DEventMap {
   inputTranscription: {message: string};
   outputTranscription: {message: string};
@@ -36,6 +38,8 @@ export class GeminiManager extends xb.Script<GeminiManagerEventMap> {
   currentInputText: string = '';
   currentOutputText: string = '';
   tools: xb.Tool[] = [];
+
+  scheduleAheadTime = DEFAULT_SCHEDULE_AHEAD_TIME;
 
   constructor() {
     super();
@@ -245,11 +249,10 @@ export class GeminiManager extends xb.Script<GeminiManagerEventMap> {
   }
 
   scheduleAudioBuffers() {
-    const SCHEDULE_AHEAD_TIME = 0.2;
     while (
       this.audioQueue.length > 0 &&
       this.nextAudioStartTime <=
-        this.audioContext!.currentTime + SCHEDULE_AHEAD_TIME
+        this.audioContext!.currentTime + this.scheduleAheadTime
     ) {
       const audioBuffer = this.audioQueue.shift()!;
       const source = this.audioContext!.createBufferSource();

--- a/src/sound/AudioPlayer.ts
+++ b/src/sound/AudioPlayer.ts
@@ -2,6 +2,8 @@ import {Script} from '../core/Script.js';
 
 import {CategoryVolumes} from './CategoryVolumes';
 
+const DEFAULT_SCHEDULE_AHEAD_TIME = 1.0;
+
 export interface AudioPlayerOptions {
   sampleRate?: number;
   channelCount?: number;
@@ -17,6 +19,7 @@ export class AudioPlayer extends Script {
   private categoryVolumes?: CategoryVolumes;
   private volume = 1.0;
   private category = 'speech';
+  scheduleAheadTime = DEFAULT_SCHEDULE_AHEAD_TIME;
 
   constructor(options: AudioPlayerOptions = {}) {
     super();
@@ -101,10 +104,10 @@ export class AudioPlayer extends Script {
   }
 
   private scheduleAudioBuffers() {
-    const SCHEDULE_AHEAD_TIME = 0.2;
     while (
       this.audioQueue.length > 0 &&
-      this.nextStartTime <= this.audioContext!.currentTime + SCHEDULE_AHEAD_TIME
+      this.nextStartTime <=
+        this.audioContext!.currentTime + this.scheduleAheadTime
     ) {
       const audioBuffer = this.audioQueue.shift()!;
       const currentTime = this.audioContext!.currentTime;


### PR DESCRIPTION
…customizable.

In https://github.com/dli7319/interior-design-xr, we found that the Gemini Live audio would be a little choppy at 0.2 seconds.