### PR TITLE
Disable matchDepthView and reticle in ballpit.

### DIFF
--- a/demos/ballpit/main.js
+++ b/demos/ballpit/main.js
@@ -20,7 +20,9 @@ if (useSceneMesh) {
 } else {
   options.depth = new xb.DepthOptions(xb.xrDepthMeshPhysicsOptions);
   options.depth.depthMesh.colliderUpdateFps = depthMeshColliderUpdateFps;
+  options.depth.matchDepthView = false;
 }
+options.reticles.enabled = false;
 options.xrButton = {
   ...options.xrButton,
   startText: '<i id="xrlogo"></i> LET THE FUN BEGIN',


### PR DESCRIPTION
Disabling matchDepthView increases FPS from ~35 to ~45 on Galaxy XR. When nothing is in the scene the FPS is around 60 now.