### PR TITLE
Support hovering event bubble up or not by returning boolean

### DIFF
--- a/src/core/Script.ts
+++ b/src/core/Script.ts
@@ -155,17 +155,17 @@ export function ScriptMixin<TBase extends Constructor<THREE.Object3D>>(
      * Called when the controller starts hovering over this object with reticle.
      * @param _controller - An XR controller.
      */
-    onHoverEnter(_controller: THREE.Object3D) {}
+    onHoverEnter(_controller: THREE.Object3D): boolean | void {}
     /**
      * Called when the controller hovers over this object with reticle.
      * @param _controller - An XR controller.
      */
-    onHoverExit(_controller: THREE.Object3D) {}
+    onHoverExit(_controller: THREE.Object3D): boolean | void {}
     /**
      * Called when the controller hovers over this object with reticle.
      * @param _controller - An XR controller.
      */
-    onHovering(_controller: THREE.Object3D) {}
+    onHovering(_controller: THREE.Object3D): boolean | void {}
     /**
      * Called when a hand's index finger starts touching this object.
      */

--- a/src/core/User.ts
+++ b/src/core/User.ts
@@ -516,8 +516,12 @@ export class User extends Script {
    */
   callHoverExit(controller: Controller, target: THREE.Object3D | null) {
     if (target == null) return;
-    if ((target as MaybeXRScript).isXRScript) {
-      (target as Script).onHoverExit(controller);
+    if (
+      (target as MaybeXRScript).isXRScript &&
+      (target as Script).onHoverExit(controller)
+    ) {
+      // The event was handled already so do not propagate up.
+      return;
     }
     this.callHoverExit(controller, target.parent);
   }
@@ -529,8 +533,12 @@ export class User extends Script {
    */
   callHoverEnter(controller: Controller, target: THREE.Object3D | null) {
     if (target == null) return;
-    if ((target as MaybeXRScript).isXRScript) {
-      (target as Script).onHoverEnter(controller);
+    if (
+      (target as MaybeXRScript).isXRScript &&
+      (target as Script).onHoverEnter(controller)
+    ) {
+      // The event was handled already so do not propagate up.
+      return;
     }
     this.callHoverEnter(controller, target.parent);
   }
@@ -542,12 +550,15 @@ export class User extends Script {
    */
   callOnHovering(controller: Controller, target: THREE.Object3D | null) {
     if (target == null) return;
-    if ((target as MaybeXRScript).isXRScript) {
-      (target as Script).onHovering(controller);
+    if (
+      (target as MaybeXRScript).isXRScript &&
+      (target as Script).onHovering(controller)
+    ) {
+      // The event was handled already so do not propagate up.
+      return;
     }
     this.callOnHovering(controller, target.parent);
   }
-
   /**
    * Recursively calls onObjectSelectStart on a target and its ancestors until
    * the event is handled.


### PR DESCRIPTION
In onHoverEnter, onHoverExit, onHovering, we now support returning booleans. In downstream overrides, if returning true, the even won't bubble up to its parent anymore. 