### PR TITLE
Remove options.enableGeminiLive()

### DIFF
--- a/demos/aisimulator/main.js
+++ b/demos/aisimulator/main.js
@@ -6,7 +6,7 @@ import * as xb from 'xrblocks';
 import {AISimulator} from './AISimulator.js';
 
 const options = new xb.Options();
-options.enableGeminiLive();
+options.simulator.geminiLivePanel.enabled = true;
 options.depth.enabled = true;
 options.depth.depthTexture.enabled = true;
 options.depth.occlusion.enabled = true;

--- a/src/core/Options.ts
+++ b/src/core/Options.ts
@@ -237,15 +237,6 @@ export class Options {
   }
 
   /**
-   * Enables the Gemini Live feature.
-   * @returns The instance for chaining.
-   */
-  enableGeminiLive() {
-    this.simulator.geminilive = true;
-    return this;
-  }
-
-  /**
    * Enables a standard set of AI features, including Gemini Live.
    * @returns The instance for chaining.
    */

--- a/src/simulator/SimulatorInterface.ts
+++ b/src/simulator/SimulatorInterface.ts
@@ -57,8 +57,10 @@ export class SimulatorInterface {
   }
 
   showGeminiLivePanel(simulatorOptions: SimulatorOptions) {
-    if (simulatorOptions.geminilive) {
-      const element = document.createElement('xrblocks-simulator-geminilive');
+    if (simulatorOptions.geminiLivePanel.enabled) {
+      const element = document.createElement(
+        simulatorOptions.geminiLivePanel.element
+      );
       document.body.appendChild(element);
       this.elements.push(element);
     }

--- a/src/simulator/SimulatorOptions.ts
+++ b/src/simulator/SimulatorOptions.ts
@@ -43,7 +43,10 @@ export class SimulatorOptions {
     enabled: true,
     element: 'xrblocks-simulator-hand-pose-panel',
   };
-  geminilive = false;
+  geminiLivePanel = {
+    enabled: false,
+    element: 'xrblocks-simulator-geminilive',
+  };
   stereo = {
     enabled: false,
   };


### PR DESCRIPTION
It's very confusing why we have enableGeminiLive() and enableAI(). This option adds a gemini live text interface to the simulator. It is only used in /demo/aisimulator/.