### PR TITLE
Check the threejs version and log an error if it is too old.

### DIFF
--- a/src/singletons.ts
+++ b/src/singletons.ts
@@ -3,6 +3,9 @@ import * as THREE from 'three';
 import {Core} from './core/Core';
 import {Options} from './core/Options';
 import {Script} from './core/Script';
+import {checkThreeVersion} from './utils/VersionCheck';
+
+checkThreeVersion();
 
 /**
  * The global singleton instance of Core, serving as the main entry point

--- a/src/utils/VersionCheck.ts
+++ b/src/utils/VersionCheck.ts
@@ -1,0 +1,10 @@
+import * as THREE from 'three';
+
+// Check the threejs version and log an error if it is too old.
+export function checkThreeVersion() {
+  if (parseInt(THREE.REVISION) < 182) {
+    console.error(
+      `three.js version ${THREE.REVISION} is too old. Please update to version 182 or higher.`
+    );
+  }
+}


### PR DESCRIPTION
This is useful when Gemini isn't following our system prompts so it knows to update the threejs version instead of trying to polyfill THREE.Timer.