### PR TITLE
Change default image model to gemini-2.5-flash-image

### DIFF
--- a/src/agent/tools/GenerateSkyboxTool.ts
+++ b/src/agent/tools/GenerateSkyboxTool.ts
@@ -41,8 +41,7 @@ export class GenerateSkyboxTool extends Tool {
         'Generate a 360 equirectangular skybox image for the prompt of:' +
           args.prompt,
         'image',
-        'Generate a 360 equirectangular skybox image for the prompt',
-        'gemini-2.5-flash-image-preview'
+        'Generate a 360 equirectangular skybox image for the prompt'
       );
       if (image) {
         console.log('Applying texture...');

--- a/src/ai/AI.ts
+++ b/src/ai/AI.ts
@@ -261,7 +261,7 @@ export class AI extends Script {
     prompt: string | string[],
     type: 'image' = 'image',
     systemInstruction = 'Generate an image',
-    model = 'gemini-2.5-flash-image-preview'
+    model = undefined
   ) {
     return this.model!.generate(prompt, type, systemInstruction, model);
   }

--- a/src/ai/Gemini.ts
+++ b/src/ai/Gemini.ts
@@ -274,7 +274,7 @@ export class Gemini extends BaseAIModel {
     prompt: string | string[],
     type: 'image' = 'image',
     systemInstruction = 'Generate an image',
-    model = 'gemini-2.5-flash-image-preview'
+    model = 'gemini-2.5-flash-image'
   ) {
     if (!this.isAvailable()) return;
 


### PR DESCRIPTION
`gemini-2.5-flash-image-preview` is deprecated and replaced by `gemini-2.5-flash-image`.

See https://ai.google.dev/gemini-api/docs/models#gemini-2.5-flash-image