### PR TITLE
Rewrite camera to world mapping logic for object detection.

### DIFF
--- a/demos/gemini-xrobject/main.js
+++ b/demos/gemini-xrobject/main.js
@@ -8,8 +8,8 @@ import {XRObjectManager} from './XRObjectManager.js';
 const options = new xb.Options();
 options.deviceCamera.enabled = true;
 options.deviceCamera.videoConstraints = {
-  width: {ideal: 640},
-  height: {ideal: 480},
+  width: {ideal: 1280},
+  height: {ideal: 720},
   facingMode: 'environment',
 };
 options.permissions.camera = true;
@@ -17,6 +17,7 @@ options.reticles.enabled = false;
 options.controllers.visualizeRays = false;
 options.world.enableObjectDetection();
 options.depth.enabled = true;
+options.depth.depthMesh.enabled = true;
 options.depth.depthMesh.updateFullResolutionGeometry = true;
 options.depth.depthMesh.renderShadow = true;
 options.depth.depthTexture.enabled = false;

--- a/src/camera/CameraParameterUtils.ts
+++ b/src/camera/CameraParameterUtils.ts
@@ -1,0 +1,34 @@
+import * as THREE from 'three';
+
+export function intrinsicsToProjectionMatrix(
+  K: number[],
+  width: number,
+  height: number,
+  near: number,
+  far: number,
+  target: THREE.Matrix4
+) {
+  const fx = K[0];
+  const fy = K[4];
+  const cx = K[2];
+  const cy = K[5];
+
+  // Calculate the projection matrix elements
+  // Note: Three.js set() takes row-major arguments (m00, m01, m02...)
+  // but stores them column-major internally.
+
+  const x = (2 * fx) / width;
+  const y = (2 * fy) / height;
+
+  // Principal point offsets
+  // These map the center of the image (cx, cy) to the center of the viewport
+  const a = 1 - (2 * cx) / width;
+  const b = (2 * cy) / height - 1;
+
+  const c = -(far + near) / (far - near);
+  const d = -(2 * far * near) / (far - near);
+
+  target.set(x, 0, a, 0, 0, y, b, 0, 0, 0, c, d, 0, 0, -1, 0);
+
+  return target;
+}

--- a/src/camera/GalaxyXRCameraParams.ts
+++ b/src/camera/GalaxyXRCameraParams.ts
@@ -1,0 +1,48 @@
+import * as THREE from 'three';
+import {intrinsicsToProjectionMatrix} from './CameraParameterUtils';
+
+// prettier-ignore
+export const MOOHAN_INTRINSICS_MATRIX = [
+  800, 0, 640,
+  0, 800, 360,
+  0, 0, 1,
+];
+
+export const MOOHAN_PROJECTION_MATRIX = intrinsicsToProjectionMatrix(
+  MOOHAN_INTRINSICS_MATRIX,
+  1280,
+  720,
+  0.1,
+  1000,
+  new THREE.Matrix4()
+);
+
+export const MOOHAN_CAMERA_POSE_IN_RIGHT_CAMERA_POSITION = new THREE.Vector3(
+  0,
+  -0.003,
+  0
+);
+export const MOOHAN_CAMERA_POSE_IN_RIGHT_CAMERA_ROTATION =
+  new THREE.Quaternion().setFromEuler(new THREE.Euler(-0.02, -0.05, 0, 'YXZ'));
+
+const MOOHAN_CAMERA_POSE_IN_RIGHT_CAMERA_SCALE = new THREE.Vector3(1, 1, 1);
+
+// Pose of the moohan camera w.r.t. right camera.
+export const MOOHAN_CAMERA_POSE_IN_RIGHT_CAMERA = new THREE.Matrix4().compose(
+  MOOHAN_CAMERA_POSE_IN_RIGHT_CAMERA_POSITION,
+  MOOHAN_CAMERA_POSE_IN_RIGHT_CAMERA_ROTATION,
+  MOOHAN_CAMERA_POSE_IN_RIGHT_CAMERA_SCALE
+);
+
+export function getMoohanCameraPose(
+  _camera: THREE.Camera,
+  xrCameras: THREE.WebXRArrayCamera,
+  target: THREE.Matrix4
+) {
+  target.compose(
+    MOOHAN_CAMERA_POSE_IN_RIGHT_CAMERA_POSITION,
+    MOOHAN_CAMERA_POSE_IN_RIGHT_CAMERA_ROTATION,
+    MOOHAN_CAMERA_POSE_IN_RIGHT_CAMERA_SCALE
+  );
+  target.premultiply(xrCameras.cameras[1].matrixWorld);
+}

--- a/src/xrblocks.ts
+++ b/src/xrblocks.ts
@@ -9,6 +9,7 @@ export * from './ai/Gemini';
 export * from './ai/OpenAI';
 export * from './camera/CameraOptions';
 export * from './camera/CameraUtils';
+export * from './camera/CameraParameterUtils';
 export * from './camera/XRDeviceCamera';
 export * from './constants';
 export * from './core/components/Raycaster';


### PR DESCRIPTION
The original code attempted to map the device camera to a point on the depth map. This is difficult to do properly because the device camera, render camera, and depth camera can be at different positions. Currently, it seems the device camera comes from the right camera.

Now instead, we have explicit projection and view matrices for the device camera and raycast to the depth mesh, essentially iterating over all depth values. We ignore distortion.