### PR TITLE
use options passed into VideoView

### DIFF
--- a/src/ui/components/VideoView.ts
+++ b/src/ui/components/VideoView.ts
@@ -70,7 +70,7 @@ export class VideoView extends View {
     this.playsInline = options.playsInline ?? this.playsInline;
     if (options.crossOrigin) this.crossOrigin = options.crossOrigin;
     if (options.mode) this.mode = options.mode;
-    
+
     const videoGeometry = new THREE.PlaneGeometry(1, 1);
     const videoMaterial = new THREE.MeshBasicMaterial({
       transparent: true,


### PR DESCRIPTION
I could not figure out why 
videoRow.addVideo({
    src: 'https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
    autoplay: false
});

would not stop the video in the UI demo (https://xrblocks.github.io/docs/samples/UI/) from autoplaying. Looked though the code and saw that the options weren't being used in the constructor and that the default values were being used no matter what.

This should allow users to pass in options for the video.

Thanks