### PR TITLE
Fix simulator camera getting stuck moving on macOS

### DIFF
--- a/src/simulator/SimulatorControls.ts
+++ b/src/simulator/SimulatorControls.ts
@@ -45,6 +45,7 @@ export class SimulatorControls {
   private _onKeyDown = this.onKeyDown.bind(this);
   private _onKeyUp = this.onKeyUp.bind(this);
   private _onPointerMove = this.onPointerMove.bind(this);
+  private _onBlur = this.onBlur.bind(this);
 
   /**
    * Create the simulator controls.
@@ -122,6 +123,8 @@ export class SimulatorControls {
     domElement.addEventListener('pointerdown', this._onPointerDown);
     domElement.addEventListener('pointerup', this._onPointerUp);
     domElement.addEventListener('contextmenu', preventDefault);
+    window.addEventListener('blur', this._onBlur);
+    document.addEventListener('visibilitychange', this._onBlur);
   }
 
   update() {
@@ -143,6 +146,16 @@ export class SimulatorControls {
   }
 
   onKeyDown(event: KeyboardEvent) {
+    // On macOS, keyup events are not fired for keys held when Command (Meta)
+    // is pressed. Clear all keys to prevent stuck movement.
+    if (
+      event.metaKey ||
+      event.code === 'MetaLeft' ||
+      event.code === 'MetaRight'
+    ) {
+      this.downKeys.clear();
+      return;
+    }
     this.downKeys.add(event.code as Keycodes);
     if (event.code == Keycodes.LEFT_SHIFT_CODE) {
       this.setSimulatorMode(NEXT_SIMULATOR_MODE[this.simulatorMode]);
@@ -152,6 +165,10 @@ export class SimulatorControls {
 
   onKeyUp(event: KeyboardEvent) {
     this.downKeys.delete(event.code as Keycodes);
+  }
+
+  onBlur() {
+    this.downKeys.clear();
   }
 
   setSimulatorMode(mode: SimulatorMode) {


### PR DESCRIPTION
## Problem

On macOS, the simulator camera can get stuck moving continuously with no way to stop it.

**Steps to reproduce:**
1. Open any template in the simulator (e.g. `templates/0_basic/index.html`)
2. Hold `Command`, then press `S` — the camera starts drifting backward and never stops, even after releasing all keys

This is caused by a macOS browser quirk where `keyup` events are not fired for keys pressed while Command (Meta) is held. The `S` key gets added to the tracked pressed-keys set but is never removed, so the camera moves forever.

This also happens with other movement keys (, `A`, `D`, `Q`, `E`) when combined with `Command`. It doesn't happen with `W` since that will close the tab.

## Fix

Clear all tracked key presses when:
- A `keydown` event has `event.metaKey` set, or the key code is `MetaLeft`/`MetaRight` — prevents the movement key from being registered in the first place
- The window fires a `blur` event — handles app switching, browser dialogs, etc.
- The document fires `visibilitychange` — handles tab switches and system dialogs

## Testing

Tested on a MacBook (macOS, Chrome):
- Held `Command` then pressed `S` — camera no longer gets stuck (previously drifted backward indefinitely)
- Normal movement with `W`/`A`/`S`/`D`/`Q`/`E` still works as expected
- `Shift` to switch simulator modes still works
- `Cmd+Tab` while moving — camera stops correctly when switching apps
- Clean build with `npm run build` (`--failAfterWarnings`), no warnings
