### PR TITLE
Fix TextView.dispose() failing to remove synccomplete listener

### DIFF
--- a/src/ui/components/TextView.ts
+++ b/src/ui/components/TextView.ts
@@ -146,6 +146,7 @@ export class TextView extends View<TextViewEventMap> {
   /** The total number of lines after text wrapping. */
   lineCount = 0;
 
+  private _onSyncCompleteBound = this.onSyncComplete.bind(this);
   private _initializeTextCalled = false;
   private _text = 'TextView';
   set text(text) {
@@ -372,7 +373,7 @@ export class TextView extends View<TextViewEventMap> {
       this.textObj.addEventListener(
         // @ts-expect-error Missing type in Troika
         'synccomplete',
-        this.onSyncComplete.bind(this)
+        this._onSyncCompleteBound
       );
 
       if (this.imageOverlay) {
@@ -413,7 +414,7 @@ export class TextView extends View<TextViewEventMap> {
       this.textObj.removeEventListener(
         // @ts-expect-error Missing type in Troika
         'synccomplete',
-        this.onSyncComplete.bind(this)
+        this._onSyncCompleteBound
       );
     }
     super.dispose();


### PR DESCRIPTION
Fixes #178

## Problem

`TextView.dispose()` calls `removeEventListener('synccomplete', this.onSyncComplete.bind(this))`, but `.bind(this)` creates a **new function reference** every time it's called. The listener was originally added with a different `.bind(this)` call, so `removeEventListener` doesn't find a match and silently does nothing.

This means the `synccomplete` listener stays attached after `dispose()`, keeping the `TextView` and its Three.js objects alive in memory.

## Fix

Store the bound callback as a class property (`onSyncCompleteBound`) and use the same reference for both `addEventListener` and `removeEventListener`.

## Testing

- Built with `npm run build` (`--failAfterWarnings`) — clean, no warnings
- Ran `npm run lint` — no errors
- Verified the pattern matches how `SimulatorHands` correctly handles bound listeners (using `onHandPoseChangeRequestBound`)
