### PR TITLE
Update default Gemini models.

### DIFF
--- a/src/ai/AIOptions.ts
+++ b/src/ai/AIOptions.ts
@@ -1,39 +1,17 @@
-export interface GeminiLiveOptions {
-  enabled?: boolean;
-  model?: string;
-  startOfSpeechSensitivity?: 'LOW' | 'HIGH';
-  endOfSpeechSensitivity?: 'LOW' | 'HIGH';
-  voiceName?: string;
-  screenshotInterval?: number;
-  audioConfig?: {
-    sampleRate?: number;
-    channelCount?: number;
-    echoCancellation?: boolean;
-    noiseSuppression?: boolean;
-    autoGainControl?: boolean;
-  };
-}
+import * as GoogleGenAITypes from '@google/genai';
+
+export const GEMINI_DEFAULT_FLASH_MODEL = 'gemini-2.5-flash';
+export const GEMINI_DEFAULT_LIVE_MODEL =
+  'gemini-2.5-flash-native-audio-preview-12-2025';
 
 export class GeminiOptions {
   apiKey = '';
   urlParam = 'geminiKey';
   keyValid = false;
   enabled = false;
-  model = 'gemini-2.0-flash';
-  config = {};
-  live: GeminiLiveOptions = {
-    enabled: false,
-    model: 'gemini-live-2.5-flash-preview',
-    voiceName: 'Aoede',
-    screenshotInterval: 3000,
-    audioConfig: {
-      sampleRate: 16000,
-      channelCount: 1,
-      echoCancellation: true,
-      noiseSuppression: true,
-      autoGainControl: true,
-    },
-  };
+  model = GEMINI_DEFAULT_FLASH_MODEL;
+  liveModel = GEMINI_DEFAULT_LIVE_MODEL;
+  config: GoogleGenAITypes.GenerateContentConfig = {};
 }
 
 export class OpenAIOptions {

--- a/src/ai/Gemini.ts
+++ b/src/ai/Gemini.ts
@@ -86,7 +86,7 @@ export class Gemini extends BaseAIModel {
 
   async startLiveSession(
     params: GoogleGenAITypes.LiveConnectConfig = {},
-    model = 'gemini-2.5-flash-native-audio-preview-09-2025'
+    model?: string
   ) {
     if (!this.isLiveAvailable()) {
       throw new Error(
@@ -142,7 +142,7 @@ export class Gemini extends BaseAIModel {
     };
     try {
       const connectParams: GoogleGenAITypes.LiveConnectParameters = {
-        model: model,
+        model: model ?? this.options.liveModel,
         callbacks: callbacks,
         config: defaultConfig,
       };
@@ -207,7 +207,7 @@ export class Gemini extends BaseAIModel {
     }
 
     const options = this.options;
-    const config = options.config || {};
+    const config: GoogleGenAITypes.GenerateContentConfig = options.config || {};
 
     if (!('type' in input)) {
       const response = await this.ai!.models.generateContent({

--- a/src/core/Options.ts
+++ b/src/core/Options.ts
@@ -297,7 +297,6 @@ export class Options {
   enableAI() {
     this.ai.enabled = true;
     this.ai.gemini.enabled = true;
-    this.ai.gemini.live.enabled = true;
     return this;
   }
 


### PR DESCRIPTION
Gemini 2.0 Flash is deprecated now.

This also cleans up some unused options.