### PR TITLE
Use depth view in object detection

### DIFF
--- a/demos/gemini-xrobject/main.js
+++ b/demos/gemini-xrobject/main.js
@@ -20,6 +20,7 @@ options.depth.enabled = true;
 options.depth.depthMesh.updateFullResolutionGeometry = true;
 options.depth.depthMesh.renderShadow = true;
 options.depth.depthTexture.enabled = true;
+options.depth.matchDepthView = false;
 options.hands.enabled = true;
 options.hands.visualization = false;
 options.hands.visualizeMeshes = false;


### PR DESCRIPTION
Setting matchDepthView to false allows us to use depth without incurring the performance penalty of Chrome reprojecting the depth. Now, we reproject the depth samples when running object detection which should be much faster.

Tested on Moohan only.