### PR TITLE
Make ToolSchema.items have type ToolSchema

### DIFF
--- a/src/agent/Tool.ts
+++ b/src/agent/Tool.ts
@@ -24,9 +24,10 @@ export interface ToolResult<T = unknown> {
 // strings so tools don't need to import the types from @google/genai.
 export type ToolSchema = Omit<
   GoogleGenAITypes.Schema,
-  'type' | 'properties'
+  'type' | 'properties' | 'items'
 > & {
   properties?: Record<string, ToolSchema>;
+  items?: ToolSchema;
   type?: keyof typeof GoogleGenAITypes.Type;
 };
 


### PR DESCRIPTION
This is so items can have properties with string types instead of enum types.