### PR TITLE
Disable depth texture in gemini-xrobject

### DIFF
--- a/demos/gemini-xrobject/main.js
+++ b/demos/gemini-xrobject/main.js
@@ -19,7 +19,7 @@ options.world.enableObjectDetection();
 options.depth.enabled = true;
 options.depth.depthMesh.updateFullResolutionGeometry = true;
 options.depth.depthMesh.renderShadow = true;
-options.depth.depthTexture.enabled = true;
+options.depth.depthTexture.enabled = false;
 options.depth.matchDepthView = false;
 options.hands.enabled = true;
 options.hands.visualization = false;


### PR DESCRIPTION
Because we're using float depth, we need to convert to float16 on CPU before uploading to GPU. This is one source of fps problems.

