### PR TITLE
Use Float32Array and FloatType directly for depth textures

### DIFF
--- a/src/depth/DepthTextures.ts
+++ b/src/depth/DepthTextures.ts
@@ -3,7 +3,7 @@ import * as THREE from 'three';
 import {DepthOptions} from './DepthOptions';
 
 export class DepthTextures {
-  private uint16Arrays: Uint16Array[] = [];
+  private float32Arrays: Float32Array[] = [];
   private uint8Arrays: Uint8Array[] = [];
   private dataTextures: THREE.DataTexture[] = [];
   private nativeTextures: THREE.ExternalTexture[] = [];
@@ -19,10 +19,10 @@ export class DepthTextures {
       this.dataTextures[view_id].dispose();
     }
     if (this.options.useFloat32) {
-      const typedArray = new Uint16Array(depthData.width * depthData.height);
+      const typedArray = new Float32Array(depthData.width * depthData.height);
       const format = THREE.RedFormat;
-      const type = THREE.HalfFloatType;
-      this.uint16Arrays[view_id] = typedArray;
+      const type = THREE.FloatType;
+      this.float32Arrays[view_id] = typedArray;
       this.dataTextures[view_id] = new THREE.DataTexture(
         typedArray,
         depthData.width,
@@ -54,12 +54,7 @@ export class DepthTextures {
       this.createDataDepthTextures(depthData, view_id);
     }
     if (this.options.useFloat32) {
-      const float32Data = new Float32Array(depthData.data);
-      const float16Data = new Uint16Array(float32Data.length);
-      for (let i = 0; i < float16Data.length; i++) {
-        float16Data[i] = THREE.DataUtils.toHalfFloat(float32Data[i]);
-      }
-      this.uint16Arrays[view_id].set(float16Data);
+      this.float32Arrays[view_id].set(new Float32Array(depthData.data));
     } else {
       this.uint8Arrays[view_id].set(new Uint8Array(depthData.data));
     }


### PR DESCRIPTION
This uses double the vram but saves us the CPU conversion to float16.