### PR TITLE
Create Raycaster with custom sorting function

### DIFF
--- a/src/core/components/Raycaster.ts
+++ b/src/core/components/Raycaster.ts
@@ -1,0 +1,75 @@
+import * as THREE from 'three';
+
+// Sorting function which uses the render order to try to find which element is on top.
+function defaultSortFunction(a: THREE.Intersection, b: THREE.Intersection) {
+  // 1. Primary: Distance (Ascending).
+  // Return physically closer objects first.
+  const distDiff = a.distance - b.distance;
+  if (Math.abs(distDiff) > 0.00001) {
+    return distDiff;
+  }
+
+  // 2. Secondary: Render Order (Descending).
+  // Higher renderOrder = drawn later = on top.
+  if (a.object.renderOrder !== b.object.renderOrder) {
+    return b.object.renderOrder - a.object.renderOrder;
+  }
+
+  // 3. Fallback to id (Descending).
+  // Higher id = created later.
+  return b.object.id - a.object.id;
+}
+
+function intersect(
+  object: THREE.Object3D,
+  raycaster: THREE.Raycaster,
+  intersects: THREE.Intersection[],
+  recursive: boolean
+) {
+  let propagate = true;
+
+  if (object.layers.test(raycaster.layers)) {
+    const result = object.raycast(raycaster, intersects);
+
+    if ((result as unknown as boolean) === false) propagate = false;
+  }
+
+  if (propagate === true && recursive === true) {
+    const children = object.children;
+
+    for (let i = 0, l = children.length; i < l; i++) {
+      intersect(children[i], raycaster, intersects, true);
+    }
+  }
+}
+
+// Raycaster which allows setting a custom sorting function. This is mainly useful to identify the clicked element for 2D UI.
+export class Raycaster extends THREE.Raycaster {
+  // Sorting function for the raycaster. Should return items from closest to furthest.
+  sortFunction: (a: THREE.Intersection, b: THREE.Intersection) => number =
+    defaultSortFunction;
+
+  /** {@inheritDoc three#Raycaster.intersectObjects} */
+  override intersectObject<TIntersected extends THREE.Object3D>(
+    object: THREE.Object3D,
+    recursive = true,
+    intersects: Array<THREE.Intersection<TIntersected>> = []
+  ): Array<THREE.Intersection<TIntersected>> {
+    intersect(object, this, intersects, recursive);
+    intersects.sort(this.sortFunction);
+    return intersects;
+  }
+
+  /** {@inheritDoc three#Raycaster.intersectObjects} */
+  override intersectObjects<TIntersected extends THREE.Object3D>(
+    objects: THREE.Object3D[],
+    recursive = true,
+    intersects: Array<THREE.Intersection<TIntersected>> = []
+  ): Array<THREE.Intersection<TIntersected>> {
+    for (let i = 0, l = objects.length; i < l; i++) {
+      intersect(objects[i], this, intersects, recursive);
+    }
+    intersects.sort(this.sortFunction);
+    return intersects;
+  }
+}

--- a/src/input/Input.ts
+++ b/src/input/Input.ts
@@ -6,6 +6,7 @@ import {NUM_HANDS} from '../constants';
 import {Options} from '../core/Options.js';
 import {KeyEvent, Script} from '../core/Script';
 import {Reticle} from '../ui/core/Reticle.js';
+import {Raycaster} from '../core/components/Raycaster';
 
 import {ControllerRayVisual} from './components/ControllerRayVisual';
 import type {
@@ -35,7 +36,7 @@ export class Input {
   controllers: Controller[] = [];
   controllerGrips: THREE.Group[] = [];
   hands: THREE.XRHandSpace[] = [];
-  raycaster = new THREE.Raycaster();
+  raycaster = new Raycaster();
   initialized = false;
   pivotsEnabled = false;
   gazeController = new GazeController();

--- a/src/xrblocks.ts
+++ b/src/xrblocks.ts
@@ -11,6 +11,7 @@ export * from './camera/CameraOptions';
 export * from './camera/CameraUtils';
 export * from './camera/XRDeviceCamera';
 export * from './constants';
+export * from './core/components/Raycaster';
 export * from './core/components/Registry';
 export * from './core/components/ScreenshotSynthesizer';
 export * from './core/components/ScriptsManager';


### PR DESCRIPTION
Our event system only considers the first intersection for each raycast.

For 2D UI, all of the meshes are the same so we instead use renderOrder to control the draw order.
This also allows overwriting the sorting function for integration with alternative 2D UI libraries.