### PR TITLE
GeminiManager: Reduce jpeg quality

### DIFF
--- a/src/addons/ai/GeminiManager.ts
+++ b/src/addons/ai/GeminiManager.ts
@@ -41,6 +41,10 @@ export class GeminiManager extends xb.Script<GeminiManagerEventMap> {
 
   scheduleAheadTime = DEFAULT_SCHEDULE_AHEAD_TIME;
 
+  // Type and quality settings for sending the camera feed to Gemini.
+  cameraMimeType = 'image/jpeg';
+  cameraQuality = 0.8;
+
   constructor() {
     super();
   }
@@ -175,8 +179,8 @@ export class GeminiManager extends xb.Script<GeminiManagerEventMap> {
     try {
       const base64Image = await this.xrDeviceCamera!.getSnapshot({
         outputFormat: 'base64',
-        mimeType: 'image/jpeg',
-        quality: 1,
+        mimeType: this.cameraMimeType,
+        quality: this.cameraQuality,
       });
       if (typeof base64Image == 'string') {
         // Strip the data URL prefix if present


### PR DESCRIPTION
At 1.0 quality, there are ~45ms (~3 frame) stutters as the blob is converted to a ~1MB base64 string.
At 0.8 quality, there are ~14ms (~1 frame) stutters as the blob is converted to a ~200KB base64 string.