### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/update-xrblocks-github-io.yml
+++ b/.github/workflows/update-xrblocks-github-io.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger build in xrblocks.github.io
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.XRBLOCKS_GITHUB_IO_PAT }}
           repository: xrblocks/xrblocks.github.io


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `peter-evans/repository-dispatch` | [`v3`](https://github.com/peter-evans/repository-dispatch/releases/tag/v3) | [`v4`](https://github.com/peter-evans/repository-dispatch/releases/tag/v4) | [Release](https://github.com/peter-evans/repository-dispatch/releases/tag/v4) | update-xrblocks-github-io.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### ⚠️ Breaking Changes

- **peter-evans/repository-dispatch** (v3 → v4): Major version upgrade — review the [release notes](https://github.com/peter-evans/repository-dispatch/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
