### PR TITLE
feat: add force field particle system demo

### DIFF
--- a/demos/forcefield/ForceFieldParticles.ts
+++ b/demos/forcefield/ForceFieldParticles.ts
@@ -1,0 +1,245 @@
+import * as THREE from 'three';
+import {VectorField, ForceSource} from './VectorField.js';
+
+/**
+ * GPU-instanced particle system driven by a vector field.
+ *
+ * Each particle's position is integrated using Symplectic Euler:
+ *   velocity += field(position) * dt
+ *   velocity *= damping
+ *   position += velocity * dt
+ *
+ * Symplectic Euler is chosen over standard Euler because it conserves
+ * energy better in oscillatory systems (particles orbiting attractors).
+ *
+ * Particles that exceed the boundary sphere are respawned near a random
+ * source or at the origin, keeping the visual density consistent.
+ */
+
+const PARTICLE_COUNT = 5000;
+const BOUNDARY_RADIUS = 5.0;
+const DAMPING = 0.98;
+const MAX_SPEED = 8.0;
+const RESPAWN_RADIUS = 0.3;
+const BASE_PARTICLE_SIZE = 0.012;
+const SPEED_SCALE_FACTOR = 0.15;
+
+/** Reusable objects for matrix composition without GC overhead. */
+const _obj = new THREE.Object3D();
+const _force = new THREE.Vector3();
+const _color = new THREE.Color();
+
+/** Per-particle state stored in flat arrays for cache-friendly access. */
+interface ParticleState {
+  positions: Float32Array; // x,y,z per particle (3 * count)
+  velocities: Float32Array; // vx,vy,vz per particle (3 * count)
+  lifetimes: Float32Array; // remaining life per particle
+  maxLifetimes: Float32Array;
+}
+
+export class ForceFieldParticles extends THREE.Object3D {
+  public field: VectorField;
+  public mesh: THREE.InstancedMesh | null = null;
+  private state: ParticleState;
+  private particleCount: number;
+
+  constructor(particleCount: number = PARTICLE_COUNT) {
+    super();
+    this.particleCount = particleCount;
+    this.field = new VectorField();
+
+    this.state = {
+      positions: new Float32Array(particleCount * 3),
+      velocities: new Float32Array(particleCount * 3),
+      lifetimes: new Float32Array(particleCount),
+      maxLifetimes: new Float32Array(particleCount),
+    };
+  }
+
+  public init() {
+    const geo = new THREE.IcosahedronGeometry(BASE_PARTICLE_SIZE, 1);
+    const mat = new THREE.MeshBasicMaterial({
+      color: 0xffffff,
+      transparent: true,
+      opacity: 0.9,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+    });
+
+    this.mesh = new THREE.InstancedMesh(geo, mat, this.particleCount);
+    this.mesh.frustumCulled = false;
+    this.add(this.mesh);
+
+    // Initialize all particles
+    for (let i = 0; i < this.particleCount; i++) {
+      this.respawnParticle(i);
+    }
+    this.updateInstanceMatrices();
+  }
+
+  /** Spawns a particle near a random force source or at origin. */
+  private respawnParticle(index: number) {
+    const i3 = index * 3;
+    const sources = this.field.sources;
+
+    let cx = 0,
+      cy = 0,
+      cz = 0;
+    if (sources.length > 0) {
+      const src = sources[Math.floor(Math.random() * sources.length)];
+      cx = src.position.x;
+      cy = src.position.y;
+      cz = src.position.z;
+    }
+
+    // Spawn in a sphere around the chosen center
+    const theta = Math.random() * Math.PI * 2;
+    const phi = Math.acos(2 * Math.random() - 1);
+    const r = RESPAWN_RADIUS * Math.cbrt(Math.random()); // cube root for uniform volume distribution
+
+    /**
+     * MATH: Spherical to Cartesian conversion with uniform volume sampling.
+     * Using Math.cbrt(random) ensures uniform distribution within the sphere
+     * (not clustered at center). Without cbrt, density ∝ 1/r².
+     */
+    this.state.positions[i3] = cx + r * Math.sin(phi) * Math.cos(theta);
+    this.state.positions[i3 + 1] = cy + r * Math.cos(phi);
+    this.state.positions[i3 + 2] = cz + r * Math.sin(phi) * Math.sin(theta);
+
+    this.state.velocities[i3] = 0;
+    this.state.velocities[i3 + 1] = 0;
+    this.state.velocities[i3 + 2] = 0;
+
+    const life = 3.0 + Math.random() * 4.0;
+    this.state.lifetimes[index] = life;
+    this.state.maxLifetimes[index] = life;
+  }
+
+  /**
+   * Steps the simulation forward.
+   *
+   * MATH — Symplectic Euler Integration:
+   *   v(t+dt) = v(t) + F(x(t)) * dt
+   *   x(t+dt) = x(t) + v(t+dt) * dt    ← note: uses NEW velocity
+   *
+   * This is more stable than standard Euler (which uses old velocity)
+   * for conservative force fields. It's a symplectic integrator, meaning
+   * it preserves the phase-space volume (Liouville's theorem), which
+   * prevents particles from spiraling inward or outward over time.
+   */
+  public update(deltaTime: number) {
+    if (!this.mesh) return;
+
+    this.field.timeOffset += deltaTime * 0.3;
+    const {positions, velocities, lifetimes, maxLifetimes} = this.state;
+    const _pos = new THREE.Vector3();
+
+    for (let i = 0; i < this.particleCount; i++) {
+      const i3 = i * 3;
+
+      lifetimes[i] -= deltaTime;
+      if (lifetimes[i] <= 0 || this.isOutOfBounds(i)) {
+        this.respawnParticle(i);
+        continue;
+      }
+
+      _pos.set(positions[i3], positions[i3 + 1], positions[i3 + 2]);
+      this.field.evaluate(_pos, _force);
+
+      // Symplectic Euler: update velocity first, then position
+      velocities[i3] = (velocities[i3] + _force.x * deltaTime) * DAMPING;
+      velocities[i3 + 1] =
+        (velocities[i3 + 1] + _force.y * deltaTime) * DAMPING;
+      velocities[i3 + 2] =
+        (velocities[i3 + 2] + _force.z * deltaTime) * DAMPING;
+
+      // Clamp speed to prevent instability
+      const speedSq =
+        velocities[i3] ** 2 + velocities[i3 + 1] ** 2 + velocities[i3 + 2] ** 2;
+      if (speedSq > MAX_SPEED * MAX_SPEED) {
+        const scale = MAX_SPEED / Math.sqrt(speedSq);
+        velocities[i3] *= scale;
+        velocities[i3 + 1] *= scale;
+        velocities[i3 + 2] *= scale;
+      }
+
+      positions[i3] += velocities[i3] * deltaTime;
+      positions[i3 + 1] += velocities[i3 + 1] * deltaTime;
+      positions[i3 + 2] += velocities[i3 + 2] * deltaTime;
+    }
+
+    this.updateInstanceMatrices();
+  }
+
+  private isOutOfBounds(index: number): boolean {
+    const i3 = index * 3;
+    const {positions} = this.state;
+    const distSq =
+      positions[i3] ** 2 + positions[i3 + 1] ** 2 + positions[i3 + 2] ** 2;
+    return distSq > BOUNDARY_RADIUS * BOUNDARY_RADIUS;
+  }
+
+  /**
+   * Rebuilds all instance matrices and colors.
+   *
+   * MATH — Speed-based visual mapping:
+   *   - Scale: baseSize * (1 + speed * factor) — faster = larger
+   *   - Color: HSL hue mapped from speed — slow=blue(0.6), fast=red(0.0)
+   *   - Opacity: lifetime ratio — fades out as particle dies
+   */
+  private updateInstanceMatrices() {
+    if (!this.mesh) return;
+    const {positions, velocities, lifetimes, maxLifetimes} = this.state;
+
+    for (let i = 0; i < this.particleCount; i++) {
+      const i3 = i * 3;
+
+      const speed = Math.sqrt(
+        velocities[i3] ** 2 + velocities[i3 + 1] ** 2 + velocities[i3 + 2] ** 2
+      );
+
+      const scale = 1.0 + speed * SPEED_SCALE_FACTOR;
+      const lifeRatio = lifetimes[i] / maxLifetimes[i];
+
+      _obj.position.set(positions[i3], positions[i3 + 1], positions[i3 + 2]);
+      _obj.scale.setScalar(scale);
+      _obj.updateMatrix();
+      this.mesh.setMatrixAt(i, _obj.matrix);
+
+      // Hue: 0.6 (blue) at rest → 0.0 (red) at max speed
+      const hue = THREE.MathUtils.lerp(
+        0.6,
+        0.0,
+        Math.min(speed / MAX_SPEED, 1.0)
+      );
+      _color.setHSL(hue, 1.0, 0.5 + 0.3 * lifeRatio);
+      this.mesh.setColorAt(i, _color);
+    }
+
+    this.mesh.instanceMatrix.needsUpdate = true;
+    if (this.mesh.instanceColor) this.mesh.instanceColor.needsUpdate = true;
+  }
+
+  /** Adds a force source to the field. Returns the source for later manipulation. */
+  public addSource(
+    type: ForceSource['type'],
+    position: THREE.Vector3,
+    strength: number = 5.0,
+    radius: number = 0.3
+  ): ForceSource {
+    const source: ForceSource = {
+      type,
+      position: position.clone(),
+      strength,
+      radius,
+    };
+    this.field.sources.push(source);
+    return source;
+  }
+
+  /** Removes a force source from the field. */
+  public removeSource(source: ForceSource) {
+    const idx = this.field.sources.indexOf(source);
+    if (idx !== -1) this.field.sources.splice(idx, 1);
+  }
+}

--- a/demos/forcefield/ForceFieldScene.ts
+++ b/demos/forcefield/ForceFieldScene.ts
@@ -1,0 +1,217 @@
+import * as THREE from 'three';
+import * as xb from 'xrblocks';
+import {ForceFieldParticles} from './ForceFieldParticles.js';
+import {ForceSource} from './VectorField.js';
+
+/**
+ * XR demo scene: place attractors, repulsors, and vortices in your room
+ * and watch thousands of particles flow through the resulting force field.
+ *
+ * Interaction model:
+ * - Pinch/click on depth mesh → place attractor
+ * - Long pinch → place vortex
+ * - Double tap → place repulsor
+ * - Drag existing source → reposition it
+ *
+ * Integrates with:
+ * - xb.core.depth.depthMesh for surface placement
+ * - xb.core.input for controller/hand interaction
+ * - Existing demo patterns (SpatialPanel, Orbiter, etc.)
+ */
+
+const SOURCE_VISUAL_SEGMENTS = 16;
+const ATTRACTOR_COLOR = 0x4285f4;
+const REPULSOR_COLOR = 0xea4335;
+const VORTEX_COLOR = 0x34a853;
+const SOURCE_VISUAL_RADIUS = 0.05;
+const SOURCE_VISUAL_OPACITY = 0.6;
+const PULSE_SPEED = 3.0;
+const PULSE_AMPLITUDE = 0.3;
+
+export class ForceFieldScene extends xb.Script {
+  private particles: ForceFieldParticles;
+  private sourceVisuals: Map<ForceSource, THREE.Mesh> = new Map();
+  private raycaster = new THREE.Raycaster();
+  private pointer = new THREE.Vector2();
+  private currentSourceType: ForceSource['type'] = 'attractor';
+  private elapsedTime = 0;
+
+  constructor() {
+    super();
+    this.particles = new ForceFieldParticles(5000);
+    this.add(this.particles);
+  }
+
+  init() {
+    this.particles.init();
+    this.addLights();
+    this.addPanel();
+    xb.showReticleOnDepthMesh(true);
+
+    // Place a default vortex at scene center for immediate visual impact
+    this.placeSource(new THREE.Vector3(0, 1.2, -1.5), 'vortex');
+  }
+
+  private addLights() {
+    this.add(new THREE.HemisphereLight(0x222233, 0x111122, 1));
+    const light = new THREE.PointLight(0x4488ff, 2, 10);
+    light.position.set(0, 2, -1);
+    this.add(light);
+  }
+
+  private addPanel() {
+    const panel = new xb.SpatialPanel({
+      backgroundColor: '#000000bb',
+      useDefaultPosition: false,
+      showEdge: false,
+    });
+    panel.position.set(0.6, 1.5, -1.0);
+    panel.isRoot = true;
+    this.add(panel);
+
+    const grid = panel.addGrid();
+
+    // Source type buttons
+    const btnRow = grid.addRow({weight: 0.3});
+    const attractBtn = btnRow.addTextButton({
+      text: '⊕ Attractor',
+      fontColor: '#ffffff',
+      backgroundColor: '#4285f4',
+      fontSize: 0.06,
+      weight: 1.0,
+    });
+    attractBtn.onTriggered = () => {
+      this.currentSourceType = 'attractor';
+    };
+
+    const repulseBtn = btnRow.addTextButton({
+      text: '⊖ Repulsor',
+      fontColor: '#ffffff',
+      backgroundColor: '#ea4335',
+      fontSize: 0.06,
+      weight: 1.0,
+    });
+    repulseBtn.onTriggered = () => {
+      this.currentSourceType = 'repulsor';
+    };
+
+    const vortexBtn = btnRow.addTextButton({
+      text: '↻ Vortex',
+      fontColor: '#ffffff',
+      backgroundColor: '#34a853',
+      fontSize: 0.06,
+      weight: 1.0,
+    });
+    vortexBtn.onTriggered = () => {
+      this.currentSourceType = 'vortex';
+    };
+
+    // Clear button
+    const clearRow = grid.addRow({weight: 0.2});
+    const clearBtn = clearRow.addTextButton({
+      text: '✕ Clear All',
+      fontColor: '#ffffff',
+      backgroundColor: '#666666',
+      fontSize: 0.06,
+      weight: 1.0,
+    });
+    clearBtn.onTriggered = () => {
+      this.clearAllSources();
+    };
+
+    const orbiter = grid.addOrbiter();
+    orbiter.addExitButton();
+    panel.updateLayouts();
+  }
+
+  /** Places a force source at a world position with a visual indicator. */
+  private placeSource(position: THREE.Vector3, type?: ForceSource['type']) {
+    const sourceType = type || this.currentSourceType;
+    const source = this.particles.addSource(sourceType, position);
+
+    // Create a pulsing sphere visual for the source
+    const colorMap = {
+      attractor: ATTRACTOR_COLOR,
+      repulsor: REPULSOR_COLOR,
+      vortex: VORTEX_COLOR,
+    };
+    const geo = new THREE.SphereGeometry(
+      SOURCE_VISUAL_RADIUS,
+      SOURCE_VISUAL_SEGMENTS,
+      SOURCE_VISUAL_SEGMENTS
+    );
+    const mat = new THREE.MeshBasicMaterial({
+      color: colorMap[sourceType],
+      transparent: true,
+      opacity: SOURCE_VISUAL_OPACITY,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+    });
+    const visual = new THREE.Mesh(geo, mat);
+    visual.position.copy(position);
+    this.add(visual);
+    this.sourceVisuals.set(source, visual);
+  }
+
+  private clearAllSources() {
+    for (const [source, visual] of this.sourceVisuals) {
+      this.particles.removeSource(source);
+      this.remove(visual);
+      visual.geometry.dispose();
+      (visual.material as THREE.Material).dispose();
+    }
+    this.sourceVisuals.clear();
+  }
+
+  /** Handles XR controller select — places source on depth mesh. */
+  onSelectStart(event: {target: THREE.Object3D}) {
+    const controller = event.target;
+    const intersections =
+      xb.core.input.intersectionsForController?.get(controller);
+    if (intersections && intersections.length > 0) {
+      const hit = intersections[0];
+      if (hit.object === xb.core.depth?.depthMesh) {
+        this.placeSource(hit.point);
+      }
+    }
+  }
+
+  /** Handles desktop pointer — places source via raycast. */
+  onPointerDown(event: MouseEvent) {
+    this.pointer.x = (event.clientX / window.innerWidth) * 2 - 1;
+    this.pointer.y = -(event.clientY / window.innerHeight) * 2 + 1;
+    this.pointer.x = 1 + 2 * this.pointer.x;
+
+    const cameras = (xb.core.renderer as any).xr.getCamera().cameras;
+    if (cameras.length === 0) return;
+    this.raycaster.setFromCamera(this.pointer, cameras[0]);
+
+    const depthMesh = xb.core.depth?.depthMesh;
+    if (depthMesh) {
+      const hits = this.raycaster.intersectObject(depthMesh);
+      if (hits.length > 0) {
+        this.placeSource(hits[0].point);
+      }
+    }
+  }
+
+  /**
+   * Per-frame update: advance particles and pulse source visuals.
+   *
+   * MATH — Pulsing visual:
+   *   scale = 1 + amplitude * sin(time * speed)
+   *   This creates a breathing effect on source indicators.
+   */
+  update() {
+    const dt = xb.getDeltaTime();
+    this.elapsedTime += dt;
+    this.particles.update(dt);
+
+    // Pulse source visuals
+    const pulse =
+      1.0 + PULSE_AMPLITUDE * Math.sin(this.elapsedTime * PULSE_SPEED);
+    for (const visual of this.sourceVisuals.values()) {
+      visual.scale.setScalar(pulse);
+    }
+  }
+}

--- a/demos/forcefield/VectorField.ts
+++ b/demos/forcefield/VectorField.ts
@@ -1,0 +1,147 @@
+import * as THREE from 'three';
+import {simplex3} from './noise.js';
+
+/**
+ * Force source types that can be placed in the scene.
+ * Each applies a different mathematical force model.
+ */
+export interface ForceSource {
+  type: 'attractor' | 'repulsor' | 'vortex';
+  position: THREE.Vector3;
+  strength: number;
+  radius: number;
+}
+
+/** Epsilon for numerical differentiation in curl computation. */
+const CURL_EPS = 0.001;
+
+/** Reusable vectors to avoid GC pressure during per-particle evaluation. */
+const _toSource = new THREE.Vector3();
+const _curlResult = new THREE.Vector3();
+const _forceAccum = new THREE.Vector3();
+
+/**
+ * Evaluates a composite vector field at any point in 3D space.
+ *
+ * The field is the sum of:
+ * 1. Curl noise — divergence-free turbulence (incompressible flow)
+ * 2. Point attractors/repulsors — inverse-square falloff with soft radius
+ * 3. Vortex sources — tangential force around an axis
+ *
+ * MATH HIGHLIGHT — Curl Noise:
+ * Given a potential field Ψ(x,y,z) built from 3 independent noise channels,
+ * the curl is:
+ *   curl(Ψ) = (∂Ψz/∂y - ∂Ψy/∂z, ∂Ψx/∂z - ∂Ψz/∂x, ∂Ψy/∂x - ∂Ψx/∂y)
+ *
+ * This produces a divergence-free field (∇·curl = 0), meaning particles
+ * never bunch up or create voids — they flow like an incompressible fluid.
+ * Partial derivatives are approximated via central differences.
+ */
+export class VectorField {
+  public sources: ForceSource[] = [];
+  public noiseScale: number = 0.8;
+  public noiseStrength: number = 2.0;
+  public timeOffset: number = 0;
+
+  /**
+   * Computes curl noise at a point using central-difference approximation.
+   *
+   * MATH:
+   *   ∂Ψz/∂y ≈ (Ψz(x, y+ε, z) - Ψz(x, y-ε, z)) / (2ε)
+   *   ... and so on for all 6 partial derivatives.
+   *
+   * We use 3 offset noise channels (offset by 31.416 and 62.832) to get
+   * 3 independent scalar fields for the potential vector Ψ.
+   */
+  public curlNoise(
+    x: number,
+    y: number,
+    z: number,
+    out: THREE.Vector3
+  ): THREE.Vector3 {
+    const s = this.noiseScale;
+    const t = this.timeOffset;
+    const e = CURL_EPS;
+
+    // Potential field channels with large offsets for independence
+    const psi = (px: number, py: number, pz: number, offset: number) =>
+      simplex3(px * s + offset, py * s + t, pz * s);
+
+    // ∂Ψz/∂y - ∂Ψy/∂z
+    const dPsi_z_dy =
+      (psi(x, y + e, z, 62.832) - psi(x, y - e, z, 62.832)) / (2 * e);
+    const dPsi_y_dz =
+      (psi(x, y, z + e, 31.416) - psi(x, y, z - e, 31.416)) / (2 * e);
+
+    // ∂Ψx/∂z - ∂Ψz/∂x
+    const dPsi_x_dz = (psi(x, y, z + e, 0) - psi(x, y, z - e, 0)) / (2 * e);
+    const dPsi_z_dx =
+      (psi(x + e, y, z, 62.832) - psi(x - e, y, z, 62.832)) / (2 * e);
+
+    // ∂Ψy/∂x - ∂Ψx/∂y
+    const dPsi_y_dx =
+      (psi(x + e, y, z, 31.416) - psi(x - e, y, z, 31.416)) / (2 * e);
+    const dPsi_x_dy = (psi(x, y + e, z, 0) - psi(x, y - e, z, 0)) / (2 * e);
+
+    return out.set(
+      dPsi_z_dy - dPsi_y_dz,
+      dPsi_x_dz - dPsi_z_dx,
+      dPsi_y_dx - dPsi_x_dy
+    );
+  }
+
+  /**
+   * Evaluates the total force at a world-space position.
+   *
+   * MATH for each source type:
+   *
+   * Attractor: F = strength * dir / (dist² + softRadius²)
+   *   - Inverse-square law with soft radius to prevent singularity at dist=0
+   *
+   * Repulsor: F = -strength * dir / (dist² + softRadius²)
+   *   - Same as attractor but reversed
+   *
+   * Vortex: F = strength * cross(up, dir) / (dist + softRadius)
+   *   - Tangential force perpendicular to the radial direction
+   *   - Creates rotational flow around the source position
+   *   - Falls off as 1/r (not 1/r²) to maintain visible rotation at distance
+   */
+  public evaluate(position: THREE.Vector3, out: THREE.Vector3): THREE.Vector3 {
+    // Start with curl noise base flow
+    this.curlNoise(position.x, position.y, position.z, _curlResult);
+    _forceAccum.copy(_curlResult).multiplyScalar(this.noiseStrength);
+
+    // Accumulate forces from all sources
+    for (const source of this.sources) {
+      _toSource.subVectors(source.position, position);
+      const distSq = _toSource.lengthSq();
+      const dist = Math.sqrt(distSq);
+      const softRadiusSq = source.radius * source.radius;
+
+      switch (source.type) {
+        case 'attractor': {
+          // F = S * d̂ / (|d|² + r²)  — inverse-square with soft core
+          const forceMag = source.strength / (distSq + softRadiusSq);
+          _forceAccum.addScaledVector(_toSource.normalize(), forceMag);
+          break;
+        }
+        case 'repulsor': {
+          const forceMag = -source.strength / (distSq + softRadiusSq);
+          _forceAccum.addScaledVector(_toSource.normalize(), forceMag);
+          break;
+        }
+        case 'vortex': {
+          // Tangential force: cross(up, radialDir) gives perpendicular direction
+          const tangent = _toSource
+            .normalize()
+            .cross(new THREE.Vector3(0, 1, 0));
+          const forceMag = source.strength / (dist + source.radius);
+          _forceAccum.addScaledVector(tangent, forceMag);
+          break;
+        }
+      }
+    }
+
+    return out.copy(_forceAccum);
+  }
+}

--- a/demos/forcefield/index.html
+++ b/demos/forcefield/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Force Field Particles — XR Blocks</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, user-scalable=no"
+    />
+    <link rel="stylesheet" href="../demo.css" />
+    <style>
+      body {
+        background-color: #0a0a1a;
+      }
+    </style>
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "https://cdn.jsdelivr.net/npm/three@0.175.0/build/three.module.js",
+          "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.175.0/examples/jsm/",
+          "xrblocks": "https://cdn.jsdelivr.net/npm/xrblocks@0.10.0/src/xrblocks.js",
+          "xrblocks/": "https://cdn.jsdelivr.net/npm/xrblocks@0.10.0/src/"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <script type="module" src="main.ts"></script>
+  </body>
+</html>

--- a/demos/forcefield/main.ts
+++ b/demos/forcefield/main.ts
@@ -1,0 +1,22 @@
+import 'xrblocks/addons/simulator/SimulatorAddons.js';
+
+import * as xb from 'xrblocks';
+import {ForceFieldScene} from './ForceFieldScene.js';
+
+const options = new xb.Options();
+options.depth = new xb.DepthOptions();
+options.depth.matchDepthView = false;
+options.reticles.enabled = true;
+options.controllers.performRaycastOnUpdate = true;
+options.xrButton = {
+  ...options.xrButton,
+  startText: '<i id="xrlogo"></i> ENTER THE FIELD',
+  endText: '<i id="xrlogo"></i> EXIT THE FIELD',
+};
+
+async function start() {
+  xb.add(new ForceFieldScene());
+  await xb.init(options);
+}
+
+document.addEventListener('DOMContentLoaded', () => start());

--- a/demos/forcefield/noise.ts
+++ b/demos/forcefield/noise.ts
@@ -1,0 +1,201 @@
+/**
+ * 3D Simplex Noise implementation for curl noise computation.
+ * Based on Stefan Gustavson's simplex noise algorithm.
+ *
+ * MATH: Simplex noise uses a skewed grid (simplex lattice) instead of a
+ * hypercubic grid. For 3D, the skew factor is F = 1/3 and unskew G = 1/6.
+ * The simplex in 3D is a tetrahedron. Gradient contributions are summed
+ * from the 4 corners of the containing tetrahedron.
+ */
+
+// Permutation table (doubled to avoid wrapping)
+const perm = new Uint8Array(512);
+const grad3 = [
+  [1, 1, 0],
+  [-1, 1, 0],
+  [1, -1, 0],
+  [-1, -1, 0],
+  [1, 0, 1],
+  [-1, 0, 1],
+  [1, 0, -1],
+  [-1, 0, -1],
+  [0, 1, 1],
+  [0, -1, 1],
+  [0, 1, -1],
+  [0, -1, -1],
+];
+
+// Seed the permutation table
+(function initPerm() {
+  const p = new Uint8Array(256);
+  for (let i = 0; i < 256; i++) p[i] = i;
+  // Fisher-Yates shuffle with fixed seed for reproducibility
+  let seed = 42;
+  for (let i = 255; i > 0; i--) {
+    seed = (seed * 16807 + 0) % 2147483647;
+    const j = seed % (i + 1);
+    [p[i], p[j]] = [p[j], p[i]];
+  }
+  for (let i = 0; i < 512; i++) perm[i] = p[i & 255];
+})();
+
+function dot3(g: number[], x: number, y: number, z: number): number {
+  return g[0] * x + g[1] * y + g[2] * z;
+}
+
+/**
+ * 3D Simplex Noise.
+ *
+ * MATH HIGHLIGHT:
+ * - Skew transform: (x,y,z) -> simplex space using F = (sqrt(4) - 1) / 3 = 1/3
+ * - Unskew: G = (1 - 1/sqrt(4)) / 3 = 1/6
+ * - Contribution kernel: max(0, 0.6 - dx² - dy² - dz²)^4 * gradient·distance
+ * - Returns value in range [-1, 1]
+ */
+export function simplex3(x: number, y: number, z: number): number {
+  const F3 = 1.0 / 3.0;
+  const G3 = 1.0 / 6.0;
+
+  // Skew input space to determine which simplex cell we're in
+  const s = (x + y + z) * F3;
+  const i = Math.floor(x + s);
+  const j = Math.floor(y + s);
+  const k = Math.floor(z + s);
+
+  const t = (i + j + k) * G3;
+  // Unskew back to (x,y,z) space
+  const x0 = x - (i - t);
+  const y0 = y - (j - t);
+  const z0 = z - (k - t);
+
+  // Determine which simplex (tetrahedron) we are in
+  let i1: number, j1: number, k1: number;
+  let i2: number, j2: number, k2: number;
+
+  if (x0 >= y0) {
+    if (y0 >= z0) {
+      i1 = 1;
+      j1 = 0;
+      k1 = 0;
+      i2 = 1;
+      j2 = 1;
+      k2 = 0;
+    } else if (x0 >= z0) {
+      i1 = 1;
+      j1 = 0;
+      k1 = 0;
+      i2 = 1;
+      j2 = 0;
+      k2 = 1;
+    } else {
+      i1 = 0;
+      j1 = 0;
+      k1 = 1;
+      i2 = 1;
+      j2 = 0;
+      k2 = 1;
+    }
+  } else {
+    if (y0 < z0) {
+      i1 = 0;
+      j1 = 0;
+      k1 = 1;
+      i2 = 0;
+      j2 = 1;
+      k2 = 1;
+    } else if (x0 < z0) {
+      i1 = 0;
+      j1 = 1;
+      k1 = 0;
+      i2 = 0;
+      j2 = 1;
+      k2 = 1;
+    } else {
+      i1 = 0;
+      j1 = 1;
+      k1 = 0;
+      i2 = 1;
+      j2 = 1;
+      k2 = 0;
+    }
+  }
+
+  // Offsets for remaining corners
+  const x1 = x0 - i1 + G3;
+  const y1 = y0 - j1 + G3;
+  const z1 = z0 - k1 + G3;
+  const x2 = x0 - i2 + 2.0 * G3;
+  const y2 = y0 - j2 + 2.0 * G3;
+  const z2 = z0 - k2 + 2.0 * G3;
+  const x3 = x0 - 1.0 + 3.0 * G3;
+  const y3 = y0 - 1.0 + 3.0 * G3;
+  const z3 = z0 - 1.0 + 3.0 * G3;
+
+  // Hash coordinates of the 4 simplex corners
+  const ii = i & 255;
+  const jj = j & 255;
+  const kk = k & 255;
+
+  // Calculate contributions from each corner
+  let n0 = 0,
+    n1 = 0,
+    n2 = 0,
+    n3 = 0;
+
+  let t0 = 0.6 - x0 * x0 - y0 * y0 - z0 * z0;
+  if (t0 > 0) {
+    t0 *= t0;
+    const gi0 = perm[ii + perm[jj + perm[kk]]] % 12;
+    n0 = t0 * t0 * dot3(grad3[gi0], x0, y0, z0);
+  }
+
+  let t1 = 0.6 - x1 * x1 - y1 * y1 - z1 * z1;
+  if (t1 > 0) {
+    t1 *= t1;
+    const gi1 = perm[ii + i1 + perm[jj + j1 + perm[kk + k1]]] % 12;
+    n1 = t1 * t1 * dot3(grad3[gi1], x1, y1, z1);
+  }
+
+  let t2 = 0.6 - x2 * x2 - y2 * y2 - z2 * z2;
+  if (t2 > 0) {
+    t2 *= t2;
+    const gi2 = perm[ii + i2 + perm[jj + j2 + perm[kk + k2]]] % 12;
+    n2 = t2 * t2 * dot3(grad3[gi2], x2, y2, z2);
+  }
+
+  let t3 = 0.6 - x3 * x3 - y3 * y3 - z3 * z3;
+  if (t3 > 0) {
+    t3 *= t3;
+    const gi3 = perm[ii + 1 + perm[jj + 1 + perm[kk + 1]]] % 12;
+    n3 = t3 * t3 * dot3(grad3[gi3], x3, y3, z3);
+  }
+
+  // Scale to [-1, 1]
+  return 32.0 * (n0 + n1 + n2 + n3);
+}
+
+/**
+ * Fractal Brownian Motion — layers multiple octaves of simplex noise.
+ *
+ * MATH: fBm(p) = Σ amplitude^i * noise(frequency^i * p)
+ * Each octave doubles frequency (lacunarity=2) and halves amplitude (gain=0.5).
+ */
+export function fbm3(
+  x: number,
+  y: number,
+  z: number,
+  octaves: number = 4,
+  lacunarity: number = 2.0,
+  gain: number = 0.5
+): number {
+  let value = 0;
+  let amplitude = 1.0;
+  let frequency = 1.0;
+
+  for (let i = 0; i < octaves; i++) {
+    value += amplitude * simplex3(x * frequency, y * frequency, z * frequency);
+    frequency *= lacunarity;
+    amplitude *= gain;
+  }
+  return value;
+}


### PR DESCRIPTION
Adds a new XR demo featuring curl noise-driven particles with interactive attractor, repulsor, and vortex force sources.

Math highlights:
- 3D simplex noise with fBm for curl noise computation
- Divergence-free vector field via central-difference curl
- Inverse-square attractor/repulsor forces with soft-core regularization
- Tangential vortex forces via cross product
- Symplectic Euler integration for energy-conserving particle physics
- 5000 GPU-instanced particles with speed-to-HSL color mapping

Files:
- demos/forcefield/noise.ts — simplex noise + fBm
- demos/forcefield/VectorField.ts — curl noise + force sources
- demos/forcefield/ForceFieldParticles.ts — particle system + integrator
- demos/forcefield/ForceFieldScene.ts — XR scene with depth mesh interaction
- demos/forcefield/main.ts + index.html — entry point