### PR TITLE
Make getSnapshot async for base64.

### DIFF
--- a/src/addons/ai/GeminiManager.ts
+++ b/src/addons/ai/GeminiManager.ts
@@ -171,9 +171,9 @@ export class GeminiManager extends xb.Script<GeminiManagerEventMap> {
     }, intervalMs);
   }
 
-  captureAndSendScreenshot() {
+  async captureAndSendScreenshot() {
     try {
-      const base64Image = this.xrDeviceCamera!.getSnapshot({
+      const base64Image = await this.xrDeviceCamera!.getSnapshot({
         outputFormat: 'base64',
         mimeType: 'image/jpeg',
         quality: 1,

--- a/src/world/objects/ObjectDetector.ts
+++ b/src/world/objects/ObjectDetector.ts
@@ -115,19 +115,19 @@ export class ObjectDetector extends Script {
       return [];
     }
 
-    const base64Image = this.deviceCamera.getSnapshot({
+    // Cache depth and camera data to align with the captured image frame.
+    const cachedDepthArray = this.depth.depthArray[0].slice(0);
+    const cachedMatrixWorld = this.camera.matrixWorld.clone();
+
+    const base64Image = await this.deviceCamera.getSnapshot({
       outputFormat: 'base64',
-    }) as string | null;
+    });
     if (!base64Image) {
       console.warn('Could not get device camera snapshot.');
       return [];
     }
 
     const {mimeType, strippedBase64} = parseBase64DataURL(base64Image);
-
-    // Cache depth and camera data to align with the captured image frame.
-    const cachedDepthArray = this.depth.depthArray[0].slice(0);
-    const cachedMatrixWorld = this.camera.matrixWorld.clone();
 
     // Temporarily set the Gemini config for this specific query type.
     const originalGeminiConfig = this.aiOptions.gemini.config;


### PR DESCRIPTION
The canvas.toDataURL() method is blocking. Converting to a blob and then reading the blob to base64 is non-blocking.

This is a breaking change. There's no significant performance increase right now, but it allows us to use the ImageCapture API for the webcam in a followup PR.

Before:
<img width="3200" height="1651" alt="image" src="https://github.com/user-attachments/assets/d1655f84-8be4-4db9-98f8-4c6e655b26ce" />
After:
<img width="3200" height="1651" alt="image" src="https://github.com/user-attachments/assets/7a12954d-1e29-4d81-9222-abaa848d1583" />
