### PR TITLE
Add gamepad support to simulator

### DIFF
--- a/src/addons/simulator/SimulatorAddons.ts
+++ b/src/addons/simulator/SimulatorAddons.ts
@@ -1,3 +1,5 @@
 import './instructions/SimulatorInstructions.js';
+import './ui/GamepadSettingsPanel.js';
+import './ui/GamepadToast.js';
 import './ui/HandPosePanel.js';
 import './ui/ModeIndicator.js';

--- a/src/addons/simulator/ui/GamepadSettingsPanel.ts
+++ b/src/addons/simulator/ui/GamepadSettingsPanel.ts
@@ -15,6 +15,12 @@ const ACTION_LABELS: Record<xb.GamepadAction, string> = {
   openSettings: 'Open Settings',
 };
 
+// Actions hidden from the rebind list. openSettings must always stay bound
+// so users can never lock themselves out of the menu.
+const REBINDABLE_ACTIONS = (
+  Object.keys(ACTION_LABELS) as xb.GamepadAction[]
+).filter((a) => a !== 'openSettings');
+
 @customElement('xrblocks-gamepad-settings')
 export class GamepadSettingsPanel extends LitElement {
   static styles = css`
@@ -174,7 +180,7 @@ export class GamepadSettingsPanel extends LitElement {
   }
 
   private get _totalItems(): number {
-    return Object.keys(ACTION_LABELS).length + 2; // bindings + reset + close
+    return REBINDABLE_ACTIONS.length + 2; // bindings + reset + close
   }
 
   show() {
@@ -260,6 +266,16 @@ export class GamepadSettingsPanel extends LitElement {
     if (this._navJustPressed(gp, 0)) this._activateFocused();
     // B button (button 1) — close panel.
     if (this._navJustPressed(gp, 1)) this.hide();
+    // Settings button (whichever is bound to openSettings) — also closes.
+    const settingsBtn = this.bindings?.getBinding('openSettings') ?? -1;
+    if (
+      settingsBtn >= 0 &&
+      settingsBtn !== 0 &&
+      settingsBtn !== 1 &&
+      this._navJustPressed(gp, settingsBtn)
+    ) {
+      this.hide();
+    }
 
     this._navUpdatePrev(gp);
   }
@@ -270,7 +286,7 @@ export class GamepadSettingsPanel extends LitElement {
   }
 
   private _activateFocused() {
-    const actions = Object.keys(ACTION_LABELS) as xb.GamepadAction[];
+    const actions = REBINDABLE_ACTIONS;
     if (this._focusedIndex < actions.length) {
       this._startListening(actions[this._focusedIndex]);
     } else if (this._focusedIndex === actions.length) {
@@ -307,7 +323,7 @@ export class GamepadSettingsPanel extends LitElement {
   }
 
   render() {
-    const actions = Object.keys(ACTION_LABELS) as xb.GamepadAction[];
+    const actions = REBINDABLE_ACTIONS;
     const resetIdx = actions.length;
     const closeIdx = actions.length + 1;
     return html`

--- a/src/addons/simulator/ui/GamepadSettingsPanel.ts
+++ b/src/addons/simulator/ui/GamepadSettingsPanel.ts
@@ -12,6 +12,7 @@ const ACTION_LABELS: Record<xb.GamepadAction, string> = {
   cycleHandPoseRight: 'Next Hand Pose',
   cycleSimulatorMode: 'Cycle Simulator Mode',
   toggleUI: 'Toggle UI',
+  toggleHand: 'Swap Active Hand',
   moveDown: 'Move Down',
   moveUp: 'Move Up',
   openSettings: 'Open Settings',

--- a/src/addons/simulator/ui/GamepadSettingsPanel.ts
+++ b/src/addons/simulator/ui/GamepadSettingsPanel.ts
@@ -1,0 +1,334 @@
+import {css, html, LitElement} from 'lit';
+import {customElement} from 'lit/decorators/custom-element.js';
+import {property} from 'lit/decorators/property.js';
+import {state} from 'lit/decorators/state.js';
+import * as xb from 'xrblocks';
+
+import {buttonName} from './GamepadToast.js';
+
+const ACTION_LABELS: Record<xb.GamepadAction, string> = {
+  select: 'Select / Interact',
+  cycleHandPoseLeft: 'Previous Hand Pose',
+  cycleHandPoseRight: 'Next Hand Pose',
+  cycleSimulatorMode: 'Cycle Simulator Mode',
+  toggleUI: 'Toggle UI',
+  openSettings: 'Open Settings',
+};
+
+@customElement('xrblocks-gamepad-settings')
+export class GamepadSettingsPanel extends LitElement {
+  static styles = css`
+    :host {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      z-index: 10001;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      pointer-events: none;
+    }
+
+    :host([hidden]) {
+      display: none;
+    }
+
+    .backdrop {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.5);
+      pointer-events: auto;
+    }
+
+    .panel {
+      position: relative;
+      background: rgba(20, 20, 30, 0.95);
+      color: #fff;
+      border-radius: 1rem;
+      padding: 1.5rem;
+      font-family: system-ui, sans-serif;
+      min-width: 20rem;
+      max-width: 28rem;
+      backdrop-filter: blur(12px);
+      pointer-events: auto;
+      z-index: 1;
+    }
+
+    h2 {
+      margin: 0 0 1rem;
+      font-size: 1.1rem;
+      font-weight: 600;
+    }
+
+    .binding-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.5rem 0;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    }
+
+    .binding-row:last-of-type {
+      border-bottom: none;
+    }
+
+    .action-label {
+      color: #ccc;
+      font-size: 0.9rem;
+    }
+
+    .bind-btn {
+      background: rgba(255, 255, 255, 0.1);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      color: #8cf;
+      border-radius: 0.5rem;
+      padding: 0.3rem 0.8rem;
+      font-size: 0.85rem;
+      cursor: pointer;
+      min-width: 4rem;
+      text-align: center;
+      font-family: inherit;
+    }
+
+    .bind-btn:hover,
+    .bind-btn.focused {
+      background: rgba(255, 255, 255, 0.2);
+      outline: 2px solid #8cf;
+      outline-offset: 2px;
+    }
+
+    .bind-btn.listening {
+      color: #fc4;
+      border-color: #fc4;
+      animation: pulse 1s infinite alternate;
+    }
+
+    @keyframes pulse {
+      from {
+        opacity: 0.6;
+      }
+      to {
+        opacity: 1;
+      }
+    }
+
+    .footer {
+      display: flex;
+      justify-content: space-between;
+      margin-top: 1rem;
+      gap: 0.5rem;
+    }
+
+    .footer button {
+      background: rgba(255, 255, 255, 0.1);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      color: #fff;
+      border-radius: 0.5rem;
+      padding: 0.4rem 1rem;
+      cursor: pointer;
+      font-size: 0.85rem;
+      font-family: inherit;
+    }
+
+    .footer button:hover,
+    .footer button.focused {
+      background: rgba(255, 255, 255, 0.2);
+      outline: 2px solid #8cf;
+      outline-offset: 2px;
+    }
+
+    .hint {
+      margin-top: 0.75rem;
+      font-size: 0.75rem;
+      color: #888;
+      text-align: center;
+    }
+  `;
+
+  @property({type: Object}) bindings?: xb.GamepadBindings;
+  @property({type: Object}) gamepadController?: xb.GamepadController;
+  @state() private _listeningAction: xb.GamepadAction | null = null;
+  @state() private _bindingSnapshot: Record<string, number> = {};
+  @state() private _focusedIndex = 0;
+  private _rafId: number | null = null;
+  private _prevStickY = 0;
+
+  private get _totalItems(): number {
+    return Object.keys(ACTION_LABELS).length + 2; // bindings + reset + close
+  }
+
+  show() {
+    this.hidden = false;
+    this._refreshSnapshot();
+    this._focusedIndex = 0;
+    this._prevStickY = 0;
+    if (this.gamepadController) {
+      this.gamepadController.menuActive = true;
+    }
+    this._startNavLoop();
+  }
+
+  hide() {
+    this.hidden = true;
+    if (this._listeningAction) {
+      this.gamepadController?.cancelCapture();
+      this._listeningAction = null;
+    }
+    if (this.gamepadController) {
+      this.gamepadController.menuActive = false;
+    }
+    this._stopNavLoop();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._stopNavLoop();
+    if (this.gamepadController) {
+      this.gamepadController.menuActive = false;
+    }
+  }
+
+  private _startNavLoop() {
+    if (this._rafId !== null) return;
+    const loop = () => {
+      this._rafId = requestAnimationFrame(loop);
+      this._pollNavigation();
+    };
+    this._rafId = requestAnimationFrame(loop);
+  }
+
+  private _stopNavLoop() {
+    if (this._rafId !== null) {
+      cancelAnimationFrame(this._rafId);
+      this._rafId = null;
+    }
+  }
+
+  private _pollNavigation() {
+    const gp = this.gamepadController;
+    if (!gp || !gp.userData.connected) return;
+
+    // While listening for a rebind, the next button press is consumed by the
+    // capture callback — don't double-handle navigation.
+    if (this._listeningAction !== null) return;
+
+    // Left stick Y for focus movement (rising-edge debounced).
+    const [, ly] = gp.getAxes();
+    const THRESH = 0.5;
+    if (ly < -THRESH && this._prevStickY >= -THRESH) {
+      this._moveFocus(-1);
+    } else if (ly > THRESH && this._prevStickY <= THRESH) {
+      this._moveFocus(1);
+    }
+    this._prevStickY = ly;
+
+    // D-pad up/down for focus movement.
+    if (gp.isButtonJustPressed(12)) this._moveFocus(-1);
+    if (gp.isButtonJustPressed(13)) this._moveFocus(1);
+
+    // Triggers as alternate up/down.
+    if (gp.isButtonJustPressed(6)) this._moveFocus(-1);
+    if (gp.isButtonJustPressed(7)) this._moveFocus(1);
+
+    // A button (button 0) — activate focused item.
+    if (gp.isButtonJustPressed(0)) this._activateFocused();
+    // B button (button 1) — close panel.
+    if (gp.isButtonJustPressed(1)) this.hide();
+  }
+
+  private _moveFocus(delta: number) {
+    const max = this._totalItems - 1;
+    this._focusedIndex = Math.max(
+      0,
+      Math.min(max, this._focusedIndex + delta)
+    );
+  }
+
+  private _activateFocused() {
+    const actions = Object.keys(ACTION_LABELS) as xb.GamepadAction[];
+    if (this._focusedIndex < actions.length) {
+      this._startListening(actions[this._focusedIndex]);
+    } else if (this._focusedIndex === actions.length) {
+      this._resetDefaults();
+    } else {
+      this.hide();
+    }
+  }
+
+  private _refreshSnapshot() {
+    if (this.bindings) {
+      this._bindingSnapshot = {...this.bindings.getAllBindings()};
+    }
+  }
+
+  private _startListening(action: xb.GamepadAction) {
+    this._listeningAction = action;
+    this.gamepadController?.captureNextButtonPress((buttonIndex: number) => {
+      this.bindings?.setBinding(action, buttonIndex);
+      this._listeningAction = null;
+      this._refreshSnapshot();
+    });
+  }
+
+  private _resetDefaults() {
+    this.bindings?.resetDefaults();
+    this._refreshSnapshot();
+  }
+
+  render() {
+    const actions = Object.keys(ACTION_LABELS) as xb.GamepadAction[];
+    const resetIdx = actions.length;
+    const closeIdx = actions.length + 1;
+    return html`
+      <div class="backdrop" @click=${this.hide}></div>
+      <div class="panel">
+        <h2>🎮 Gamepad Settings</h2>
+        ${actions.map((action, i) => {
+          const btnIdx = this._bindingSnapshot[action] ?? -1;
+          const isListening = this._listeningAction === action;
+          const isFocused = this._focusedIndex === i;
+          return html`
+            <div class="binding-row">
+              <span class="action-label">${ACTION_LABELS[action]}</span>
+              <button
+                class="bind-btn ${isListening ? 'listening' : ''} ${isFocused
+                  ? 'focused'
+                  : ''}"
+                @click=${() =>
+                  isListening ? null : this._startListening(action)}
+              >
+                ${isListening
+                  ? 'Press button...'
+                  : btnIdx >= 0
+                    ? buttonName(btnIdx)
+                    : 'Unbound'}
+              </button>
+            </div>
+          `;
+        })}
+        <div class="footer">
+          <button
+            class=${this._focusedIndex === resetIdx ? 'focused' : ''}
+            @click=${this._resetDefaults}
+          >
+            Reset Defaults
+          </button>
+          <button
+            class=${this._focusedIndex === closeIdx ? 'focused' : ''}
+            @click=${this.hide}
+          >
+            Close
+          </button>
+        </div>
+        <div class="hint">
+          Stick / D-pad / LT-RT: Navigate · A: Select · B: Close
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/addons/simulator/ui/GamepadSettingsPanel.ts
+++ b/src/addons/simulator/ui/GamepadSettingsPanel.ts
@@ -243,10 +243,7 @@ export class GamepadSettingsPanel extends LitElement {
 
   private _moveFocus(delta: number) {
     const max = this._totalItems - 1;
-    this._focusedIndex = Math.max(
-      0,
-      Math.min(max, this._focusedIndex + delta)
-    );
+    this._focusedIndex = Math.max(0, Math.min(max, this._focusedIndex + delta));
   }
 
   private _activateFocused() {

--- a/src/addons/simulator/ui/GamepadSettingsPanel.ts
+++ b/src/addons/simulator/ui/GamepadSettingsPanel.ts
@@ -12,6 +12,8 @@ const ACTION_LABELS: Record<xb.GamepadAction, string> = {
   cycleHandPoseRight: 'Next Hand Pose',
   cycleSimulatorMode: 'Cycle Simulator Mode',
   toggleUI: 'Toggle UI',
+  moveDown: 'Move Down',
+  moveUp: 'Move Up',
   openSettings: 'Open Settings',
 };
 

--- a/src/addons/simulator/ui/GamepadSettingsPanel.ts
+++ b/src/addons/simulator/ui/GamepadSettingsPanel.ts
@@ -157,6 +157,21 @@ export class GamepadSettingsPanel extends LitElement {
   @state() private _focusedIndex = 0;
   private _rafId: number | null = null;
   private _prevStickY = 0;
+  private _navPrevButtons: boolean[] = [];
+
+  private _navJustPressed(gp: xb.GamepadController, index: number): boolean {
+    const down = gp.activeGamepad?.buttons[index]?.pressed ?? false;
+    const wasDown = this._navPrevButtons[index] ?? false;
+    return down && !wasDown;
+  }
+
+  private _navUpdatePrev(gp: xb.GamepadController) {
+    const buttons = gp.activeGamepad?.buttons;
+    if (!buttons) return;
+    for (let i = 0; i < buttons.length; i++) {
+      this._navPrevButtons[i] = buttons[i]?.pressed ?? false;
+    }
+  }
 
   private get _totalItems(): number {
     return Object.keys(ACTION_LABELS).length + 2; // bindings + reset + close
@@ -167,8 +182,10 @@ export class GamepadSettingsPanel extends LitElement {
     this._refreshSnapshot();
     this._focusedIndex = 0;
     this._prevStickY = 0;
+    this._navPrevButtons = [];
     if (this.gamepadController) {
       this.gamepadController.menuActive = true;
+      this._navUpdatePrev(this.gamepadController);
     }
     this._startNavLoop();
   }
@@ -214,8 +231,12 @@ export class GamepadSettingsPanel extends LitElement {
     if (!gp || !gp.userData.connected) return;
 
     // While listening for a rebind, the next button press is consumed by the
-    // capture callback — don't double-handle navigation.
-    if (this._listeningAction !== null) return;
+    // capture callback — don't double-handle navigation. Still update prev
+    // button state so we don't fire a stale rising edge on the next frame.
+    if (this._listeningAction !== null) {
+      this._navUpdatePrev(gp);
+      return;
+    }
 
     // Left stick Y for focus movement (rising-edge debounced).
     const [, ly] = gp.getAxes();
@@ -228,17 +249,19 @@ export class GamepadSettingsPanel extends LitElement {
     this._prevStickY = ly;
 
     // D-pad up/down for focus movement.
-    if (gp.isButtonJustPressed(12)) this._moveFocus(-1);
-    if (gp.isButtonJustPressed(13)) this._moveFocus(1);
+    if (this._navJustPressed(gp, 12)) this._moveFocus(-1);
+    if (this._navJustPressed(gp, 13)) this._moveFocus(1);
 
     // Triggers as alternate up/down.
-    if (gp.isButtonJustPressed(6)) this._moveFocus(-1);
-    if (gp.isButtonJustPressed(7)) this._moveFocus(1);
+    if (this._navJustPressed(gp, 6)) this._moveFocus(-1);
+    if (this._navJustPressed(gp, 7)) this._moveFocus(1);
 
     // A button (button 0) — activate focused item.
-    if (gp.isButtonJustPressed(0)) this._activateFocused();
+    if (this._navJustPressed(gp, 0)) this._activateFocused();
     // B button (button 1) — close panel.
-    if (gp.isButtonJustPressed(1)) this.hide();
+    if (this._navJustPressed(gp, 1)) this.hide();
+
+    this._navUpdatePrev(gp);
   }
 
   private _moveFocus(delta: number) {
@@ -269,6 +292,12 @@ export class GamepadSettingsPanel extends LitElement {
       this.bindings?.setBinding(action, buttonIndex);
       this._listeningAction = null;
       this._refreshSnapshot();
+      // Sync nav prev-buttons to current state so the just-captured press
+      // isn't seen as a fresh rising edge by the next nav poll (which would
+      // e.g. close the menu when B is bound).
+      if (this.gamepadController) {
+        this._navUpdatePrev(this.gamepadController);
+      }
     });
   }
 

--- a/src/addons/simulator/ui/GamepadToast.ts
+++ b/src/addons/simulator/ui/GamepadToast.ts
@@ -1,0 +1,119 @@
+import {css, html, LitElement} from 'lit';
+import {customElement} from 'lit/decorators/custom-element.js';
+import {property} from 'lit/decorators/property.js';
+
+const BUTTON_NAMES: Record<number, string> = {
+  0: 'A',
+  1: 'B',
+  2: 'X',
+  3: 'Y',
+  4: 'LB',
+  5: 'RB',
+  6: 'LT',
+  7: 'RT',
+  8: 'Back',
+  9: 'Start',
+  10: 'L3',
+  11: 'R3',
+  12: 'D-Up',
+  13: 'D-Down',
+  14: 'D-Left',
+  15: 'D-Right',
+};
+
+export function buttonName(index: number): string {
+  return BUTTON_NAMES[index] ?? `Btn ${index}`;
+}
+
+@customElement('xrblocks-gamepad-toast')
+export class GamepadToast extends LitElement {
+  static styles = css`
+    :host {
+      position: fixed;
+      top: 1.5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 10000;
+      pointer-events: none;
+    }
+
+    .toast {
+      background: rgba(0, 0, 0, 0.85);
+      color: #fff;
+      border-radius: 1rem;
+      padding: 1rem 1.5rem;
+      font-family: system-ui, sans-serif;
+      font-size: 0.9rem;
+      backdrop-filter: blur(8px);
+      opacity: 1;
+      transition: opacity 0.4s ease-out;
+      pointer-events: auto;
+      cursor: pointer;
+      max-width: 28rem;
+    }
+
+    .toast.hidden {
+      opacity: 0;
+    }
+
+    h3 {
+      margin: 0 0 0.5rem;
+      font-size: 1rem;
+      font-weight: 600;
+    }
+
+    .controls {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 0.2rem 0.8rem;
+    }
+
+    .key {
+      font-weight: 600;
+      color: #8cf;
+      text-align: right;
+    }
+
+    .action {
+      color: #ccc;
+    }
+  `;
+
+  @property({type: Boolean}) visible = false;
+
+  private _timer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Map of button label → action description. */
+  @property({type: Object}) controls: Record<string, string> = {};
+
+  show(controls: Record<string, string>, duration = 5000) {
+    this.controls = controls;
+    this.visible = true;
+    if (this._timer) clearTimeout(this._timer);
+    this._timer = setTimeout(() => this.dismiss(), duration);
+  }
+
+  dismiss() {
+    this.visible = false;
+    if (this._timer) {
+      clearTimeout(this._timer);
+      this._timer = null;
+    }
+  }
+
+  render() {
+    return html`
+      <div class="toast ${this.visible ? '' : 'hidden'}" @click=${this.dismiss}>
+        <h3>🎮 Gamepad Connected</h3>
+        <div class="controls">
+          ${Object.entries(this.controls).map(
+            ([key, action]) => html`
+              <span class="key">${key}</span>
+              <span class="action">${action}</span>
+            `
+          )}
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/addons/simulator/ui/GamepadToast.ts
+++ b/src/addons/simulator/ui/GamepadToast.ts
@@ -86,8 +86,20 @@ export class GamepadToast extends LitElement {
   /** Map of button label → action description. */
   @property({type: Object}) controls: Record<string, string> = {};
 
+  @property({type: String}) private _flashMessage = '';
+
   show(controls: Record<string, string>, duration = 5000) {
     this.controls = controls;
+    this._flashMessage = '';
+    this.visible = true;
+    if (this._timer) clearTimeout(this._timer);
+    this._timer = setTimeout(() => this.dismiss(), duration);
+  }
+
+  /** Show a brief single-line message (e.g. "Active Hand: Right"). */
+  flash(message: string, duration = 1500) {
+    this._flashMessage = message;
+    this.controls = {};
     this.visible = true;
     if (this._timer) clearTimeout(this._timer);
     this._timer = setTimeout(() => this.dismiss(), duration);
@@ -102,6 +114,16 @@ export class GamepadToast extends LitElement {
   }
 
   render() {
+    if (this._flashMessage) {
+      return html`
+        <div
+          class="toast ${this.visible ? '' : 'hidden'}"
+          @click=${this.dismiss}
+        >
+          <span class="action">${this._flashMessage}</span>
+        </div>
+      `;
+    }
     return html`
       <div class="toast ${this.visible ? '' : 'hidden'}" @click=${this.dismiss}>
         <h3>🎮 Gamepad Connected</h3>

--- a/src/input/GamepadBindings.test.ts
+++ b/src/input/GamepadBindings.test.ts
@@ -74,6 +74,19 @@ describe('GamepadBindings', () => {
     expect(bindings.getBinding('select')).toBe(0);
   });
 
+  it('refuses to rebind openSettings', () => {
+    const bindings = new GamepadBindings();
+    bindings.setBinding('openSettings', 0);
+    expect(bindings.getBinding('openSettings')).toBe(9);
+  });
+
+  it('does not unbind openSettings when another action steals its button', () => {
+    const bindings = new GamepadBindings();
+    bindings.setBinding('select', 9); // openSettings is on 9
+    expect(bindings.getBinding('select')).toBe(0); // refused, kept default
+    expect(bindings.getBinding('openSettings')).toBe(9);
+  });
+
   it('resetDefaults restores all to defaults and persists', () => {
     const bindings = new GamepadBindings();
     bindings.setBinding('select', 5);

--- a/src/input/GamepadBindings.test.ts
+++ b/src/input/GamepadBindings.test.ts
@@ -12,7 +12,7 @@ describe('GamepadBindings', () => {
     expect(bindings.getBinding('select')).toBe(0);
     expect(bindings.getBinding('cycleHandPoseLeft')).toBe(14);
     expect(bindings.getBinding('cycleHandPoseRight')).toBe(15);
-    expect(bindings.getBinding('cycleSimulatorMode')).toBe(8);
+    expect(bindings.getBinding('cycleSimulatorMode')).toBe(3);
     expect(bindings.getBinding('toggleUI')).toBe(5);
     expect(bindings.getBinding('openSettings')).toBe(9);
   });

--- a/src/input/GamepadBindings.test.ts
+++ b/src/input/GamepadBindings.test.ts
@@ -1,0 +1,124 @@
+import {describe, it, expect, beforeEach, vi} from 'vitest';
+
+import {GamepadBindings} from './GamepadBindings';
+
+describe('GamepadBindings', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns default bindings when no storage exists', () => {
+    const bindings = new GamepadBindings();
+    expect(bindings.getBinding('select')).toBe(0);
+    expect(bindings.getBinding('cycleHandPoseLeft')).toBe(14);
+    expect(bindings.getBinding('cycleHandPoseRight')).toBe(15);
+    expect(bindings.getBinding('cycleSimulatorMode')).toBe(8);
+    expect(bindings.getBinding('toggleUI')).toBe(5);
+    expect(bindings.getBinding('openSettings')).toBe(9);
+  });
+
+  it('persists bindings to localStorage', () => {
+    const bindings = new GamepadBindings();
+    bindings.setBinding('select', 1);
+
+    const stored = localStorage.getItem(
+      'xrblocks:simulator:gamepad-bindings:v1'
+    );
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored!);
+    expect(parsed.version).toBe(1);
+    expect(parsed.bindings.select).toBe(1);
+  });
+
+  it('loads persisted bindings', () => {
+    localStorage.setItem(
+      'xrblocks:simulator:gamepad-bindings:v1',
+      JSON.stringify({version: 1, bindings: {select: 3, toggleUI: 7}})
+    );
+    const bindings = new GamepadBindings();
+    expect(bindings.getBinding('select')).toBe(3);
+    expect(bindings.getBinding('toggleUI')).toBe(7);
+    // Non-stored keys keep defaults
+    expect(bindings.getBinding('cycleHandPoseLeft')).toBe(14);
+  });
+
+  it('falls back to defaults on malformed localStorage', () => {
+    localStorage.setItem(
+      'xrblocks:simulator:gamepad-bindings:v1',
+      'not valid json'
+    );
+    const bindings = new GamepadBindings();
+    expect(bindings.getBinding('select')).toBe(0);
+  });
+
+  it('falls back to defaults on wrong version', () => {
+    localStorage.setItem(
+      'xrblocks:simulator:gamepad-bindings:v1',
+      JSON.stringify({version: 99, bindings: {select: 5}})
+    );
+    const bindings = new GamepadBindings();
+    expect(bindings.getBinding('select')).toBe(0);
+  });
+
+  it('auto-unbinds duplicate when setting a binding', () => {
+    const bindings = new GamepadBindings();
+    // select = 0 by default, cycleHandPoseLeft = 14
+    bindings.setBinding('cycleHandPoseLeft', 0); // steal button 0 from select
+    expect(bindings.getBinding('cycleHandPoseLeft')).toBe(0);
+    expect(bindings.getBinding('select')).toBe(-1); // unbound
+  });
+
+  it('does not unbind self when re-setting same button', () => {
+    const bindings = new GamepadBindings();
+    bindings.setBinding('select', 0); // same as default
+    expect(bindings.getBinding('select')).toBe(0);
+  });
+
+  it('resetDefaults restores all to defaults and persists', () => {
+    const bindings = new GamepadBindings();
+    bindings.setBinding('select', 5);
+    bindings.setBinding('toggleUI', 12);
+    bindings.resetDefaults();
+
+    expect(bindings.getBinding('select')).toBe(0);
+    expect(bindings.getBinding('toggleUI')).toBe(5);
+
+    // Check it persisted the reset
+    const stored = JSON.parse(
+      localStorage.getItem('xrblocks:simulator:gamepad-bindings:v1')!
+    );
+    expect(stored.bindings.select).toBe(0);
+  });
+
+  it('getAllBindings returns a copy', () => {
+    const bindings = new GamepadBindings();
+    const all = bindings.getAllBindings();
+    all.select = 99;
+    expect(bindings.getBinding('select')).toBe(0); // not affected
+  });
+
+  it('handles localStorage throwing gracefully', () => {
+    const spy = vi
+      .spyOn(Storage.prototype, 'getItem')
+      .mockImplementation(() => {
+        throw new Error('SecurityError');
+      });
+    // Should not throw
+    const bindings = new GamepadBindings();
+    expect(bindings.getBinding('select')).toBe(0);
+    spy.mockRestore();
+  });
+
+  it('handles localStorage.setItem throwing gracefully', () => {
+    const spy = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('QuotaExceeded');
+      });
+    const bindings = new GamepadBindings();
+    // Should not throw
+    bindings.setBinding('select', 3);
+    expect(bindings.getBinding('select')).toBe(3); // in-memory still works
+    spy.mockRestore();
+  });
+});

--- a/src/input/GamepadBindings.ts
+++ b/src/input/GamepadBindings.ts
@@ -12,7 +12,7 @@ const DEFAULT_BINDINGS: Record<GamepadAction, number> = {
   select: 0, // A / Cross
   cycleHandPoseLeft: 14, // D-pad left
   cycleHandPoseRight: 15, // D-pad right
-  cycleSimulatorMode: 8, // Back / Select
+  cycleSimulatorMode: 3, // Y
   toggleUI: 5, // RB / R1
   openSettings: 9, // Start / Menu
 };

--- a/src/input/GamepadBindings.ts
+++ b/src/input/GamepadBindings.ts
@@ -38,9 +38,19 @@ export class GamepadBindings {
   }
 
   setBinding(action: GamepadAction, buttonIndex: number) {
-    // Auto-unbind any other action using this button.
+    // openSettings must always be bound so users can never lock themselves
+    // out of the menu — silently ignore attempts to rebind or unbind it,
+    // and refuse to assign its button to any other action.
+    if (action === 'openSettings') return;
+    if (buttonIndex === this.bindings.openSettings) return;
+    // Auto-unbind any other action using this button, except openSettings
+    // (same lock-out reason).
     for (const key of Object.keys(this.bindings) as GamepadAction[]) {
-      if (key !== action && this.bindings[key] === buttonIndex) {
+      if (
+        key !== action &&
+        key !== 'openSettings' &&
+        this.bindings[key] === buttonIndex
+      ) {
         this.bindings[key] = -1;
       }
     }

--- a/src/input/GamepadBindings.ts
+++ b/src/input/GamepadBindings.ts
@@ -6,6 +6,8 @@ export type GamepadAction =
   | 'cycleHandPoseRight'
   | 'cycleSimulatorMode'
   | 'toggleUI'
+  | 'moveDown'
+  | 'moveUp'
   | 'openSettings';
 
 const DEFAULT_BINDINGS: Record<GamepadAction, number> = {
@@ -14,6 +16,8 @@ const DEFAULT_BINDINGS: Record<GamepadAction, number> = {
   cycleHandPoseRight: 15, // D-pad right
   cycleSimulatorMode: 3, // Y
   toggleUI: 5, // RB / R1
+  moveDown: 6, // LT (analog)
+  moveUp: 7, // RT (analog)
   openSettings: 9, // Start / Menu
 };
 

--- a/src/input/GamepadBindings.ts
+++ b/src/input/GamepadBindings.ts
@@ -6,6 +6,7 @@ export type GamepadAction =
   | 'cycleHandPoseRight'
   | 'cycleSimulatorMode'
   | 'toggleUI'
+  | 'toggleHand'
   | 'moveDown'
   | 'moveUp'
   | 'openSettings';
@@ -16,6 +17,7 @@ const DEFAULT_BINDINGS: Record<GamepadAction, number> = {
   cycleHandPoseRight: 15, // D-pad right
   cycleSimulatorMode: 3, // Y
   toggleUI: 5, // RB / R1
+  toggleHand: 4, // LB / L1
   moveDown: 6, // LT (analog)
   moveUp: 7, // RT (analog)
   openSettings: 9, // Start / Menu

--- a/src/input/GamepadBindings.ts
+++ b/src/input/GamepadBindings.ts
@@ -1,0 +1,82 @@
+const STORAGE_KEY = 'xrblocks:simulator:gamepad-bindings:v1';
+
+export type GamepadAction =
+  | 'select'
+  | 'cycleHandPoseLeft'
+  | 'cycleHandPoseRight'
+  | 'cycleSimulatorMode'
+  | 'toggleUI'
+  | 'openSettings';
+
+const DEFAULT_BINDINGS: Record<GamepadAction, number> = {
+  select: 0, // A / Cross
+  cycleHandPoseLeft: 14, // D-pad left
+  cycleHandPoseRight: 15, // D-pad right
+  cycleSimulatorMode: 8, // Back / Select
+  toggleUI: 5, // RB / R1
+  openSettings: 9, // Start / Menu
+};
+
+/**
+ * Manages gamepad button-to-action mappings with localStorage persistence.
+ * One button per action — assigning a button removes it from any previous action.
+ */
+export class GamepadBindings {
+  private bindings: Record<GamepadAction, number>;
+
+  constructor() {
+    this.bindings = {...DEFAULT_BINDINGS};
+    this.load();
+  }
+
+  getBinding(action: GamepadAction): number {
+    return this.bindings[action];
+  }
+
+  getAllBindings(): Record<GamepadAction, number> {
+    return {...this.bindings};
+  }
+
+  setBinding(action: GamepadAction, buttonIndex: number) {
+    // Auto-unbind any other action using this button.
+    for (const key of Object.keys(this.bindings) as GamepadAction[]) {
+      if (key !== action && this.bindings[key] === buttonIndex) {
+        this.bindings[key] = -1;
+      }
+    }
+    this.bindings[action] = buttonIndex;
+    this.save();
+  }
+
+  resetDefaults() {
+    this.bindings = {...DEFAULT_BINDINGS};
+    this.save();
+  }
+
+  private load() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (parsed?.version !== 1 || typeof parsed.bindings !== 'object') return;
+      for (const key of Object.keys(DEFAULT_BINDINGS) as GamepadAction[]) {
+        if (typeof parsed.bindings[key] === 'number') {
+          this.bindings[key] = parsed.bindings[key];
+        }
+      }
+    } catch {
+      // localStorage unavailable or corrupted — keep defaults.
+    }
+  }
+
+  private save() {
+    try {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({version: 1, bindings: this.bindings})
+      );
+    } catch {
+      // localStorage unavailable — silently continue.
+    }
+  }
+}

--- a/src/input/GamepadController.test.ts
+++ b/src/input/GamepadController.test.ts
@@ -1,0 +1,43 @@
+import {describe, it, expect} from 'vitest';
+
+import {GamepadController} from './GamepadController';
+
+describe('GamepadController', () => {
+  describe('applyDeadzone', () => {
+    it('returns 0 for values within deadzone', () => {
+      expect(GamepadController.applyDeadzone(0)).toBe(0);
+      expect(GamepadController.applyDeadzone(0.1)).toBe(0);
+      expect(GamepadController.applyDeadzone(-0.1)).toBe(0);
+      expect(GamepadController.applyDeadzone(0.14)).toBe(0);
+    });
+
+    it('returns remapped value outside deadzone', () => {
+      const result = GamepadController.applyDeadzone(1.0);
+      expect(result).toBeCloseTo(1.0, 2);
+    });
+
+    it('returns negative remapped value for negative input', () => {
+      const result = GamepadController.applyDeadzone(-1.0);
+      expect(result).toBeCloseTo(-1.0, 2);
+    });
+
+    it('remaps linearly from deadzone edge', () => {
+      // At exactly the deadzone boundary, should be ~0
+      const atEdge = GamepadController.applyDeadzone(0.15);
+      expect(atEdge).toBeCloseTo(0, 1);
+
+      // Halfway between deadzone and 1.0
+      const mid = GamepadController.applyDeadzone(0.575);
+      expect(mid).toBeCloseTo(0.5, 1);
+    });
+
+    it('returns 0 for NaN', () => {
+      expect(GamepadController.applyDeadzone(NaN)).toBe(0);
+    });
+
+    it('returns 0 for Infinity', () => {
+      expect(GamepadController.applyDeadzone(Infinity)).toBe(0);
+      expect(GamepadController.applyDeadzone(-Infinity)).toBe(0);
+    });
+  });
+});

--- a/src/input/GamepadController.ts
+++ b/src/input/GamepadController.ts
@@ -1,0 +1,214 @@
+import * as THREE from 'three';
+
+import {Script} from '../core/Script.js';
+
+import {Controller} from './Controller.js';
+import {GamepadBindings} from './GamepadBindings.js';
+
+/** Defines the event map for the GamepadController's custom events. */
+interface GamepadControllerEventMap extends THREE.Object3DEventMap {
+  connected: {target: GamepadController};
+  disconnected: {target: GamepadController};
+  selectstart: {target: GamepadController};
+  selectend: {target: GamepadController};
+}
+
+const DEADZONE = 0.15;
+
+/**
+ * Simulates an XR controller using a connected gamepad (Xbox/PS).
+ * The controller ray always points forward from the camera center,
+ * similar to GazeController but with button-driven selection.
+ */
+export class GamepadController
+  extends Script<GamepadControllerEventMap>
+  implements Controller
+{
+  static dependencies = {
+    camera: THREE.Camera,
+  };
+  type = 'GamepadController';
+  name = 'Gamepad Controller';
+
+  userData = {id: 4, connected: false, selected: false};
+
+  camera?: THREE.Camera;
+  bindings = new GamepadBindings();
+
+  /** The browser Gamepad object, refreshed each frame. */
+  activeGamepad?: Gamepad | null;
+  gamepad?: Gamepad;
+
+  /** True if the toast has been shown this session. */
+  hasShownToast = false;
+
+  /** Callback set by SimulatorInterface for opening settings. */
+  onOpenSettings?: () => void;
+
+  /** When true, normal gamepad UI/select actions are suppressed (modal menu). */
+  menuActive = false;
+
+  private _prevButtons: boolean[] = [];
+  private _risingEdges: boolean[] = [];
+  private _captureCallback: ((buttonIndex: number) => void) | null = null;
+
+  constructor() {
+    super();
+  }
+
+  init({camera}: {camera: THREE.Camera}) {
+    this.camera = camera;
+  }
+
+  /**
+   * Enters capture mode — the next button press will invoke the callback
+   * instead of triggering normal actions, then exit capture mode.
+   */
+  captureNextButtonPress(callback: (buttonIndex: number) => void) {
+    this._captureCallback = callback;
+  }
+
+  cancelCapture() {
+    this._captureCallback = null;
+  }
+
+  get captureActive(): boolean {
+    return this._captureCallback !== null;
+  }
+
+  update() {
+    super.update();
+
+    const gp = this._pollGamepad();
+
+    if (gp && !this.userData.connected) {
+      this.activeGamepad = gp;
+      this.gamepad = gp;
+      this.dispatchEvent({type: 'connected', target: this});
+    } else if (!gp && this.userData.connected) {
+      this._onDisconnect();
+      return;
+    }
+
+    if (!gp || !this.userData.connected) return;
+    this.activeGamepad = gp;
+
+    // Compute rising edges for this frame (before any consumption).
+    for (let i = 0; i < gp.buttons.length; i++) {
+      const down = gp.buttons[i]?.pressed ?? false;
+      const wasDown = this._prevButtons[i] ?? false;
+      this._risingEdges[i] = down && !wasDown;
+    }
+
+    // Sync pose with camera (center-screen ray, like GazeController).
+    this.position.copy(this.camera!.position);
+    this.quaternion.copy(this.camera!.quaternion);
+    this.updateMatrixWorld();
+
+    // Check for capture mode on any rising edge.
+    if (this._captureCallback) {
+      for (let i = 0; i < gp.buttons.length; i++) {
+        if (this._risingEdges[i]) {
+          const cb = this._captureCallback;
+          this._captureCallback = null;
+          cb(i);
+          this._updatePrevButtons(gp);
+          return; // Consume all input this frame.
+        }
+      }
+    }
+
+    // Normal select handling via bindings (suppressed when a modal menu is
+    // active so A-button activates UI rather than firing scene selects).
+    if (!this.menuActive) {
+      const selectBtn = this.bindings.getBinding('select');
+      const selectDown = gp.buttons[selectBtn]?.pressed ?? false;
+      const selectWas = this._prevButtons[selectBtn] ?? false;
+      if (selectDown && !selectWas) this.callSelectStart();
+      if (!selectDown && selectWas) this.callSelectEnd();
+    }
+
+    this._updatePrevButtons(gp);
+  }
+
+  callSelectStart() {
+    this.dispatchEvent({type: 'selectstart', target: this});
+  }
+
+  callSelectEnd() {
+    this.dispatchEvent({type: 'selectend', target: this});
+  }
+
+  connect() {
+    this.dispatchEvent({type: 'connected', target: this});
+  }
+
+  disconnect() {
+    this.dispatchEvent({type: 'disconnected', target: this});
+  }
+
+  /**
+   * Returns the axes of the active gamepad with deadzone applied.
+   * [leftX, leftY, rightX, rightY]
+   */
+  getAxes(): [number, number, number, number] {
+    const gp = this.activeGamepad;
+    if (!gp) return [0, 0, 0, 0];
+    return [
+      GamepadController.applyDeadzone(gp.axes[0] ?? 0),
+      GamepadController.applyDeadzone(gp.axes[1] ?? 0),
+      GamepadController.applyDeadzone(gp.axes[2] ?? 0),
+      GamepadController.applyDeadzone(gp.axes[3] ?? 0),
+    ];
+  }
+
+  static applyDeadzone(value: number): number {
+    if (!Number.isFinite(value)) return 0;
+    if (Math.abs(value) < DEADZONE) return 0;
+    const sign = Math.sign(value);
+    return sign * ((Math.abs(value) - DEADZONE) / (1 - DEADZONE));
+  }
+
+  /**
+   * Returns the analog values of the left and right triggers (LT, RT) on a
+   * standard-mapped gamepad, in [0, 1]. Returns [0, 0] when no gamepad.
+   */
+  getTriggers(): [number, number] {
+    const gp = this.activeGamepad;
+    if (!gp) return [0, 0];
+    return [gp.buttons[6]?.value ?? 0, gp.buttons[7]?.value ?? 0];
+  }
+
+  /**
+   * Returns true if the given button index had a rising edge this frame.
+   * Safe to call from any update order — uses pre-computed edges.
+   */
+  isButtonJustPressed(buttonIndex: number): boolean {
+    return this._risingEdges[buttonIndex] ?? false;
+  }
+
+  private _updatePrevButtons(gp: Gamepad) {
+    for (let i = 0; i < gp.buttons.length; i++) {
+      this._prevButtons[i] = gp.buttons[i]?.pressed ?? false;
+    }
+  }
+
+  private _pollGamepad(): Gamepad | null {
+    const gamepads = navigator.getGamepads?.();
+    if (!gamepads) return null;
+    for (const pad of gamepads) {
+      if (pad && pad.connected && pad.mapping === 'standard') return pad;
+    }
+    return null;
+  }
+
+  private _onDisconnect() {
+    if (this.userData.selected) {
+      this.callSelectEnd();
+    }
+    this._prevButtons = [];
+    this._captureCallback = null;
+    this.activeGamepad = null;
+    this.dispatchEvent({type: 'disconnected', target: this});
+  }
+}

--- a/src/input/GamepadController.ts
+++ b/src/input/GamepadController.ts
@@ -170,6 +170,15 @@ export class GamepadController
   }
 
   /**
+   * Returns the analog value (0..1) of the given button index, or 0 if
+   * unbound or no gamepad. Useful for triggers (which expose .value).
+   */
+  getButtonValue(index: number): number {
+    if (index < 0) return 0;
+    return this.activeGamepad?.buttons[index]?.value ?? 0;
+  }
+
+  /**
    * Returns the analog values of the left and right triggers (LT, RT) on a
    * standard-mapped gamepad, in [0, 1]. Returns [0, 0] when no gamepad.
    */

--- a/src/input/Input.ts
+++ b/src/input/Input.ts
@@ -14,6 +14,7 @@ import type {
   ControllerEvent,
   ControllerEventMap,
 } from './Controller';
+import {GamepadController} from './GamepadController';
 import {GazeController} from './GazeController';
 import {MouseController} from './MouseController';
 import {XRSystems} from '../core/components/XRSystems';
@@ -50,6 +51,7 @@ export class Input {
   pivotsEnabled = false;
   gazeController = new GazeController();
   mouseController = new MouseController();
+  gamepadController = new GamepadController();
   controllersEnabled = true;
   listeners = new Map();
   intersectionsForController = new Map<Controller, THREE.Intersection[]>();
@@ -93,6 +95,8 @@ export class Input {
     controllers.push(this.gazeController);
     controllers.push(this.mouseController);
     this.activeControllers.add(this.mouseController);
+    controllers.push(this.gamepadController);
+    this.activeControllers.add(this.gamepadController);
 
     for (const controller of controllers) {
       this.intersectionsForController.set(controller, []);

--- a/src/simulator/Simulator.ts
+++ b/src/simulator/Simulator.ts
@@ -113,7 +113,7 @@ export class Simulator extends Script {
     const deviceCamera = registry.get(XRDeviceCamera);
     this.options = simulatorOptions;
     camera.position.copy(this.options.initialCameraPosition);
-    this.userInterface.init(simulatorOptions, this.controls, this.hands);
+    this.userInterface.init(simulatorOptions, this.controls, this.hands, input);
     renderer.autoClearColor = false;
     await this.simulatorScene.init(simulatorOptions);
     await this.simulatorWorld.init(options, world);

--- a/src/simulator/SimulatorControls.ts
+++ b/src/simulator/SimulatorControls.ts
@@ -66,27 +66,36 @@ export class SimulatorControls {
     const toggleUserInterface = () => {
       this.userInterface.toggleInterfaceVisible();
     };
+    const cycleSimulatorMode = () => {
+      if (!this.simulatorOptions) return;
+      this.setSimulatorMode(
+        this.simulatorOptions.modeToggle.toggleOrder[this.simulatorMode]
+      );
+    };
     this.simulatorModes = {
       [SimulatorMode.USER]: new SimulatorUserMode(
         this.simulatorControllerState,
         this.downKeys,
         hands,
         setStereoRenderMode,
-        toggleUserInterface
+        toggleUserInterface,
+        cycleSimulatorMode
       ),
       [SimulatorMode.POSE]: new SimulatorPoseMode(
         this.simulatorControllerState,
         this.downKeys,
         hands,
         setStereoRenderMode,
-        toggleUserInterface
+        toggleUserInterface,
+        cycleSimulatorMode
       ),
       [SimulatorMode.CONTROLLER]: new SimulatorControllerMode(
         this.simulatorControllerState,
         this.downKeys,
         hands,
         setStereoRenderMode,
-        toggleUserInterface
+        toggleUserInterface,
+        cycleSimulatorMode
       ),
     };
 

--- a/src/simulator/SimulatorHands.ts
+++ b/src/simulator/SimulatorHands.ts
@@ -354,5 +354,13 @@ export class SimulatorHands {
     this.simulatorControllerState.currentControllerIndex =
       (this.simulatorControllerState.currentControllerIndex + 1) % 2;
     this.updateHandPosePanel();
+    this.onHandednessChanged?.(
+      this.simulatorControllerState.currentControllerIndex === 0
+        ? 'left'
+        : 'right'
+    );
   }
+
+  /** Optional callback fired after the active hand changes. */
+  onHandednessChanged?: (handedness: 'left' | 'right') => void;
 }

--- a/src/simulator/SimulatorInterface.ts
+++ b/src/simulator/SimulatorInterface.ts
@@ -181,6 +181,7 @@ export class SimulatorInterface {
       btnName(b.getBinding('cycleHandPoseRight'))]: 'Cycle Hand Pose',
       [btnName(b.getBinding('cycleSimulatorMode'))]: 'Cycle Simulator Mode',
       [btnName(b.getBinding('toggleUI'))]: 'Toggle UI',
+      [btnName(b.getBinding('toggleHand'))]: 'Swap Active Hand',
       [btnName(b.getBinding('openSettings'))]: 'Gamepad Settings',
     });
   }

--- a/src/simulator/SimulatorInterface.ts
+++ b/src/simulator/SimulatorInterface.ts
@@ -172,7 +172,9 @@ export class SimulatorInterface {
     this._gamepadToast.show({
       'Left Stick': 'Move (or Hand in Controller mode)',
       'Right Stick': 'Look',
-      'LT / RT': 'Down / Up',
+      [btnName(b.getBinding('moveDown')) +
+      ' / ' +
+      btnName(b.getBinding('moveUp'))]: 'Down / Up',
       [btnName(b.getBinding('select'))]: 'Select / Interact',
       [btnName(b.getBinding('cycleHandPoseLeft')) +
       ' / ' +

--- a/src/simulator/SimulatorInterface.ts
+++ b/src/simulator/SimulatorInterface.ts
@@ -13,6 +13,7 @@ import {
 /** Minimal interface for the gamepad toast element. */
 interface GamepadToastElement extends HTMLElement {
   show(controls: Record<string, string>, duration?: number): void;
+  flash(message: string, duration?: number): void;
   dismiss(): void;
 }
 
@@ -70,6 +71,11 @@ export class SimulatorInterface {
     this.createModeIndicator(simulatorOptions, simulatorControls);
     this.showGeminiLivePanel(simulatorOptions);
     this.createHandPosePanel(simulatorOptions, simulatorHands);
+    simulatorHands.onHandednessChanged = (handedness) => {
+      this._ensureGamepadToast().flash(
+        `Active Hand: ${handedness === 'left' ? 'Left' : 'Right'}`
+      );
+    };
     this.showInstructions(simulatorOptions);
     if (input) this._initGamepadUI(input);
   }
@@ -161,15 +167,20 @@ export class SimulatorInterface {
     gp.onOpenSettings = () => this.toggleGamepadSettings(gp);
   }
 
-  showGamepadToast(gp: GamepadController) {
+  private _ensureGamepadToast(): GamepadToastElement {
     if (!this._gamepadToast) {
       this._gamepadToast = document.createElement(
         'xrblocks-gamepad-toast'
       ) as GamepadToastElement;
       document.body.appendChild(this._gamepadToast);
     }
+    return this._gamepadToast;
+  }
+
+  showGamepadToast(gp: GamepadController) {
+    const toast = this._ensureGamepadToast();
     const b = gp.bindings;
-    this._gamepadToast.show({
+    toast.show({
       'Left Stick': 'Move (or Hand in Controller mode)',
       'Right Stick': 'Look',
       [btnName(b.getBinding('moveDown')) +

--- a/src/simulator/SimulatorInterface.ts
+++ b/src/simulator/SimulatorInterface.ts
@@ -1,3 +1,5 @@
+import {GamepadController} from '../input/GamepadController.js';
+import {Input} from '../input/Input.js';
 import {
   SimulatorControls,
   SimulatorModeIndicatorElement,
@@ -8,6 +10,44 @@ import {
   SimulatorOptions,
 } from './SimulatorOptions.js';
 
+/** Minimal interface for the gamepad toast element. */
+interface GamepadToastElement extends HTMLElement {
+  show(controls: Record<string, string>, duration?: number): void;
+  dismiss(): void;
+}
+
+/** Minimal interface for the gamepad settings element. */
+interface GamepadSettingsElement extends HTMLElement {
+  bindings: unknown;
+  gamepadController: unknown;
+  show(): void;
+  hide(): void;
+}
+
+/** Standard gamepad button names for display. */
+const BUTTON_NAMES: Record<number, string> = {
+  0: 'A',
+  1: 'B',
+  2: 'X',
+  3: 'Y',
+  4: 'LB',
+  5: 'RB',
+  6: 'LT',
+  7: 'RT',
+  8: 'Back',
+  9: 'Start',
+  10: 'L3',
+  11: 'R3',
+  12: 'D-Up',
+  13: 'D-Down',
+  14: 'D-Left',
+  15: 'D-Right',
+};
+
+function btnName(index: number): string {
+  return BUTTON_NAMES[index] ?? `Btn ${index}`;
+}
+
 type SimulatorInstructionsHTMLElement = HTMLElement & {
   customInstructions: SimulatorCustomInstruction[];
 };
@@ -15,6 +55,8 @@ type SimulatorInstructionsHTMLElement = HTMLElement & {
 export class SimulatorInterface {
   private elements: HTMLElement[] = [];
   private interfaceVisible = true;
+  private _gamepadToast?: GamepadToastElement;
+  private _gamepadSettings?: GamepadSettingsElement;
 
   /**
    * Initialize the simulator interface.
@@ -22,12 +64,14 @@ export class SimulatorInterface {
   init(
     simulatorOptions: SimulatorOptions,
     simulatorControls: SimulatorControls,
-    simulatorHands: SimulatorHands
+    simulatorHands: SimulatorHands,
+    input?: Input
   ) {
     this.createModeIndicator(simulatorOptions, simulatorControls);
     this.showGeminiLivePanel(simulatorOptions);
     this.createHandPosePanel(simulatorOptions, simulatorHands);
     this.showInstructions(simulatorOptions);
+    if (input) this._initGamepadUI(input);
   }
 
   createModeIndicator(
@@ -103,6 +147,56 @@ export class SimulatorInterface {
       this.hideUiElements();
     } else {
       this.showUiElements();
+    }
+  }
+
+  private _initGamepadUI(input: Input) {
+    const gp = input.gamepadController;
+    gp.addEventListener('connected', () => {
+      if (!gp.hasShownToast) {
+        gp.hasShownToast = true;
+        this.showGamepadToast(gp);
+      }
+    });
+    gp.onOpenSettings = () => this.toggleGamepadSettings(gp);
+  }
+
+  showGamepadToast(gp: GamepadController) {
+    if (!this._gamepadToast) {
+      this._gamepadToast = document.createElement(
+        'xrblocks-gamepad-toast'
+      ) as GamepadToastElement;
+      document.body.appendChild(this._gamepadToast);
+    }
+    const b = gp.bindings;
+    this._gamepadToast.show({
+      'Left Stick': 'Move (or Hand in Controller mode)',
+      'Right Stick': 'Look',
+      'LT / RT': 'Down / Up',
+      [btnName(b.getBinding('select'))]: 'Select / Interact',
+      [btnName(b.getBinding('cycleHandPoseLeft')) +
+      ' / ' +
+      btnName(b.getBinding('cycleHandPoseRight'))]: 'Cycle Hand Pose',
+      [btnName(b.getBinding('cycleSimulatorMode'))]: 'Cycle Simulator Mode',
+      [btnName(b.getBinding('toggleUI'))]: 'Toggle UI',
+      [btnName(b.getBinding('openSettings'))]: 'Gamepad Settings',
+    });
+  }
+
+  toggleGamepadSettings(gp: GamepadController) {
+    if (!this._gamepadSettings) {
+      this._gamepadSettings = document.createElement(
+        'xrblocks-gamepad-settings'
+      ) as GamepadSettingsElement;
+      this._gamepadSettings.bindings = gp.bindings;
+      this._gamepadSettings.gamepadController = gp;
+      this._gamepadSettings.hidden = true;
+      document.body.appendChild(this._gamepadSettings);
+    }
+    if (this._gamepadSettings.hidden) {
+      this._gamepadSettings.show();
+    } else {
+      this._gamepadSettings.hide();
     }
   }
 }

--- a/src/simulator/controlModes/SimulatorControlMode.ts
+++ b/src/simulator/controlModes/SimulatorControlMode.ts
@@ -123,9 +123,10 @@ export class SimulatorControlMode {
         cameraRotation.setFromEuler(euler);
       }
 
-      // Triggers → vertical movement (RT up, LT down) in world space.
-      const [lt, rt] = gp.getTriggers();
-      const verticalDelta = (rt - lt) * deltaTime;
+      // Configurable vertical movement bindings (defaults LT/RT, analog).
+      const downVal = gp.getButtonValue(gp.bindings.getBinding('moveDown'));
+      const upVal = gp.getButtonValue(gp.bindings.getBinding('moveUp'));
+      const verticalDelta = (upVal - downVal) * deltaTime;
       if (verticalDelta !== 0) {
         cameraPosition.y += verticalDelta;
       }

--- a/src/simulator/controlModes/SimulatorControlMode.ts
+++ b/src/simulator/controlModes/SimulatorControlMode.ts
@@ -1,14 +1,17 @@
 import * as THREE from 'three';
 
+import {GamepadController} from '../../input/GamepadController.js';
 import {Input} from '../../input/Input.js';
 import {Keycodes} from '../../utils/Keycodes';
 import {SimulatorRenderMode} from '../SimulatorConstants';
 import {SimulatorControllerState} from '../SimulatorControllerState';
 import {SimulatorHands} from '../SimulatorHands.js';
+import {SimulatorHandPose} from '../handPoses/HandPoses';
 
 const {A_CODE, D_CODE, E_CODE, Q_CODE, S_CODE, W_CODE} = Keycodes;
 const vector3 = new THREE.Vector3();
 const euler = new THREE.Euler();
+const HAND_POSES = Object.values(SimulatorHandPose);
 
 export class SimulatorControlMode {
   camera!: THREE.Camera;
@@ -23,7 +26,8 @@ export class SimulatorControlMode {
     protected downKeys: Set<Keycodes>,
     protected hands: SimulatorHands,
     protected setStereoRenderMode: (_: SimulatorRenderMode) => void,
-    protected toggleUserInterface: () => void
+    protected toggleUserInterface: () => void,
+    protected cycleSimulatorMode: () => void = () => {}
   ) {}
 
   /**
@@ -41,6 +45,7 @@ export class SimulatorControlMode {
     this.camera = camera;
     this.input = input;
     this.timer = timer;
+    input.gamepadController.init({camera});
   }
 
   onPointerDown(_: MouseEvent) {}
@@ -59,11 +64,27 @@ export class SimulatorControlMode {
   onModeDeactivated() {}
 
   update() {
+    this.updateGamepad();
     this.updateCameraPosition();
     this.updateControllerPositions();
   }
 
+  /**
+   * Poll the gamepad and handle button actions. Called from all modes.
+   */
+  updateGamepad() {
+    const gp = this.input.gamepadController;
+    gp.update();
+    if (gp.userData.connected) {
+      this.updateGamepadUI(gp);
+    }
+  }
+
   updateCameraPosition() {
+    const gp = this.input.gamepadController;
+    // While a modal menu owns gamepad input, don't move the camera.
+    if (gp.menuActive) return;
+
     const deltaTime = this.timer.getDelta();
     const cameraRotation = this.camera.quaternion;
     const cameraPosition = this.camera.position;
@@ -77,6 +98,79 @@ export class SimulatorControlMode {
       .multiplyScalar(deltaTime)
       .applyQuaternion(cameraRotation);
     cameraPosition.add(vector3);
+
+    // Gamepad stick input (if connected).
+    if (gp.userData.connected) {
+      const [lx, ly, rx, ry] = gp.getAxes();
+
+      // Left stick → move camera.
+      if (lx !== 0 || ly !== 0) {
+        vector3
+          .set(lx, 0, ly)
+          .multiplyScalar(deltaTime)
+          .applyQuaternion(cameraRotation);
+        cameraPosition.add(vector3);
+      }
+
+      // Right stick → look (yaw + pitch).
+      if (rx !== 0 || ry !== 0) {
+        const LOOK_SPEED = 2.0;
+        euler.setFromQuaternion(cameraRotation, 'YXZ');
+        euler.y -= rx * LOOK_SPEED * deltaTime;
+        euler.x -= ry * LOOK_SPEED * deltaTime;
+        const PI_2 = Math.PI / 2;
+        euler.x = Math.max(-PI_2 + 0.01, Math.min(PI_2 - 0.01, euler.x));
+        cameraRotation.setFromEuler(euler);
+      }
+
+      // Triggers → vertical movement (RT up, LT down) in world space.
+      const [lt, rt] = gp.getTriggers();
+      const verticalDelta = (rt - lt) * deltaTime;
+      if (verticalDelta !== 0) {
+        cameraPosition.y += verticalDelta;
+      }
+    }
+  }
+
+  /**
+   * Handle gamepad buttons for simulator UI using configurable bindings.
+   */
+  updateGamepadUI(gp: GamepadController) {
+    // Suppress normal actions during rebind or while a modal menu owns input.
+    if (gp.captureActive || gp.menuActive) return;
+
+    const b = gp.bindings;
+
+    if (gp.isButtonJustPressed(b.getBinding('cycleHandPoseLeft'))) {
+      this.cycleHandPose(-1);
+    }
+    if (gp.isButtonJustPressed(b.getBinding('cycleHandPoseRight'))) {
+      this.cycleHandPose(1);
+    }
+    if (gp.isButtonJustPressed(b.getBinding('cycleSimulatorMode'))) {
+      this.cycleSimulatorMode();
+    }
+    if (gp.isButtonJustPressed(b.getBinding('toggleUI'))) {
+      this.toggleUserInterface();
+    }
+    if (gp.isButtonJustPressed(b.getBinding('openSettings'))) {
+      gp.onOpenSettings?.();
+    }
+  }
+
+  cycleHandPose(direction: number) {
+    const idx = this.simulatorControllerState.currentControllerIndex;
+    const currentPose =
+      idx === 0 ? this.hands.leftHandPose : this.hands.rightHandPose;
+    const currentIdx = HAND_POSES.indexOf(currentPose ?? HAND_POSES[0]);
+    const nextIdx =
+      (currentIdx + direction + HAND_POSES.length) % HAND_POSES.length;
+    const nextPose = HAND_POSES[nextIdx];
+    if (idx === 0) {
+      this.hands.setLeftHandLerpPose(nextPose);
+    } else {
+      this.hands.setRightHandLerpPose(nextPose);
+    }
   }
 
   updateControllerPositions() {

--- a/src/simulator/controlModes/SimulatorControlMode.ts
+++ b/src/simulator/controlModes/SimulatorControlMode.ts
@@ -154,6 +154,9 @@ export class SimulatorControlMode {
     if (gp.isButtonJustPressed(b.getBinding('toggleUI'))) {
       this.toggleUserInterface();
     }
+    if (gp.isButtonJustPressed(b.getBinding('toggleHand'))) {
+      this.hands.toggleHandedness();
+    }
     if (gp.isButtonJustPressed(b.getBinding('openSettings'))) {
       gp.onOpenSettings?.();
     }

--- a/src/simulator/controlModes/SimulatorControllerMode.ts
+++ b/src/simulator/controlModes/SimulatorControllerMode.ts
@@ -20,6 +20,7 @@ export class SimulatorControllerMode extends SimulatorControlMode {
   }
 
   override update() {
+    this.updateGamepad();
     this.updateControllerPositions();
   }
 
@@ -30,6 +31,10 @@ export class SimulatorControllerMode extends SimulatorControlMode {
   updateControllerPositions() {
     const deltaTime = this.timer.getDelta();
     const downKeys = this.downKeys;
+    const localPos =
+      this.simulatorControllerState.localControllerPositions[
+        this.simulatorControllerState.currentControllerIndex
+      ];
     vector3
       .set(
         Number(downKeys.has(D_CODE)) - Number(downKeys.has(A_CODE)),
@@ -37,9 +42,17 @@ export class SimulatorControllerMode extends SimulatorControlMode {
         Number(downKeys.has(S_CODE)) - Number(downKeys.has(W_CODE))
       )
       .multiplyScalar(deltaTime);
-    this.simulatorControllerState.localControllerPositions[
-      this.simulatorControllerState.currentControllerIndex
-    ].add(vector3);
+    localPos.add(vector3);
+
+    // Gamepad: left stick moves hand on XZ; triggers move hand on Y.
+    const gp = this.input.gamepadController;
+    if (gp.userData.connected && !gp.menuActive) {
+      const [lx, ly] = gp.getAxes();
+      const [lt, rt] = gp.getTriggers();
+      vector3.set(lx, rt - lt, ly).multiplyScalar(deltaTime);
+      localPos.add(vector3);
+    }
+
     super.updateControllerPositions();
   }
 

--- a/src/simulator/controlModes/SimulatorControllerMode.ts
+++ b/src/simulator/controlModes/SimulatorControllerMode.ts
@@ -44,12 +44,13 @@ export class SimulatorControllerMode extends SimulatorControlMode {
       .multiplyScalar(deltaTime);
     localPos.add(vector3);
 
-    // Gamepad: left stick moves hand on XZ; triggers move hand on Y.
+    // Gamepad: left stick moves hand on XZ; configurable buttons on Y.
     const gp = this.input.gamepadController;
     if (gp.userData.connected && !gp.menuActive) {
       const [lx, ly] = gp.getAxes();
-      const [lt, rt] = gp.getTriggers();
-      vector3.set(lx, rt - lt, ly).multiplyScalar(deltaTime);
+      const downVal = gp.getButtonValue(gp.bindings.getBinding('moveDown'));
+      const upVal = gp.getButtonValue(gp.bindings.getBinding('moveUp'));
+      vector3.set(lx, upVal - downVal, ly).multiplyScalar(deltaTime);
       localPos.add(vector3);
     }
 

--- a/src/simulator/controlModes/SimulatorUserMode.ts
+++ b/src/simulator/controlModes/SimulatorUserMode.ts
@@ -10,6 +10,15 @@ export class SimulatorUserMode extends SimulatorControlMode {
     this.input.mouseController.disconnect();
   }
 
+  /**
+   * In User mode, hands are hidden — switch to a hand-visible mode
+   * before cycling so the change is visible.
+   */
+  override cycleHandPose(direction: number) {
+    this.cycleSimulatorMode();
+    super.cycleHandPose(direction);
+  }
+
   onPointerDown(event: MouseEvent) {
     if (event.buttons & 1) {
       this.input.mouseController.callSelectStart();

--- a/src/xrblocks.ts
+++ b/src/xrblocks.ts
@@ -30,6 +30,8 @@ export * from './depth/DepthTextures';
 export * from './depth/occlusion/OcclusionPass';
 export * from './depth/occlusion/OcclusionUtils';
 export * from './input/components/HandJointNames';
+export * from './input/GamepadController';
+export * from './input/GamepadBindings';
 export * from './input/GazeController';
 export * from './input/Hands';
 export * from './input/HandsOptions';


### PR DESCRIPTION
Adds gamepad support to the simulator so people on PC who don't want to switch to keyboard/mouse can use an Xbox/PS controller instead. WebXR already supports controllers, but the desktop simulator preview didn't.

Sticks move and look, triggers go up/down, RB toggles the UI, Start opens a settings panel for rebinding buttons, D-pad cycles hand poses. In Controller mode the stick also moves the active hand. Bindings are stored in localStorage so they persist.

When the settings panel is open it grabs gamepad input so the camera doesn't fly around while you're picking menu items.

Tested manually with an Xbox controller. New unit tests cover the bindings store and rising-edge button timing.

Demo: https://youtu.be/RgJJfYdkvJM
