### PR TITLE
Walk-in portal immersives

### DIFF
--- a/demos/portals/CosmicImmersive.js
+++ b/demos/portals/CosmicImmersive.js
@@ -1,0 +1,381 @@
+import * as THREE from 'three';
+
+import {CosmicScene} from './scenes/CosmicScene.js';
+
+const SPHERE_RADIUS = 50;
+const IMMERSIVE_SCALE = 4.0; // Push planets farther out so user doesn't reach them in 2 steps.
+
+/**
+ * Full-surround cosmic environment for "walk-in" mode.
+ * Renders the cosmic raymarcher on an inverted sphere around the user,
+ * with direction-based UVs so the scene wraps naturally in 360°.
+ */
+export class CosmicImmersive extends THREE.Object3D {
+  constructor() {
+    super();
+    this._time = 0;
+    this._buildSphere();
+  }
+
+  show(portalWorldMatrix) {
+    this._entryMatrix = portalWorldMatrix.clone();
+    this._entryMatrixInv = portalWorldMatrix.clone().invert();
+    this.visible = true;
+  }
+
+  hide() {
+    this.visible = false;
+  }
+
+  update(dt, camera) {
+    if (!this.visible) return;
+    this._time += dt * 4.0;
+
+    const mat = this._sphere.material;
+    mat.uniforms.uTime.value = this._time;
+
+    if (camera) {
+      // Camera world position → portal-local space = cosmic origin.
+      const camWorld = camera.getWorldPosition(new THREE.Vector3());
+      const camLocal = camWorld.clone().applyMatrix4(this._entryMatrixInv);
+      mat.uniforms.uCamLocal.value.copy(camLocal);
+
+      // Camera world quaternion → portal-local rotation for view directions.
+      const portalQuat = new THREE.Quaternion().setFromRotationMatrix(this._entryMatrix);
+      const portalQuatInv = portalQuat.clone().invert();
+      const camQuat = camera.getWorldQuaternion(new THREE.Quaternion());
+      const localQuat = portalQuatInv.multiply(camQuat);
+      // Build a rotation Matrix4, then extract upper-left 3×3 as Matrix3.
+      const rotMat4 = new THREE.Matrix4().makeRotationFromQuaternion(localQuat);
+      mat.uniforms.uViewRotation.value.setFromMatrix4(rotMat4);
+    }
+
+    // Keep sphere centered on camera so it always surrounds the user.
+    if (camera) {
+      camera.getWorldPosition(this.position);
+    }
+  }
+
+  _buildSphere() {
+    const s = CosmicScene;
+    const geom = new THREE.SphereGeometry(SPHERE_RADIUS, 64, 32);
+
+    const mat = new THREE.ShaderMaterial({
+      uniforms: {
+        uTime: {value: 0},
+        uCamLocal: {value: new THREE.Vector3(0, 0, 1.6)},
+        uViewRotation: {value: new THREE.Matrix3()},
+      },
+      vertexShader: /* glsl */ `
+        varying vec3 vWorldDir;
+        void main() {
+          // Direction from center to vertex (normalized sphere direction).
+          vWorldDir = normalize(position);
+          gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        }
+      `,
+      fragmentShader: /* glsl */ `
+        precision highp float;
+        uniform float uTime;
+        uniform vec3 uCamLocal;
+        uniform mat3 uViewRotation;
+        varying vec3 vWorldDir;
+
+        // ---------- shared helpers (3D to avoid spherical UV seam) ----------
+        float hash(vec2 p) {
+          p = fract(p * vec2(123.34, 456.21));
+          p += dot(p, p + 45.32);
+          return fract(p.x * p.y);
+        }
+        float hash3(vec3 p) {
+          p = fract(p * vec3(123.34, 456.21, 789.53));
+          p += dot(p, p.yzx + 45.32);
+          return fract(p.x * p.y * p.z);
+        }
+        float noise3(vec3 p) {
+          vec3 i = floor(p);
+          vec3 f = fract(p);
+          vec3 u = f * f * (3.0 - 2.0 * f);
+          return mix(
+            mix(mix(hash3(i), hash3(i + vec3(1,0,0)), u.x),
+                mix(hash3(i + vec3(0,1,0)), hash3(i + vec3(1,1,0)), u.x), u.y),
+            mix(mix(hash3(i + vec3(0,0,1)), hash3(i + vec3(1,0,1)), u.x),
+                mix(hash3(i + vec3(0,1,1)), hash3(i + vec3(1,1,1)), u.x), u.y),
+            u.z);
+        }
+        float fbm3(vec3 p) {
+          float v = 0.0; float a = 0.5;
+          for (int i = 0; i < 4; i++) {
+            v += a * noise3(p); p *= 2.07; a *= 0.5;
+          }
+          return v;
+        }
+        float ridgedFbm3(vec3 p) {
+          float v = 0.0; float a = 0.5;
+          for (int i = 0; i < 4; i++) {
+            float n = 1.0 - abs(noise3(p) * 2.0 - 1.0);
+            v += a * n * n; p *= 2.13; a *= 0.5;
+          }
+          return v;
+        }
+        float warpedFbm3(vec3 p) {
+          vec3 q = vec3(fbm3(p), fbm3(p + vec3(5.2, 1.3, 3.7)),
+                        fbm3(p + vec3(9.1, 4.6, 2.8)));
+          return fbm3(p + 4.0 * q);
+        }
+
+        // 2D hash/noise kept for starsLayer and raymarched object surfaces
+        float noise(vec2 p) {
+          vec2 i = floor(p);
+          vec2 f = fract(p);
+          float a = hash(i);
+          float b = hash(i + vec2(1.0, 0.0));
+          float c = hash(i + vec2(0.0, 1.0));
+          float d = hash(i + vec2(1.0, 1.0));
+          vec2 u = f * f * (3.0 - 2.0 * f);
+          return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x)
+                                + (d - b) * u.x * u.y;
+        }
+        float fbm(vec2 p) {
+          float v = 0.0; float a = 0.5;
+          for (int i = 0; i < 4; i++) {
+            v += a * noise(p); p *= 2.07; a *= 0.5;
+          }
+          return v;
+        }
+
+        float starsLayer(vec3 rd, float density, float threshold) {
+          // Use octahedral mapping for seamless 2D grid on a sphere.
+          vec3 a = abs(rd);
+          float sum = a.x + a.y + a.z;
+          vec2 oct = rd.xz / sum;
+          if (rd.y < 0.0) {
+            oct = (1.0 - abs(oct.yx)) * vec2(oct.x >= 0.0 ? 1.0 : -1.0,
+                                              oct.y >= 0.0 ? 1.0 : -1.0);
+          }
+          vec2 uv = oct * 0.5 + 0.5;
+          vec2 g = floor(uv * density);
+          vec2 f = fract(uv * density);
+          float h = hash(g);
+          if (h < threshold) return 0.0;
+          vec2 jitter = vec2(hash(g + 1.7), hash(g + 7.3)) * 0.6 + 0.2;
+          float d = length(f - jitter);
+          float twinkle = 0.5 + 0.5 * sin(uTime * (2.0 + h * 6.0) + h * 30.0);
+          return smoothstep(0.05, 0.0, d) * (0.5 + twinkle * 0.5);
+        }
+
+        float raySphere(vec3 ro, vec3 rd, vec3 c, float rad) {
+          vec3 oc = ro - c;
+          float b = dot(oc, rd);
+          float d = b * b - (dot(oc, oc) - rad * rad);
+          if (d < 0.0) return -1.0;
+          return -b - sqrt(d);
+        }
+
+        // ---------- cosmic scene helpers ----------
+        ${s.helpers}
+
+        void main() {
+          // View direction in cosmic-local space.
+          vec3 rd = normalize(uViewRotation * vWorldDir);
+          vec3 ro = uCamLocal;
+
+          // Forward-cone projection for 2D effects (comets, events).
+          // Matches the disc-portal's p when looking forward.
+          float forwardness = max(-rd.z, 0.0);
+          vec2 p = rd.xy / max(-rd.z, 0.15);
+
+          // ---- Nebula background (3D noise on direction, no UV seam) ----
+          vec3 nDir = rd * 2.8;
+          float n1 = warpedFbm3(nDir * 1.0 + vec3(uTime * 0.03, -uTime * 0.02, uTime * 0.01));
+          float n2 = fbm3(nDir * 2.8 - vec3(uTime * 0.05, uTime * 0.04, -uTime * 0.03));
+          float n3 = ridgedFbm3(nDir * 4.0 + vec3(-uTime * 0.04, uTime * 0.03, uTime * 0.02));
+          float density = pow(n1 * 0.55 + n2 * 0.45, 1.6);
+          float wisps = pow(n3, 2.2);
+          vec3 nebulaA = vec3(0.05, 0.08, 0.30);
+          vec3 nebulaB = vec3(0.55, 0.18, 0.70);
+          vec3 nebulaC = vec3(0.95, 0.45, 0.25);
+          vec3 nebulaD = vec3(0.35, 0.85, 1.00);
+          vec3 col = mix(nebulaA, nebulaB, smoothstep(0.15, 0.7, n1));
+          col = mix(col, nebulaC, smoothstep(0.55, 1.0, n2) * 0.9);
+          col = mix(col, nebulaD, wisps * 0.6);
+          col *= 0.15 + density * 2.4;
+          col = mix(vec3(0.005, 0.005, 0.02), col, 0.92);
+
+          // ---- Stars (octahedral mapping, no seam) ----
+          float s1 = starsLayer(rd, 45.0, 0.975);
+          float s2 = starsLayer(rd, 95.0, 0.985);
+          float s3 = starsLayer(rd, 180.0, 0.992);
+          float s4 = starsLayer(rd, 260.0, 0.996);
+          col += vec3(0.9, 0.95, 1.0) *
+                 (s1 * 1.1 + s2 * 0.9 + s3 * 0.7 + s4 * 0.6);
+
+          // ---- Raymarched objects (true 3D, scaled positions) ----
+          float t = uTime;
+          float sc = ${IMMERSIVE_SCALE.toFixed(1)};
+
+          vec3 sunPos = vec3(0.05, 0.65, -2.6) * sc;
+          float sunRad = 0.18 * sc;
+          vec3 sunDir = normalize(sunPos - ro);
+          vec3 planetPos = vec3(-0.85, -0.10, -1.6) * sc;
+          float planetRad = 0.40 * sc;
+          float gasA = t * 0.05;
+          vec3 gasPos = vec3(0.95 + sin(gasA) * 0.06,
+                             0.10 + cos(gasA * 0.7) * 0.04,
+                             -2.2 + cos(gasA) * 0.10) * sc;
+          float gasRad = 0.42 * sc;
+          float moonA = t * 0.18;
+          vec3 moonOffset = vec3(cos(moonA) * 0.85,
+                                 sin(moonA * 1.3) * 0.12,
+                                 sin(moonA) * 0.85) * sc;
+          vec3 moonPos = planetPos + moonOffset;
+          float moonRad = 0.11 * sc;
+          vec3 lightDirPlanet = normalize(sunPos - planetPos);
+          vec3 lightDirMoon   = normalize(sunPos - moonPos);
+          vec3 lightDirGas    = normalize(sunPos - gasPos);
+
+          float tBest = 1e9; int hitId = 0;
+          float tP = raySphere(ro, rd, planetPos, planetRad);
+          float tM = raySphere(ro, rd, moonPos, moonRad);
+          float tS = raySphere(ro, rd, sunPos, sunRad);
+          float tG = raySphere(ro, rd, gasPos, gasRad);
+          if (tP > 0.0 && tP < tBest) { tBest = tP; hitId = 1; }
+          if (tM > 0.0 && tM < tBest) { tBest = tM; hitId = 2; }
+          if (tS > 0.0 && tS < tBest) { tBest = tS; hitId = 3; }
+          if (tG > 0.0 && tG < tBest) { tBest = tG; hitId = 4; }
+
+          // Saturn-style ring around gas giant.
+          float rt = 0.55;
+          vec3 ringN = normalize(vec3(0.15, cos(rt), sin(rt)));
+          float ringDenom = dot(rd, ringN);
+          if (abs(ringDenom) > 1e-3) {
+            float tR = dot(gasPos - ro, ringN) / ringDenom;
+            if (tR > 0.0) {
+              vec3 rp = ro + rd * tR - gasPos;
+              float rr = length(rp);
+              float inner = gasRad * 1.3;
+              float outer = gasRad * 2.4;
+              if (rr > inner && rr < outer) {
+                float u = (rr - inner) / (outer - inner);
+                float ang = atan(rp.z, rp.x) + t * 0.06;
+                float bands = fbm(vec2(u * 40.0, 0.0)) * 0.55
+                            + fbm(vec2(u * 140.0, 7.3)) * 0.30
+                            + fbm(vec2(u * 320.0, 1.1)) * 0.15;
+                bands = smoothstep(0.28, 0.78, bands);
+                float gap1 = smoothstep(0.46, 0.49, u) - smoothstep(0.49, 0.53, u);
+                float gap2 = smoothstep(0.72, 0.74, u) - smoothstep(0.74, 0.77, u);
+                float gap3 = smoothstep(0.18, 0.20, u) - smoothstep(0.20, 0.22, u);
+                bands *= 1.0 - clamp(gap1 + gap2 + gap3, 0.0, 1.0);
+                float dust = fbm(vec2(ang * 60.0, u * 30.0));
+                bands *= 0.55 + dust * 0.7;
+                bands *= smoothstep(0.0, 0.06, u) * smoothstep(1.0, 0.94, u);
+                vec3 ringCol = mix(vec3(1.00, 0.85, 0.55),
+                                   vec3(0.90, 0.95, 1.10), u);
+                vec3 ringHit = ro + rd * tR;
+                vec3 toLight = normalize(sunPos - ringHit);
+                float shadowT = raySphere(ringHit, toLight, gasPos, gasRad * 1.02);
+                float shade = (shadowT > 0.0) ? 0.35 : 1.0;
+                bool behind = (hitId == 4 && tR > tBest);
+                if (!behind) {
+                  col += ringCol * bands * shade * 1.6;
+                }
+              }
+            }
+          }
+
+          // Sun glow + corona.
+          {
+            float breathe = 0.85 + 0.15 * sin(t * 0.6);
+            vec3 oc = ro - sunPos;
+            float b2 = dot(oc, rd);
+            float closest = length(oc - rd * (-b2));
+            float halo = smoothstep(0.9, 0.0, closest / (sunRad * 4.0));
+            float coronaR = closest / sunRad;
+            float angSun = atan(
+                dot(rd - sunDir * dot(rd, sunDir), vec3(0.0, 1.0, 0.0)),
+                dot(rd - sunDir * dot(rd, sunDir), vec3(1.0, 0.0, 0.0)));
+            float corona = smoothstep(5.0, 1.0, coronaR)
+                         * (0.5 + 0.5 * fbm(vec2(angSun * 4.0, t * 0.3 + coronaR)));
+            col += vec3(1.0, 0.85, 0.55) * halo * 0.9 * breathe;
+            col += vec3(1.0, 0.55, 0.20) * corona * 0.45;
+          }
+
+          // Planet shading.
+          if (hitId == 1) {
+            vec3 hp = ro + rd * tBest;
+            vec3 n = normalize(hp - planetPos);
+            col = shadePlanet(n, lightDirPlanet, rd,
+                vec3(0.05, 0.20, 0.55), vec3(0.30, 0.55, 0.25),
+                vec3(1.00, 1.00, 1.00));
+          } else if (hitId == 2) {
+            vec3 hp = ro + rd * tBest;
+            vec3 n = normalize(hp - moonPos);
+            float crater = fbm(vec2(n.x * 8.0, n.z * 8.0));
+            float lon = atan(n.z, n.x);
+            float lat = asin(clamp(n.y, -1.0, 1.0));
+            float surface = fbm(vec2(lon, lat) * 4.0);
+            vec3 base = mix(vec3(0.55, 0.50, 0.48),
+                            vec3(0.85, 0.80, 0.75), surface);
+            base *= 0.7 + crater * 0.5;
+            float lambert = max(dot(n, lightDirMoon), 0.0);
+            col = base * (0.1 + lambert);
+          } else if (hitId == 3) {
+            vec3 hp = ro + rd * tBest;
+            vec3 n = normalize(hp - sunPos);
+            float surf = fbm(vec2(n.x * 4.0 + t * 0.30, n.y * 4.0 - t * 0.20));
+            float granules = fbm(vec2(n.x * 18.0 - t * 0.4, n.y * 18.0 + t * 0.3));
+            vec3 c = mix(vec3(1.00, 0.55, 0.20),
+                         vec3(1.00, 0.95, 0.80), surf);
+            c += vec3(0.4, 0.15, 0.05) * (granules - 0.5) * 0.6;
+            float limb = pow(max(dot(n, -rd), 0.0), 0.45);
+            col = c * 1.6 * limb;
+          } else if (hitId == 4) {
+            vec3 hp = ro + rd * tBest;
+            vec3 n = normalize(hp - gasPos);
+            float lon = atan(n.z, n.x);
+            float lat = asin(clamp(n.y, -1.0, 1.0));
+            float bandNoise = fbm(vec2(lat * 6.0, lon * 0.5 + t * 0.05));
+            float bands = sin(lat * 14.0 + bandNoise * 3.0) * 0.5 + 0.5;
+            vec3 colA = vec3(0.95, 0.78, 0.50);
+            vec3 colB = vec3(0.78, 0.55, 0.30);
+            vec3 colC = vec3(1.00, 0.92, 0.72);
+            vec3 base = mix(colA, colB, bands);
+            base = mix(base, colC, smoothstep(0.55, 0.85,
+                       fbm(vec2(lon * 2.0 + t * 0.1, lat * 2.0))) * 0.6);
+            float spot = smoothstep(0.30, 0.0,
+                length(vec2(lon - 1.0, lat + 0.3)));
+            base = mix(base, vec3(0.90, 0.35, 0.20), spot * 0.7);
+            float lambert = max(dot(n, lightDirGas), 0.0);
+            float rim = pow(1.0 - max(dot(n, -rd), 0.0), 2.5);
+            col = base * (0.35 + lambert * 0.95)
+                + vec3(1.0, 0.75, 0.55) * rim * 0.55;
+          }
+
+          // ---- Comets (forward cone only) ----
+          float fwdMask = smoothstep(0.0, 0.3, forwardness);
+          if (fwdMask > 0.0) {
+            col += cosmicComet(p, uTime, 0.13) * fwdMask;
+            col += cosmicComet(p, uTime + 2.7, 0.61) * fwdMask;
+            col += cosmicComet(p, uTime + 4.1, 0.84) * fwdMask;
+          }
+
+          // Tone-map.
+          col = col / (col + vec3(1.0));
+          col = pow(col, vec3(0.85));
+
+          gl_FragColor = vec4(col, 1.0);
+        }
+      `,
+      side: THREE.BackSide,
+      depthWrite: false,
+    });
+
+    this._sphere = new THREE.Mesh(geom, mat);
+    this._sphere.renderOrder = -100;
+    this._sphere.frustumCulled = false;
+    // Prevent raycast from hitting the sky sphere.
+    this._sphere.raycast = () => {};
+    this.add(this._sphere);
+    this.visible = false;
+  }
+}

--- a/demos/portals/CosmicImmersive.js
+++ b/demos/portals/CosmicImmersive.js
@@ -281,7 +281,7 @@ export class CosmicImmersive extends THREE.Object3D {
           vec3 lightDirPlanet = normalize(sunPos - planetPos);
           vec3 lightDirMoon   = normalize(sunPos - moonPos);
           vec3 lightDirGas    = normalize(sunPos - gasPos);
-          vec3 limbCenter = vec3(3.5, -5.5, -3.5) * sc;
+          vec3 limbCenter = vec3(-3.5, -5.5, -3.5) * sc;
           float limbRadius = 5.5 * sc;
           vec3 lightDirLimb = normalize(sunPos - limbCenter);
 

--- a/demos/portals/CosmicImmersive.js
+++ b/demos/portals/CosmicImmersive.js
@@ -236,8 +236,18 @@ export class CosmicImmersive extends THREE.Object3D {
             mc *= 0.15 + mDensity * 2.4;
             col = mix(col, mc, clamp(mDensity * 0.7, 0.0, 1.0));
           }
-          // Far layer removed — near + mid give enough volume and the
-          // 3rd noise pass was the heaviest perf hit in this shader.
+          // Far layer (depth 5.0) — distant haze
+          {
+            vec3 nDir = rd * 5.0;
+            float fn1 = fbm3(nDir * 1.2 + vec3(uTime * 0.02, -uTime * 0.015, uTime * 0.01));
+            float fn3 = ridgedFbm3(nDir * 3.0 + vec3(-uTime * 0.03, uTime * 0.02, uTime * 0.015));
+            float fDensity = pow(fn1, 1.8);
+            float fWisps = pow(fn3, 2.2);
+            vec3 fc = mix(nebulaA, nebulaB, smoothstep(0.2, 0.75, fn1));
+            fc = mix(fc, nebulaD, fWisps * 0.5);
+            fc *= 0.1 + fDensity * 1.8;
+            col = mix(col, fc, clamp(fDensity * 0.4, 0.0, 1.0));
+          }
           col = mix(vec3(0.005, 0.005, 0.02), col, 0.92);
 
           // ---- Stars (octahedral mapping, no seam) ----

--- a/demos/portals/CosmicImmersive.js
+++ b/demos/portals/CosmicImmersive.js
@@ -45,10 +45,10 @@ export class CosmicImmersive extends THREE.Object3D {
         this._entryMatrix
       );
       const portalQuatInv = portalQuat.clone().invert();
-      const camQuat = camera.getWorldQuaternion(new THREE.Quaternion());
-      const localQuat = portalQuatInv.multiply(camQuat);
       // Build a rotation Matrix4, then extract upper-left 3×3 as Matrix3.
-      const rotMat4 = new THREE.Matrix4().makeRotationFromQuaternion(localQuat);
+      const rotMat4 = new THREE.Matrix4().makeRotationFromQuaternion(
+        portalQuatInv
+      );
       mat.uniforms.uViewRotation.value.setFromMatrix4(rotMat4);
     }
 

--- a/demos/portals/CosmicImmersive.js
+++ b/demos/portals/CosmicImmersive.js
@@ -236,18 +236,8 @@ export class CosmicImmersive extends THREE.Object3D {
             mc *= 0.15 + mDensity * 2.4;
             col = mix(col, mc, clamp(mDensity * 0.7, 0.0, 1.0));
           }
-          // Far layer (depth 5.0) — distant haze
-          {
-            vec3 nDir = rd * 5.0;
-            float fn1 = fbm3(nDir * 1.2 + vec3(uTime * 0.02, -uTime * 0.015, uTime * 0.01));
-            float fn3 = ridgedFbm3(nDir * 3.0 + vec3(-uTime * 0.03, uTime * 0.02, uTime * 0.015));
-            float fDensity = pow(fn1, 1.8);
-            float fWisps = pow(fn3, 2.2);
-            vec3 fc = mix(nebulaA, nebulaB, smoothstep(0.2, 0.75, fn1));
-            fc = mix(fc, nebulaD, fWisps * 0.5);
-            fc *= 0.1 + fDensity * 1.8;
-            col = mix(col, fc, clamp(fDensity * 0.4, 0.0, 1.0));
-          }
+          // Far layer removed — near + mid give enough volume and the
+          // 3rd noise pass was the heaviest perf hit in this shader.
           col = mix(vec3(0.005, 0.005, 0.02), col, 0.92);
 
           // ---- Stars (octahedral mapping, no seam) ----

--- a/demos/portals/CosmicImmersive.js
+++ b/demos/portals/CosmicImmersive.js
@@ -41,7 +41,9 @@ export class CosmicImmersive extends THREE.Object3D {
       mat.uniforms.uCamLocal.value.copy(camLocal);
 
       // Camera world quaternion → portal-local rotation for view directions.
-      const portalQuat = new THREE.Quaternion().setFromRotationMatrix(this._entryMatrix);
+      const portalQuat = new THREE.Quaternion().setFromRotationMatrix(
+        this._entryMatrix
+      );
       const portalQuatInv = portalQuat.clone().invert();
       const camQuat = camera.getWorldQuaternion(new THREE.Quaternion());
       const localQuat = portalQuatInv.multiply(camQuat);

--- a/demos/portals/CosmicImmersive.js
+++ b/demos/portals/CosmicImmersive.js
@@ -151,6 +151,18 @@ export class CosmicImmersive extends THREE.Object3D {
           }
           return v;
         }
+        float ridgedFbm(vec2 p) {
+          float v = 0.0; float a = 0.5;
+          for (int i = 0; i < 4; i++) {
+            float n = 1.0 - abs(noise(p) * 2.0 - 1.0);
+            v += a * n * n; p *= 2.13; a *= 0.5;
+          }
+          return v;
+        }
+        float warpedFbm(vec2 p) {
+          vec2 q = vec2(fbm(p), fbm(p + vec2(5.2, 1.3)));
+          return fbm(p + 4.0 * q);
+        }
 
         float starsLayer(vec3 rd, float density, float threshold) {
           // Use octahedral mapping for seamless 2D grid on a sphere.
@@ -193,21 +205,49 @@ export class CosmicImmersive extends THREE.Object3D {
           float forwardness = max(-rd.z, 0.0);
           vec2 p = rd.xy / max(-rd.z, 0.15);
 
-          // ---- Nebula background (3D noise on direction, no UV seam) ----
-          vec3 nDir = rd * 2.8;
-          float n1 = warpedFbm3(nDir * 1.0 + vec3(uTime * 0.03, -uTime * 0.02, uTime * 0.01));
-          float n2 = fbm3(nDir * 2.8 - vec3(uTime * 0.05, uTime * 0.04, -uTime * 0.03));
-          float n3 = ridgedFbm3(nDir * 4.0 + vec3(-uTime * 0.04, uTime * 0.03, uTime * 0.02));
-          float density = pow(n1 * 0.55 + n2 * 0.45, 1.6);
-          float wisps = pow(n3, 2.2);
+          // ---- Nebula background (depth-layered 3D noise for volume) ----
           vec3 nebulaA = vec3(0.05, 0.08, 0.30);
           vec3 nebulaB = vec3(0.55, 0.18, 0.70);
           vec3 nebulaC = vec3(0.95, 0.45, 0.25);
           vec3 nebulaD = vec3(0.35, 0.85, 1.00);
-          vec3 col = mix(nebulaA, nebulaB, smoothstep(0.15, 0.7, n1));
-          col = mix(col, nebulaC, smoothstep(0.55, 1.0, n2) * 0.9);
-          col = mix(col, nebulaD, wisps * 0.6);
-          col *= 0.15 + density * 2.4;
+          vec3 col = vec3(0.005, 0.005, 0.02);
+          // Near layer (depth 1.5) — large soft structures
+          {
+            vec3 nDir = rd * 1.5;
+            float ln1 = warpedFbm3(nDir + vec3(uTime * 0.03, -uTime * 0.02, uTime * 0.01));
+            float ln2 = fbm3(nDir * 2.8 - vec3(uTime * 0.05, uTime * 0.04, -uTime * 0.03));
+            float ld = pow(ln1 * 0.55 + ln2 * 0.45, 1.6);
+            vec3 lc = mix(nebulaA, nebulaB, smoothstep(0.15, 0.7, ln1));
+            lc = mix(lc, nebulaC, smoothstep(0.55, 1.0, ln2) * 0.9);
+            lc *= 0.15 + ld * 2.4;
+            col = mix(col, lc, ld * 0.35);
+          }
+          // Mid layer (depth 2.8) — primary detail
+          {
+            vec3 nDir = rd * 2.8;
+            float mn1 = warpedFbm3(nDir + vec3(uTime * 0.03, -uTime * 0.02, uTime * 0.01));
+            float mn2 = fbm3(nDir * 2.8 - vec3(uTime * 0.05, uTime * 0.04, -uTime * 0.03));
+            float mn3 = ridgedFbm3(nDir * 4.0 + vec3(-uTime * 0.04, uTime * 0.03, uTime * 0.02));
+            float mDensity = pow(mn1 * 0.55 + mn2 * 0.45, 1.6);
+            float mWisps = pow(mn3, 2.2);
+            vec3 mc = mix(nebulaA, nebulaB, smoothstep(0.15, 0.7, mn1));
+            mc = mix(mc, nebulaC, smoothstep(0.55, 1.0, mn2) * 0.9);
+            mc = mix(mc, nebulaD, mWisps * 0.6);
+            mc *= 0.15 + mDensity * 2.4;
+            col = mix(col, mc, clamp(mDensity * 0.7, 0.0, 1.0));
+          }
+          // Far layer (depth 5.0) — distant haze
+          {
+            vec3 nDir = rd * 5.0;
+            float fn1 = fbm3(nDir * 1.2 + vec3(uTime * 0.02, -uTime * 0.015, uTime * 0.01));
+            float fn3 = ridgedFbm3(nDir * 3.0 + vec3(-uTime * 0.03, uTime * 0.02, uTime * 0.015));
+            float fDensity = pow(fn1, 1.8);
+            float fWisps = pow(fn3, 2.2);
+            vec3 fc = mix(nebulaA, nebulaB, smoothstep(0.2, 0.75, fn1));
+            fc = mix(fc, nebulaD, fWisps * 0.5);
+            fc *= 0.1 + fDensity * 1.8;
+            col = mix(col, fc, clamp(fDensity * 0.4, 0.0, 1.0));
+          }
           col = mix(vec3(0.005, 0.005, 0.02), col, 0.92);
 
           // ---- Stars (octahedral mapping, no seam) ----
@@ -241,16 +281,21 @@ export class CosmicImmersive extends THREE.Object3D {
           vec3 lightDirPlanet = normalize(sunPos - planetPos);
           vec3 lightDirMoon   = normalize(sunPos - moonPos);
           vec3 lightDirGas    = normalize(sunPos - gasPos);
+          vec3 limbCenter = vec3(3.5, -5.5, -3.5) * sc;
+          float limbRadius = 5.5 * sc;
+          vec3 lightDirLimb = normalize(sunPos - limbCenter);
 
           float tBest = 1e9; int hitId = 0;
           float tP = raySphere(ro, rd, planetPos, planetRad);
           float tM = raySphere(ro, rd, moonPos, moonRad);
           float tS = raySphere(ro, rd, sunPos, sunRad);
           float tG = raySphere(ro, rd, gasPos, gasRad);
+          float tLB = raySphere(ro, rd, limbCenter, limbRadius);
           if (tP > 0.0 && tP < tBest) { tBest = tP; hitId = 1; }
           if (tM > 0.0 && tM < tBest) { tBest = tM; hitId = 2; }
           if (tS > 0.0 && tS < tBest) { tBest = tS; hitId = 3; }
           if (tG > 0.0 && tG < tBest) { tBest = tG; hitId = 4; }
+          if (tLB > 0.0 && tLB < tBest) { tBest = tLB; hitId = 5; }
 
           // Saturn-style ring around gas giant.
           float rt = 0.55;
@@ -291,7 +336,47 @@ export class CosmicImmersive extends THREE.Object3D {
             }
           }
 
-          // Sun glow + corona.
+          // Horizon gas-giant limb ring.
+          {
+            vec3 limbRingN = normalize(vec3(-0.25, 0.90, 0.15));
+            float lrd = dot(rd, limbRingN);
+            if (abs(lrd) > 1e-3) {
+              float tLR = dot(limbCenter - ro, limbRingN) / lrd;
+              if (tLR > 0.0) {
+                bool behindLimb = (tLB > 0.0 && tLR > tLB);
+                bool behindObj = (hitId != 5 && hitId > 0 && tLR > tBest);
+                if (!behindLimb && !behindObj) {
+                  vec3 rp = ro + rd * tLR - limbCenter;
+                  float rr = length(rp);
+                  float lInner = limbRadius * 1.15;
+                  float lOuter = limbRadius * 1.8;
+                  if (rr > lInner && rr < lOuter) {
+                    float u = (rr - lInner) / (lOuter - lInner);
+                    float ang = atan(rp.z, rp.x) + t * 0.03;
+                    float rb = fbm(vec2(u * 50.0, 0.0)) * 0.5
+                             + fbm(vec2(u * 150.0, 5.1)) * 0.3
+                             + fbm(vec2(u * 350.0, 2.2)) * 0.2;
+                    rb = smoothstep(0.25, 0.75, rb);
+                    float rGap1 = smoothstep(0.40, 0.43, u) - smoothstep(0.43, 0.47, u);
+                    float rGap2 = smoothstep(0.65, 0.67, u) - smoothstep(0.67, 0.70, u);
+                    rb *= 1.0 - clamp(rGap1 + rGap2, 0.0, 1.0);
+                    float rDust = fbm(vec2(ang * 50.0, u * 25.0));
+                    rb *= 0.5 + rDust * 0.7;
+                    rb *= smoothstep(0.0, 0.05, u) * smoothstep(1.0, 0.95, u);
+                    vec3 lrCol = mix(vec3(0.95, 0.80, 0.50),
+                                     vec3(0.85, 0.90, 1.05), u);
+                    vec3 lrHit = ro + rd * tLR;
+                    vec3 toL = normalize(sunPos - lrHit);
+                    float shT = raySphere(lrHit, toL, limbCenter, limbRadius * 1.01);
+                    float shade = (shT > 0.0) ? 0.30 : 1.0;
+                    col += lrCol * rb * shade * 1.4;
+                  }
+                }
+              }
+            }
+          }
+
+          // Sun glow + corona + flare.
           {
             float breathe = 0.85 + 0.15 * sin(t * 0.6);
             vec3 oc = ro - sunPos;
@@ -306,6 +391,11 @@ export class CosmicImmersive extends THREE.Object3D {
                          * (0.5 + 0.5 * fbm(vec2(angSun * 4.0, t * 0.3 + coronaR)));
             col += vec3(1.0, 0.85, 0.55) * halo * 0.9 * breathe;
             col += vec3(1.0, 0.55, 0.20) * corona * 0.45;
+            float flarePhase = mod(t, 11.0) / 11.0;
+            float flareEnv = smoothstep(0.0, 0.05, flarePhase)
+                           * smoothstep(0.35, 0.10, flarePhase);
+            col += vec3(1.0, 0.7, 0.3)
+                 * smoothstep(2.0, 0.6, coronaR) * flareEnv * 1.2;
           }
 
           // Planet shading.
@@ -357,6 +447,26 @@ export class CosmicImmersive extends THREE.Object3D {
             float rim = pow(1.0 - max(dot(n, -rd), 0.0), 2.5);
             col = base * (0.35 + lambert * 0.95)
                 + vec3(1.0, 0.75, 0.55) * rim * 0.55;
+          } else if (hitId == 5) {
+            vec3 hp = ro + rd * tBest;
+            vec3 n = normalize(hp - limbCenter);
+            float lon = atan(n.z, n.x) + t * 0.02;
+            float lat = asin(clamp(n.y, -1.0, 1.0));
+            float bandN = fbm(vec2(lat * 8.0, lon * 0.3 + t * 0.03));
+            float bands = sin(lat * 20.0 + bandN * 4.0) * 0.5 + 0.5;
+            vec3 limbA = vec3(0.85, 0.65, 0.40);
+            vec3 limbB = vec3(0.70, 0.45, 0.25);
+            vec3 limbC = vec3(1.00, 0.88, 0.65);
+            vec3 base = mix(limbA, limbB, bands);
+            base = mix(base, limbC, smoothstep(0.6, 0.9,
+                       fbm(vec2(lon * 1.5 + t * 0.06, lat * 1.5))) * 0.5);
+            float grs = smoothstep(0.35, 0.0,
+                length(vec2(lon - 2.0, lat + 0.15) * vec2(1.0, 1.5)));
+            base = mix(base, vec3(0.85, 0.30, 0.15), grs * 0.6);
+            float lambert = max(dot(n, lightDirLimb), 0.0);
+            float rim = pow(1.0 - max(dot(n, -rd), 0.0), 3.0);
+            col = base * (0.20 + lambert * 0.80)
+                + vec3(1.0, 0.80, 0.55) * rim * 0.65;
           }
 
           // ---- Comets (forward cone only) ----
@@ -365,6 +475,129 @@ export class CosmicImmersive extends THREE.Object3D {
             col += cosmicComet(p, uTime, 0.13) * fwdMask;
             col += cosmicComet(p, uTime + 2.7, 0.61) * fwdMask;
             col += cosmicComet(p, uTime + 4.1, 0.84) * fwdMask;
+          }
+
+          // ---- Supernova every 22s (forward cone) ----
+          if (fwdMask > 0.0) {
+            float snCycle = 22.0;
+            float snK = floor(uTime / snCycle);
+            float snLocal = uTime - snK * snCycle;
+            vec2 snPos = vec2(hash(vec2(snK, 1.7)) * 1.4 - 0.7,
+                             hash(vec2(snK, 4.3)) * 1.4 - 0.7);
+            vec2 snD = p - snPos;
+            float dSn = length(snD);
+            float snAng = atan(snD.y, snD.x);
+            float flash = smoothstep(0.0, 0.25, snLocal)
+                        * smoothstep(6.0, 0.4, snLocal);
+            float snCore = smoothstep(0.06, 0.0, dSn) * 4.5;
+            float bloom = smoothstep(0.7, 0.0, dSn) * 1.4;
+            vec3 hotCol = mix(vec3(0.7, 0.85, 1.20),
+                              vec3(1.00, 0.95, 0.80), smoothstep(0.0, 1.0, snLocal));
+            hotCol = mix(hotCol, vec3(1.00, 0.55, 0.30),
+                         smoothstep(2.0, 6.0, snLocal));
+            col += hotCol * (snCore + bloom) * flash * fwdMask;
+            float jetAng = hash(vec2(snK, 13.7)) * 6.2832;
+            vec2 jetDir = vec2(cos(jetAng), sin(jetAng));
+            float snAlong = dot(snD, jetDir);
+            float snAcross = dot(snD, vec2(-jetDir.y, jetDir.x));
+            float jetR = smoothstep(0.0, 4.0, snLocal) * 0.6;
+            float jet = smoothstep(0.04, 0.0, abs(snAcross))
+                      * smoothstep(jetR, jetR * 0.05, abs(snAlong));
+            jet *= smoothstep(7.0, 1.5, snLocal);
+            jet *= 0.4 + 0.6 * fbm(vec2(snAlong * 30.0, uTime * 0.6));
+            col += vec3(0.85, 0.95, 1.10) * jet * 0.9 * fwdMask;
+            float ringR = smoothstep(0.0, 6.0, snLocal) * 0.65;
+            float perturb = ridgedFbm(vec2(snAng * 3.0 + snK * 5.0, ringR * 8.0)) * 0.06;
+            float frontDist = abs(dSn - (ringR + perturb));
+            float snWidth = 0.012 + smoothstep(0.0, 6.0, snLocal) * 0.025;
+            float shock = smoothstep(snWidth, 0.0, frontDist);
+            shock *= 0.5 + ridgedFbm(vec2(snAng * 8.0, ringR * 22.0 + uTime * 0.3)) * 1.1;
+            float shockFade = smoothstep(8.0, 1.5, snLocal);
+            col += vec3(1.0, 0.95, 1.0) * shock * shockFade * 1.4 * fwdMask;
+          }
+
+          // ---- Meteor shower every 17s (forward cone) ----
+          if (fwdMask > 0.0) {
+            float msCycle = 17.0;
+            float msK = floor(uTime / msCycle);
+            float msLocal = uTime - msK * msCycle;
+            float burstEnv = smoothstep(0.0, 0.2, msLocal)
+                           * smoothstep(2.5, 0.2, msLocal);
+            if (burstEnv > 0.0) {
+              float msAng = hash(vec2(msK, 9.1)) * 6.2832;
+              vec2 mDir = vec2(cos(msAng), sin(msAng));
+              vec2 mPerp = vec2(-mDir.y, mDir.x);
+              for (int i = 0; i < 7; i++) {
+                float fi = float(i);
+                vec2 origin = vec2(hash(vec2(msK, fi + 11.1)) * 2.0 - 1.0,
+                                   hash(vec2(msK, fi + 23.7)) * 2.0 - 1.0);
+                float speed = 1.6 + hash(vec2(msK, fi + 4.4));
+                vec2 mPos = origin + mDir * (msLocal * speed);
+                vec2 dd = p - mPos;
+                float across2 = dot(dd, mPerp);
+                float along2 = dot(dd, -mDir);
+                float head = smoothstep(0.012, 0.0, length(dd));
+                float tail = smoothstep(0.005, 0.0, abs(across2))
+                           * smoothstep(0.30, 0.0, along2)
+                           * step(0.0, along2);
+                col += vec3(1.0, 0.9, 0.7) * (head * 1.8 + tail * 0.85) * burstEnv * fwdMask;
+              }
+            }
+          }
+
+          // ---- Rocket flyby every 13s (forward cone) ----
+          if (fwdMask > 0.0) {
+            float rCycle = 13.0;
+            float rK = floor(uTime / rCycle);
+            float rLocal = uTime - rK * rCycle;
+            float rLife = smoothstep(0.0, 0.3, rLocal)
+                        * smoothstep(rCycle, rCycle - 1.0, rLocal);
+            float rAng = hash(vec2(rK, 31.7)) * 6.2832;
+            vec2 rDir = vec2(cos(rAng), sin(rAng));
+            vec2 rPerp = vec2(-rDir.y, rDir.x);
+            vec2 rStart = -rDir * 1.6 + rPerp * (hash(vec2(rK, 7.7)) - 0.5);
+            vec2 rPos = rStart + rDir * rLocal * 0.30;
+            vec2 rd2 = p - rPos;
+            float rAlong = dot(rd2, -rDir);
+            float rAcross = dot(rd2, rPerp);
+            float hull = smoothstep(0.055, 0.038, abs(rAlong))
+                       * smoothstep(0.014, 0.0, abs(rAcross));
+            float wing = smoothstep(0.045, 0.0, abs(rAlong + 0.005))
+                       * smoothstep(0.005, 0.0, max(abs(rAcross) - 0.030, 0.0));
+            col += vec3(0.95, 0.97, 1.00) * (hull + wing) * 1.6 * rLife * fwdMask;
+            float plumeAlong = rAlong + 0.060;
+            float plume = smoothstep(0.32, 0.0, plumeAlong) * step(0.0, plumeAlong)
+                        * smoothstep(0.018, 0.0, abs(rAcross));
+            col += vec3(0.30, 0.65, 1.00) * plume * 1.4 * rLife * fwdMask;
+            float plumeCore = plume * smoothstep(0.10, 0.0, plumeAlong);
+            col += vec3(1.00, 0.95, 0.75) * plumeCore * 2.0 * rLife * fwdMask;
+          }
+
+          // ---- Wormhole every 27s (forward cone) ----
+          if (fwdMask > 0.0) {
+            float wCycle = 27.0;
+            float wK = floor(uTime / wCycle);
+            float wLocal = uTime - wK * wCycle;
+            float wOpen = smoothstep(0.0, 2.0, wLocal) * smoothstep(8.0, 5.0, wLocal);
+            if (wOpen > 0.001) {
+              vec2 wPos = vec2(hash(vec2(wK, 71.3)) * 1.2 - 0.6,
+                              hash(vec2(wK, 88.9)) * 1.2 - 0.6);
+              vec2 wd = p - wPos;
+              float wdr = length(wd);
+              float wAng = atan(wd.y, wd.x);
+              float horizon = smoothstep(0.05, 0.045, wdr);
+              col *= 1.0 - horizon * wOpen * fwdMask;
+              float discMask = smoothstep(0.05, 0.06, wdr)
+                             * smoothstep(0.22, 0.10, wdr);
+              float swirl = pow(warpedFbm(vec2(wAng * 4.0 + uTime * 2.0,
+                                               wdr * 25.0 - uTime * 1.5)), 1.6);
+              vec3 discCol = mix(vec3(1.0, 0.55, 0.20),
+                                 vec3(0.55, 0.75, 1.20),
+                                 smoothstep(0.05, 0.22, wdr));
+              col += discCol * discMask * swirl * 1.8 * wOpen * fwdMask;
+              float arc = smoothstep(0.072, 0.060, wdr) * smoothstep(0.045, 0.058, wdr);
+              col += vec3(1.0, 0.85, 0.55) * arc * (0.6 + 0.4 * cos(wAng)) * wOpen * 1.2 * fwdMask;
+            }
           }
 
           // Tone-map.

--- a/demos/portals/CosmicImmersive.js
+++ b/demos/portals/CosmicImmersive.js
@@ -17,9 +17,15 @@ export class CosmicImmersive extends THREE.Object3D {
     this._buildSphere();
   }
 
-  show(portalWorldMatrix) {
-    this._entryMatrix = portalWorldMatrix.clone();
-    this._entryMatrixInv = portalWorldMatrix.clone().invert();
+  show(portalWorldMatrix, fromSide = 'front') {
+    let m = portalWorldMatrix.clone();
+    if (fromSide === 'back') {
+      // User entered through the back face of the portal — apply a 180° yaw
+      // so they spawn facing the scene rather than the wall behind it.
+      m.multiply(new THREE.Matrix4().makeRotationY(Math.PI));
+    }
+    this._entryMatrix = m;
+    this._entryMatrixInv = m.clone().invert();
     this.visible = true;
   }
 

--- a/demos/portals/CosmicImmersive.js
+++ b/demos/portals/CosmicImmersive.js
@@ -363,8 +363,8 @@ export class CosmicImmersive extends THREE.Object3D {
                     float rDust = fbm(vec2(ang * 50.0, u * 25.0));
                     rb *= 0.5 + rDust * 0.7;
                     rb *= smoothstep(0.0, 0.05, u) * smoothstep(1.0, 0.95, u);
-                    vec3 lrCol = mix(vec3(0.95, 0.80, 0.50),
-                                     vec3(0.85, 0.90, 1.05), u);
+                    vec3 lrCol = mix(vec3(0.65, 0.80, 0.95),
+                                     vec3(0.85, 0.95, 1.05), u);
                     vec3 lrHit = ro + rd * tLR;
                     vec3 toL = normalize(sunPos - lrHit);
                     float shT = raySphere(lrHit, toL, limbCenter, limbRadius * 1.01);
@@ -454,19 +454,19 @@ export class CosmicImmersive extends THREE.Object3D {
             float lat = asin(clamp(n.y, -1.0, 1.0));
             float bandN = fbm(vec2(lat * 8.0, lon * 0.3 + t * 0.03));
             float bands = sin(lat * 20.0 + bandN * 4.0) * 0.5 + 0.5;
-            vec3 limbA = vec3(0.85, 0.65, 0.40);
-            vec3 limbB = vec3(0.70, 0.45, 0.25);
-            vec3 limbC = vec3(1.00, 0.88, 0.65);
+            vec3 limbA = vec3(0.30, 0.55, 0.85);
+            vec3 limbB = vec3(0.15, 0.30, 0.55);
+            vec3 limbC = vec3(0.65, 0.85, 1.00);
             vec3 base = mix(limbA, limbB, bands);
             base = mix(base, limbC, smoothstep(0.6, 0.9,
                        fbm(vec2(lon * 1.5 + t * 0.06, lat * 1.5))) * 0.5);
-            float grs = smoothstep(0.35, 0.0,
+            float storm = smoothstep(0.35, 0.0,
                 length(vec2(lon - 2.0, lat + 0.15) * vec2(1.0, 1.5)));
-            base = mix(base, vec3(0.85, 0.30, 0.15), grs * 0.6);
+            base = mix(base, vec3(0.90, 0.95, 1.00), storm * 0.5);
             float lambert = max(dot(n, lightDirLimb), 0.0);
             float rim = pow(1.0 - max(dot(n, -rd), 0.0), 3.0);
             col = base * (0.20 + lambert * 0.80)
-                + vec3(1.0, 0.80, 0.55) * rim * 0.65;
+                + vec3(0.55, 0.80, 1.00) * rim * 0.65;
           }
 
           // ---- Comets (forward cone only) ----

--- a/demos/portals/CyberpunkImmersive.js
+++ b/demos/portals/CyberpunkImmersive.js
@@ -42,9 +42,9 @@ export class CyberpunkImmersive extends THREE.Object3D {
         this._entryMatrix
       );
       const portalQuatInv = portalQuat.clone().invert();
-      const camQuat = camera.getWorldQuaternion(new THREE.Quaternion());
-      const localQuat = portalQuatInv.multiply(camQuat);
-      const rotMat4 = new THREE.Matrix4().makeRotationFromQuaternion(localQuat);
+      const rotMat4 = new THREE.Matrix4().makeRotationFromQuaternion(
+        portalQuatInv
+      );
       mat.uniforms.uViewRotation.value.setFromMatrix4(rotMat4);
     }
 
@@ -183,6 +183,133 @@ export class CyberpunkImmersive extends THREE.Object3D {
           return hit;
         }
 
+        // Ray-AABB intersection. Returns nearest positive t and normal.
+        // Returns -1 if no hit.
+        float rayBox(vec3 ro, vec3 rd, vec3 ctr, vec3 hsz,
+                      out vec3 nrm) {
+          vec3 m = 1.0 / rd;
+          vec3 oc = ctr - ro;
+          vec3 t1 = (oc - hsz) * m;
+          vec3 t2 = (oc + hsz) * m;
+          vec3 tmin = min(t1, t2);
+          vec3 tmax = max(t1, t2);
+          float tNear = max(max(tmin.x, tmin.y), tmin.z);
+          float tFar = min(min(tmax.x, tmax.y), tmax.z);
+          if (tNear > tFar || tFar < 0.0) return -1.0;
+          if (tNear == tmin.x) nrm = vec3(-sign(rd.x), 0.0, 0.0);
+          else if (tNear == tmin.y) nrm = vec3(0.0, -sign(rd.y), 0.0);
+          else nrm = vec3(0.0, 0.0, -sign(rd.z));
+          return tNear;
+        }
+
+        // 3D ring of skyscraper boxes. Returns vec4(rgb, t).
+        vec4 cityRing3D(vec3 ro, vec3 rd, float t) {
+          float bestT = 1e9;
+          vec3 bestCol = vec3(0.0);
+          for (int i = 0; i < 14; i++) {
+            float fi = float(i);
+            float seed = fi + 19.0;
+            float ang = fi * (6.28318 / 14.0)
+                      + (hash(vec2(seed, 0.7)) - 0.5) * 0.15;
+            float dist = 18.0 + hash(vec2(seed, 1.7)) * 14.0;
+            vec3 base = vec3(cos(ang) * dist, -1.6, sin(ang) * dist);
+            float w = 2.5 + hash(vec2(seed, 2.7)) * 2.5;
+            float d = 2.5 + hash(vec2(seed, 3.7)) * 2.5;
+            float h = 8.0 + hash(vec2(seed, 4.7)) * 18.0;
+            vec3 hsz = vec3(w, h * 0.5, d);
+            vec3 ctr = base + vec3(0.0, h * 0.5, 0.0);
+            vec3 nrm;
+            float th = rayBox(ro, rd, ctr, hsz, nrm);
+            if (th > 0.5 && th < bestT) {
+              bestT = th;
+              vec3 hp = ro + rd * th - ctr;
+              // Pick window UV based on hit face.
+              vec2 uv = vec2(0.0);
+              float isSide = 1.0 - step(0.5, abs(nrm.y));
+              if (abs(nrm.x) > 0.5) {
+                uv = vec2((hp.z + d) / (2.0 * d),
+                           (hp.y + h * 0.5) / h);
+              } else if (abs(nrm.z) > 0.5) {
+                uv = vec2((hp.x + w) / (2.0 * w),
+                           (hp.y + h * 0.5) / h);
+              }
+              vec2 grid = vec2(6.0, 16.0);
+              vec2 cell = uv * grid;
+              vec2 fc = fract(cell);
+              vec2 ic = floor(cell);
+              float lit = step(0.55, hash(ic + seed));
+              float win = step(0.18, fc.x) * step(fc.x, 0.82)
+                        * step(0.20, fc.y) * step(fc.y, 0.85);
+              float flickerOn = step(0.92, hash(ic + seed + 7.7));
+              float flicker = mix(1.0,
+                  0.5 + 0.5 * sin(t * 6.0 + ic.x + ic.y),
+                  flickerOn);
+              float winMask = lit * win * flicker * isSide;
+              float colorRoll = hash(vec2(seed, 33.7));
+              vec3 wc;
+              if (colorRoll < 0.5) wc = vec3(1.00, 0.85, 0.50);
+              else if (colorRoll < 0.75) wc = vec3(0.20, 0.95, 1.00);
+              else wc = vec3(1.00, 0.30, 0.80);
+              vec3 buildingBase = vec3(0.020, 0.015, 0.035)
+                                + vec3(0.06, 0.02, 0.08);
+              vec3 c = buildingBase + wc * winMask * 1.5;
+              // Antenna glow on top face.
+              float topMask = step(0.5, nrm.y);
+              c += vec3(1.0, 0.30, 0.55) * topMask
+                 * (0.4 + 0.3 * sin(t * 3.0 + seed * 7.0));
+              bestCol = c;
+            }
+          }
+          return vec4(bestCol, bestT);
+        }
+
+        // Holographic neon billboard slabs at fixed positions.
+        vec4 neonBillboards(vec3 ro, vec3 rd, float t) {
+          float bestT = 1e9;
+          vec3 bestCol = vec3(0.0);
+          for (int i = 0; i < 3; i++) {
+            float fi = float(i);
+            float ang = fi * 2.094 + 0.5;
+            float dist = 8.0 + fi * 1.5;
+            vec3 ctr = vec3(cos(ang) * dist, 2.5 + fi * 0.8,
+                             sin(ang) * dist);
+            vec3 hsz = vec3(2.0, 1.2, 0.08);
+            // Orient slab to face inward (rotate hsz xz by ang).
+            // Use AABB approximation: swap x/z for slabs roughly perpendicular
+            // to the radial direction.
+            if (abs(cos(ang)) < abs(sin(ang))) hsz = vec3(0.08, 1.2, 2.0);
+            vec3 nrm;
+            float th = rayBox(ro, rd, ctr, hsz, nrm);
+            if (th > 0.5 && th < bestT) {
+              bestT = th;
+              vec3 hp = ro + rd * th - ctr;
+              vec2 uv = vec2(hp.x / hsz.x, hp.y / hsz.y) * 0.5 + 0.5;
+              if (hsz.x < 0.2) uv = vec2(hp.z / hsz.z, hp.y / hsz.y) * 0.5
+                                  + 0.5;
+              float scan = 0.5 + 0.5 * sin(uv.y * 80.0 + t * 8.0);
+              float flicker = 0.7 + 0.3 * sin(t * 18.0 + fi);
+              vec3 base = vec3(0.0);
+              if (i == 0) base = vec3(1.00, 0.30, 0.80);
+              else if (i == 1) base = vec3(0.20, 0.95, 1.00);
+              else base = vec3(1.00, 0.75, 0.20);
+              float shape = smoothstep(0.05, 0.10, uv.x)
+                          * smoothstep(0.05, 0.10, 1.0 - uv.x)
+                          * smoothstep(0.10, 0.20, uv.y)
+                          * smoothstep(0.10, 0.20, 1.0 - uv.y);
+              bestCol = base * (0.7 + scan * 0.5) * flicker * shape * 1.4;
+            }
+          }
+          return vec4(bestCol, bestT);
+        }
+
+        float raySphere(vec3 ro, vec3 rd, vec3 c, float rad) {
+          vec3 oc = ro - c;
+          float b = dot(oc, rd);
+          float d = b * b - (dot(oc, oc) - rad * rad);
+          if (d < 0.0) return -1.0;
+          return -b - sqrt(d);
+        }
+
         // Hover-car streaks: thin horizontal bright lines crossing the sky.
         vec3 hoverCars(vec3 rd, float t) {
           vec3 col = vec3(0.0);
@@ -311,17 +438,22 @@ export class CyberpunkImmersive extends THREE.Object3D {
           col = mix(col, vec3(0.20, 0.05, 0.18),
                     smog * smoothstep(0.0, 0.3, rd.y) * 0.5);
 
-          // ---- Ring of skyscraper silhouettes ----
-          BuildingHit b = cityRing(rd, t);
-          if (b.mask > 0.5) {
-            vec3 buildingCol = vec3(0.020, 0.015, 0.035);
-            // Backlit edge tint
-            buildingCol += vec3(0.06, 0.02, 0.08);
-            // Apply windows.
-            vec3 lit = b.windowCol * b.windowMask * 1.5;
-            col = buildingCol + lit;
-            // Top antenna glow.
-            col += vec3(1.00, 0.30, 0.55) * b.topGlow * 0.4;
+          // ---- 3D raycast city ring (parallaxes correctly) ----
+          float opaqueT = 1e9;
+          vec3 opaqueCol = vec3(0.0);
+          vec4 cityHit = cityRing3D(ro, rd, t);
+          if (cityHit.w < opaqueT) {
+            opaqueT = cityHit.w;
+            opaqueCol = cityHit.rgb;
+          }
+          vec4 boardHit = neonBillboards(ro, rd, t);
+          if (boardHit.w < opaqueT) {
+            opaqueT = boardHit.w;
+            opaqueCol = boardHit.rgb;
+          }
+          if (opaqueT < 1e8) {
+            float fogF = smoothstep(8.0, 50.0, opaqueT);
+            col = mix(opaqueCol, col, fogF * 0.4);
           }
 
           // ---- Hover-car streaks ----
@@ -335,10 +467,12 @@ export class CyberpunkImmersive extends THREE.Object3D {
 
           // ---- Wet street (looking down) ----
           if (rd.y < 0.0) {
-            vec3 streetCol = wetStreet(ro, rd, t);
-            // Replace sky/building color below horizon.
-            float weight = smoothstep(0.0, -0.05, rd.y);
-            col = mix(col, streetCol, weight);
+            float gt = -ro.y / rd.y;
+            if (gt > 0.0 && gt < opaqueT) {
+              vec3 streetCol = wetStreet(ro, rd, t);
+              float weight = smoothstep(0.0, -0.05, rd.y);
+              col = mix(col, streetCol, weight);
+            }
           }
 
           // Atmospheric magenta lift.

--- a/demos/portals/CyberpunkImmersive.js
+++ b/demos/portals/CyberpunkImmersive.js
@@ -16,9 +16,15 @@ export class CyberpunkImmersive extends THREE.Object3D {
     this._buildSphere();
   }
 
-  show(portalWorldMatrix) {
-    this._entryMatrix = portalWorldMatrix.clone();
-    this._entryMatrixInv = portalWorldMatrix.clone().invert();
+  show(portalWorldMatrix, fromSide = 'front') {
+    let m = portalWorldMatrix.clone();
+    if (fromSide === 'back') {
+      // User entered through the back face of the portal — apply a 180° yaw
+      // so they spawn facing the scene rather than the wall behind it.
+      m.multiply(new THREE.Matrix4().makeRotationY(Math.PI));
+    }
+    this._entryMatrix = m;
+    this._entryMatrixInv = m.clone().invert();
     this.visible = true;
   }
 

--- a/demos/portals/CyberpunkImmersive.js
+++ b/demos/portals/CyberpunkImmersive.js
@@ -1,0 +1,365 @@
+import * as THREE from 'three';
+
+const SPHERE_RADIUS = 50;
+
+/**
+ * Full-surround neon city for "walk-in" mode.
+ * Inverted sphere: smoggy purple sky with neon billboards, ring of
+ * skyscraper silhouettes around the user with lit-window grids,
+ * hover-cars streaking past as glowing line streaks, holographic billboard,
+ * occasional rain streaks, wet street with neon reflections.
+ */
+export class CyberpunkImmersive extends THREE.Object3D {
+  constructor() {
+    super();
+    this._time = 0;
+    this._buildSphere();
+  }
+
+  show(portalWorldMatrix) {
+    this._entryMatrix = portalWorldMatrix.clone();
+    this._entryMatrixInv = portalWorldMatrix.clone().invert();
+    this.visible = true;
+  }
+
+  hide() {
+    this.visible = false;
+  }
+
+  update(dt, camera) {
+    if (!this.visible) return;
+    this._time += dt;
+
+    const mat = this._sphere.material;
+    mat.uniforms.uTime.value = this._time;
+
+    if (camera) {
+      const camWorld = camera.getWorldPosition(new THREE.Vector3());
+      const camLocal = camWorld.clone().applyMatrix4(this._entryMatrixInv);
+      mat.uniforms.uCamLocal.value.copy(camLocal);
+
+      const portalQuat = new THREE.Quaternion().setFromRotationMatrix(
+        this._entryMatrix
+      );
+      const portalQuatInv = portalQuat.clone().invert();
+      const camQuat = camera.getWorldQuaternion(new THREE.Quaternion());
+      const localQuat = portalQuatInv.multiply(camQuat);
+      const rotMat4 = new THREE.Matrix4().makeRotationFromQuaternion(localQuat);
+      mat.uniforms.uViewRotation.value.setFromMatrix4(rotMat4);
+    }
+
+    if (camera) {
+      camera.getWorldPosition(this.position);
+    }
+  }
+
+  _buildSphere() {
+    const geom = new THREE.SphereGeometry(SPHERE_RADIUS, 64, 32);
+
+    const mat = new THREE.ShaderMaterial({
+      uniforms: {
+        uTime: {value: 0},
+        uCamLocal: {value: new THREE.Vector3(0, 0, 1.6)},
+        uViewRotation: {value: new THREE.Matrix3()},
+      },
+      vertexShader: /* glsl */ `
+        varying vec3 vWorldDir;
+        void main() {
+          vWorldDir = normalize(position);
+          gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        }
+      `,
+      fragmentShader: /* glsl */ `
+        precision highp float;
+        uniform float uTime;
+        uniform vec3 uCamLocal;
+        uniform mat3 uViewRotation;
+        varying vec3 vWorldDir;
+
+        float hash(vec2 p) {
+          p = fract(p * vec2(123.34, 456.21));
+          p += dot(p, p + 45.32);
+          return fract(p.x * p.y);
+        }
+        float noise(vec2 p) {
+          vec2 i = floor(p); vec2 f = fract(p);
+          float a = hash(i); float b = hash(i + vec2(1,0));
+          float c = hash(i + vec2(0,1)); float d = hash(i + vec2(1,1));
+          vec2 u = f * f * (3.0 - 2.0 * f);
+          return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x)
+                                + (d - b) * u.x * u.y;
+        }
+        float fbm(vec2 p) {
+          float v = 0.0; float a = 0.5;
+          for (int i = 0; i < 4; i++) { v += a * noise(p); p *= 2.07; a *= 0.5; }
+          return v;
+        }
+
+        // Building silhouette in cylindrical (azimuth, altitude) space.
+        // Returns mask 0..1 plus window-light contribution (vec3).
+        // azBase = building center azimuth; widthAz = half angular width.
+        // heightAlt = top altitude; baseAlt = base altitude (usually 0).
+        struct BuildingHit {
+          float mask;
+          vec3 windowCol;
+          float windowMask;
+          float topGlow;
+        };
+
+        BuildingHit buildingAt(vec3 rd, float azBase, float widthAz,
+                                float heightAlt, float seed, float t) {
+          BuildingHit h;
+          h.mask = 0.0; h.windowCol = vec3(0.0);
+          h.windowMask = 0.0; h.topGlow = 0.0;
+          float az = atan(rd.x, -rd.z);
+          float alt = asin(clamp(rd.y, -1.0, 1.0));
+          float dAz = az - azBase;
+          if (dAz > 3.14159) dAz -= 6.28318;
+          if (dAz < -3.14159) dAz += 6.28318;
+          if (abs(dAz) > widthAz) return h;
+          if (alt < 0.0 || alt > heightAlt) return h;
+          h.mask = 1.0;
+          // Local building UVs: (0..1 across, 0..1 up).
+          float u = (dAz + widthAz) / (widthAz * 2.0);
+          float v = alt / heightAlt;
+          // Window grid.
+          vec2 grid = vec2(8.0, 26.0);
+          vec2 cell = vec2(u, v) * grid;
+          vec2 fc = fract(cell);
+          vec2 ic = floor(cell);
+          float lit = step(0.55, hash(ic + seed));
+          float win = step(0.18, fc.x) * step(fc.x, 0.82)
+                    * step(0.20, fc.y) * step(fc.y, 0.85);
+          float flickerOn = step(0.92, hash(ic + seed + 7.7));
+          float flicker = mix(1.0,
+              0.5 + 0.5 * sin(t * 6.0 + ic.x + ic.y),
+              flickerOn);
+          h.windowMask = lit * win * flicker;
+          // Window color: warm yellow / cyan / magenta variations per building.
+          float colorRoll = hash(vec2(seed, 33.7));
+          vec3 wc;
+          if (colorRoll < 0.5) {
+            wc = vec3(1.00, 0.85, 0.50); // warm
+          } else if (colorRoll < 0.75) {
+            wc = vec3(0.20, 0.95, 1.00); // cyan
+          } else {
+            wc = vec3(1.00, 0.30, 0.80); // magenta
+          }
+          h.windowCol = wc;
+          // Top antenna glow.
+          float topZone = smoothstep(0.95, 1.0, v);
+          h.topGlow = topZone * (0.5 + 0.5 * sin(t * 3.0 + seed * 7.0));
+          return h;
+        }
+
+        // Pick the closest building among a few in the slot containing this
+        // azimuth. We use 18 slots around the circle; each has its own params.
+        BuildingHit cityRing(vec3 rd, float t) {
+          BuildingHit hit;
+          hit.mask = 0.0; hit.windowCol = vec3(0.0);
+          hit.windowMask = 0.0; hit.topGlow = 0.0;
+          float az = atan(rd.x, -rd.z);
+          float density = 18.0;
+          float slice = az * density / (2.0 * 3.14159265);
+          float slotIdx = floor(slice);
+          // Try this slot and its two neighbours so widths can overlap.
+          for (int k = -1; k <= 1; k++) {
+            float si = slotIdx + float(k);
+            float seed = si + 19.0;
+            float baseAz = (si + 0.5) * (2.0 * 3.14159265) / density;
+            // Per-building param variation.
+            float widthAz = 0.10 + hash(vec2(seed, 1.7)) * 0.06;
+            float heightAlt = 0.18 + hash(vec2(seed, 2.7)) * 0.40;
+            BuildingHit h = buildingAt(rd, baseAz, widthAz, heightAlt,
+                                        seed, t);
+            // The closer (taller) building visually overrides; we approximate
+            // by picking the one that wrote the higher altitude top.
+            if (h.mask > 0.5 && heightAlt > 0.0 && h.mask >= hit.mask) {
+              if (hit.mask < 0.5 || heightAlt > 0.18) {
+                hit = h;
+              }
+            }
+          }
+          return hit;
+        }
+
+        // Hover-car streaks: thin horizontal bright lines crossing the sky.
+        vec3 hoverCars(vec3 rd, float t) {
+          vec3 col = vec3(0.0);
+          for (int i = 0; i < 5; i++) {
+            float fi = float(i);
+            float seed = fi * 13.7;
+            float lane = mix(0.05, 0.30, hash(vec2(seed, 1.3)));
+            float spd = mix(0.4, 0.9, hash(vec2(seed, 2.7)));
+            // Horizontal sweep: az = -PI..PI cycles.
+            float phase = mod(t * spd + seed, 6.28318) - 3.14159;
+            float az = atan(rd.x, -rd.z);
+            float alt = asin(clamp(rd.y, -1.0, 1.0));
+            float dAz = az - phase;
+            if (dAz > 3.14159) dAz -= 6.28318;
+            if (dAz < -3.14159) dAz += 6.28318;
+            float dAlt = alt - lane;
+            // Streak: long thin trail behind position.
+            float along = -dAz; // behind = az < phase
+            float thickness = 0.012;
+            float bright = smoothstep(thickness, 0.0, abs(dAlt))
+                         * smoothstep(0.0, 0.005, along)
+                         * smoothstep(0.20, 0.0, along);
+            // Color alternates cyan / magenta / amber.
+            vec3 streakCol;
+            float roll = hash(vec2(seed, 3.7));
+            if (roll < 0.4) streakCol = vec3(0.20, 0.95, 1.00);
+            else if (roll < 0.75) streakCol = vec3(1.00, 0.30, 0.80);
+            else streakCol = vec3(1.00, 0.75, 0.20);
+            col += streakCol * bright * 1.4;
+          }
+          return col;
+        }
+
+        // Holographic billboard: rectangular flicker with scanlines.
+        vec3 hologram(vec3 rd, float t) {
+          float az = atan(rd.x, -rd.z);
+          float alt = asin(clamp(rd.y, -1.0, 1.0));
+          // Place hologram at fixed direction.
+          float az0 = -0.6;
+          float alt0 = 0.18;
+          float dAz = az - az0;
+          if (dAz > 3.14159) dAz -= 6.28318;
+          if (dAz < -3.14159) dAz += 6.28318;
+          float dAlt = alt - alt0;
+          float w = 0.10, h = 0.08;
+          if (abs(dAz) > w || abs(dAlt) > h) return vec3(0.0);
+          // Scanlines.
+          float scan = 0.5 + 0.5 * sin(dAlt * 220.0 + t * 6.0);
+          float flicker = 0.7 + 0.3 * sin(t * 18.0);
+          // Shape: "logo-like" arc.
+          float shape = smoothstep(0.5, 0.45, length(vec2(dAz / w, dAlt / h)));
+          vec3 base = mix(vec3(0.20, 0.95, 1.00),
+                          vec3(1.00, 0.30, 0.80), 0.5 + 0.5 * sin(t * 0.7));
+          return base * shape * scan * flicker * 1.3;
+        }
+
+        // Rain streaks: short diagonal lines as projected directional noise.
+        float rain(vec3 rd, float t) {
+          float az = atan(rd.x, -rd.z);
+          float alt = asin(clamp(rd.y, -1.0, 1.0));
+          // Diagonal streak coordinate.
+          vec2 uv = vec2(az * 8.0 + alt * 1.5, alt * 18.0 + t * 4.0);
+          float r = 0.0;
+          for (int k = 0; k < 2; k++) {
+            float fk = float(k);
+            vec2 cell = floor(uv + vec2(fk * 0.37, 0.0));
+            vec2 fc = fract(uv + vec2(fk * 0.37, 0.0));
+            float h = hash(cell);
+            if (h > 0.94) {
+              float streak = smoothstep(0.04, 0.0, abs(fc.x - 0.5))
+                           * smoothstep(0.45, 0.0, abs(fc.y - 0.5));
+              r += streak * 0.4;
+            }
+          }
+          // Above horizon only.
+          r *= smoothstep(-0.05, 0.20, alt);
+          return r;
+        }
+
+        // Wet street reflection: when looking down, mirror the sky/buildings.
+        vec3 wetStreet(vec3 ro, vec3 rd, float t) {
+          if (rd.y > -0.05) return vec3(0.0);
+          float gt = -ro.y / rd.y;
+          if (gt < 0.0 || gt > 60.0) return vec3(0.0);
+          vec3 gp = ro + rd * gt;
+          // Puddle pattern: brighter in puddle areas.
+          float puddle = fbm(gp.xz * 0.4);
+          puddle = smoothstep(0.45, 0.7, puddle);
+          // Reflected ray (mirror across y=0).
+          vec3 refRd = vec3(rd.x, -rd.y, rd.z);
+          // Sample the ring sky color along reflected direction (cheap).
+          float az = atan(refRd.x, -refRd.z);
+          // Pick a representative neon color based on azimuth.
+          float c = sin(az * 3.0 + t * 0.2) * 0.5 + 0.5;
+          vec3 reflCol = mix(vec3(0.20, 0.05, 0.18),
+                             vec3(1.00, 0.30, 0.80), c);
+          // Mix in cyan glow.
+          reflCol += vec3(0.20, 0.95, 1.00)
+                   * smoothstep(0.5, 1.0, sin(az * 5.0 + t * 0.3) * 0.5 + 0.5)
+                   * 0.4;
+          // Base wet asphalt color.
+          vec3 base = vec3(0.04, 0.03, 0.06);
+          float fog = smoothstep(0.0, 25.0, gt);
+          vec3 col = mix(base, reflCol * 0.5, puddle);
+          // Distance fade into smog.
+          col = mix(col, vec3(0.10, 0.04, 0.15), fog * 0.7);
+          return col;
+        }
+
+        void main() {
+          vec3 rd = normalize(uViewRotation * vWorldDir);
+          vec3 ro = uCamLocal;
+          float t = uTime;
+
+          // ---- Smoggy purple sky with magenta horizon ----
+          float skyT = clamp(rd.y * 0.5 + 0.5, 0.0, 1.0);
+          vec3 skyHigh = vec3(0.04, 0.02, 0.10);
+          vec3 skyMid = vec3(0.18, 0.05, 0.22);
+          vec3 skyLow = vec3(0.45, 0.10, 0.35);
+          vec3 col = mix(skyLow, skyMid, smoothstep(0.50, 0.65, skyT));
+          col = mix(col, skyHigh, smoothstep(0.65, 1.0, skyT));
+
+          // Smog clouds.
+          float smog = fbm(vec2(atan(rd.x, -rd.z) * 2.5,
+                                rd.y * 4.0 + t * 0.05));
+          col = mix(col, vec3(0.20, 0.05, 0.18),
+                    smog * smoothstep(0.0, 0.3, rd.y) * 0.5);
+
+          // ---- Ring of skyscraper silhouettes ----
+          BuildingHit b = cityRing(rd, t);
+          if (b.mask > 0.5) {
+            vec3 buildingCol = vec3(0.020, 0.015, 0.035);
+            // Backlit edge tint
+            buildingCol += vec3(0.06, 0.02, 0.08);
+            // Apply windows.
+            vec3 lit = b.windowCol * b.windowMask * 1.5;
+            col = buildingCol + lit;
+            // Top antenna glow.
+            col += vec3(1.00, 0.30, 0.55) * b.topGlow * 0.4;
+          }
+
+          // ---- Hover-car streaks ----
+          col += hoverCars(rd, t);
+
+          // ---- Holographic billboard ----
+          col += hologram(rd, t);
+
+          // ---- Rain streaks (above horizon, slight bright shimmer) ----
+          col += vec3(0.50, 0.65, 0.95) * rain(rd, t) * 0.6;
+
+          // ---- Wet street (looking down) ----
+          if (rd.y < 0.0) {
+            vec3 streetCol = wetStreet(ro, rd, t);
+            // Replace sky/building color below horizon.
+            float weight = smoothstep(0.0, -0.05, rd.y);
+            col = mix(col, streetCol, weight);
+          }
+
+          // Atmospheric magenta lift.
+          col = mix(col, vec3(0.55, 0.10, 0.45), 0.05);
+
+          // Tone-map.
+          col = col / (col + vec3(1.0));
+          col = pow(col, vec3(0.85));
+
+          gl_FragColor = vec4(col, 1.0);
+        }
+      `,
+      side: THREE.BackSide,
+      depthWrite: false,
+    });
+
+    this._sphere = new THREE.Mesh(geom, mat);
+    this._sphere.renderOrder = -100;
+    this._sphere.frustumCulled = false;
+    this._sphere.raycast = () => {};
+    this.add(this._sphere);
+    this.visible = false;
+  }
+}

--- a/demos/portals/CyberpunkImmersive.js
+++ b/demos/portals/CyberpunkImmersive.js
@@ -207,6 +207,7 @@ export class CyberpunkImmersive extends THREE.Object3D {
           float bestT = 1e9;
           vec3 bestCol = vec3(0.0);
           for (int i = 0; i < 14; i++) {
+            if (i == 10 || i == 11) continue; // park wedge — no building here
             float fi = float(i);
             float seed = fi + 19.0;
             float ang = fi * (6.28318 / 14.0)
@@ -257,6 +258,33 @@ export class CyberpunkImmersive extends THREE.Object3D {
               float topMask = step(0.5, nrm.y);
               c += vec3(1.0, 0.30, 0.55) * topMask
                  * (0.4 + 0.3 * sin(t * 3.0 + seed * 7.0));
+              // ---- Shop fronts on lower 2 stories ----
+              float lowZone = step(uv.y, 0.10) * isSide;
+              vec2 sgrid = vec2(3.0, 2.0);
+              vec2 scell = uv * sgrid;
+              vec2 sf = fract(scell);
+              vec2 si = floor(scell);
+              float swin = step(0.08, sf.x) * step(sf.x, 0.92)
+                         * step(0.15, sf.y) * step(sf.y, 0.92);
+              float doorway = step(abs(sf.x - 0.5), 0.12)
+                            * step(sf.y, 0.55);
+              float shopRoll = hash(si + seed + 13.3);
+              vec3 shopCol = (shopRoll < 0.34)
+                  ? vec3(1.00, 0.80, 0.30)
+                  : (shopRoll < 0.67)
+                      ? vec3(1.00, 0.20, 0.70)
+                      : vec3(0.20, 0.95, 1.00);
+              float interior = 0.65 + 0.35
+                  * sin(t * 3.0 + si.x * 11.0 + si.y * 7.0);
+              float shopMask = swin * (1.0 - doorway * 0.85) * interior;
+              vec3 shopFacade = vec3(0.06, 0.04, 0.05)
+                              + shopCol * shopMask * 2.0;
+              c = mix(c, shopFacade, lowZone);
+              // Store sign band slightly above shop front.
+              float signBand = step(0.105, uv.y) * step(uv.y, 0.135)
+                             * isSide;
+              c += shopCol * signBand
+                 * (1.0 + 0.3 * sin(t * 5.0 + seed));
               bestCol = c;
             }
           }
@@ -299,6 +327,204 @@ export class CyberpunkImmersive extends THREE.Object3D {
               bestCol = base * (0.7 + scan * 0.5) * flicker * shape * 1.4;
             }
           }
+          return vec4(bestCol, bestT);
+        }
+
+        // ---- Street life: cars, hovercars, pedestrians, traffic lights ----
+        // Returns vec4(rgb, t) for the closest hit primitive.
+        vec4 streetLife(vec3 ro, vec3 rd, float t) {
+          float bestT = 1e9;
+          vec3 bestCol = vec3(0.0);
+          vec3 nrm;
+
+          // Ground cars: 8 across two circular lanes, opposite directions.
+          for (int i = 0; i < 8; i++) {
+            float fi = float(i);
+            float lane = mod(fi, 2.0);
+            float r = mix(15.5, 13.8, lane);
+            float dir = mix(1.0, -1.0, lane);
+            float spd = mix(0.20, 0.26, lane);
+            float baseAng = fi * 0.7854 + lane * 0.39;
+            float ang = baseAng + dir * t * spd;
+            // Skip cars currently inside the park wedge.
+            float pd = mod(ang + 1.5708 + 3.14159, 6.28318) - 3.14159;
+            if (abs(pd) < 0.30) continue;
+            vec3 ctr = vec3(cos(ang) * r, -1.40, sin(ang) * r);
+            vec3 hsz = vec3(0.42, 0.18, 0.42);
+            float th = rayBox(ro, rd, ctr, hsz, nrm);
+            if (th > 0.05 && th < bestT) {
+              bestT = th;
+              vec3 fwd = vec3(-sin(ang), 0.0, cos(ang)) * dir;
+              vec3 fwdAxis = (abs(fwd.x) > abs(fwd.z))
+                  ? vec3(sign(fwd.x), 0.0, 0.0)
+                  : vec3(0.0, 0.0, sign(fwd.z));
+              float head = step(0.9, dot(nrm, fwdAxis));
+              float tail = step(0.9, dot(nrm, -fwdAxis));
+              vec3 body = vec3(0.04, 0.03, 0.07);
+              bestCol = body
+                      + vec3(1.00, 0.95, 0.80) * head * 1.8
+                      + vec3(1.00, 0.15, 0.10) * tail * 1.4;
+            }
+          }
+
+          // Hovercars: 4 above ground, opposite layer flow.
+          for (int i = 0; i < 4; i++) {
+            float fi = float(i);
+            float lane = mod(fi, 2.0);
+            float r = mix(12.0, 13.5, lane);
+            float dir = mix(-1.0, 1.0, lane);
+            float spd = mix(0.32, 0.38, lane);
+            float baseAng = fi * 1.5708 + 0.6;
+            float ang = baseAng + dir * t * spd;
+            float pd = mod(ang + 1.5708 + 3.14159, 6.28318) - 3.14159;
+            if (abs(pd) < 0.30) continue;
+            float yH = mix(2.6, 3.6, lane);
+            vec3 ctr = vec3(cos(ang) * r, yH, sin(ang) * r);
+            vec3 hsz = vec3(0.45, 0.16, 0.45);
+            float th = rayBox(ro, rd, ctr, hsz, nrm);
+            if (th > 0.05 && th < bestT) {
+              bestT = th;
+              vec3 fwd = vec3(-sin(ang), 0.0, cos(ang)) * dir;
+              vec3 fwdAxis = (abs(fwd.x) > abs(fwd.z))
+                  ? vec3(sign(fwd.x), 0.0, 0.0)
+                  : vec3(0.0, 0.0, sign(fwd.z));
+              float head = step(0.9, dot(nrm, fwdAxis));
+              float tail = step(0.9, dot(nrm, -fwdAxis));
+              float bottom = step(0.5, -nrm.y);
+              vec3 body = vec3(0.06, 0.05, 0.10);
+              bestCol = body
+                      + vec3(0.20, 0.95, 1.00) * head * 1.6
+                      + vec3(1.00, 0.25, 0.60) * tail * 1.4
+                      + vec3(0.30, 0.95, 1.00) * bottom * 0.7;
+            }
+          }
+
+          // Pedestrians: 12 silhouettes drifting along the sidewalk.
+          for (int i = 0; i < 12; i++) {
+            float fi = float(i);
+            float r = 16.5 + hash(vec2(fi, 7.3)) * 0.7;
+            float dir = (mod(fi, 2.0) < 0.5) ? 1.0 : -1.0;
+            float spd = 0.04 + hash(vec2(fi, 9.1)) * 0.02;
+            float baseAng = fi * 0.5236 + hash(vec2(fi, 3.3)) * 0.3;
+            float ang = baseAng + dir * t * spd;
+            float pd = mod(ang + 1.5708 + 3.14159, 6.28318) - 3.14159;
+            if (abs(pd) < 0.30) continue;
+            float bob = sin(t * 4.0 + fi * 1.7) * 0.04;
+            vec3 ctr = vec3(cos(ang) * r, -1.10 + bob, sin(ang) * r);
+            vec3 hsz = vec3(0.10, 0.32, 0.10);
+            float th = rayBox(ro, rd, ctr, hsz, nrm);
+            if (th > 0.05 && th < bestT) {
+              bestT = th;
+              vec3 hp = ro + rd * th - ctr;
+              float headZ = step(0.22, hp.y);
+              vec3 body = vec3(0.020, 0.018, 0.030);
+              vec3 head = vec3(0.10, 0.08, 0.12);
+              float rim = 1.0 - abs(nrm.y);
+              vec3 neon = vec3(0.45, 0.10, 0.35) * rim * 0.4;
+              bestCol = mix(body, head, headZ) + neon;
+            }
+          }
+
+          // Traffic lights: 4 poles at intersections of the street loop.
+          for (int i = 0; i < 4; i++) {
+            float fi = float(i);
+            float ang = fi * 1.5708 + 0.3927;
+            float r = 14.7;
+            vec3 base = vec3(cos(ang) * r, -1.60, sin(ang) * r);
+            vec3 poleHsz = vec3(0.07, 1.20, 0.07);
+            vec3 poleCtr = base + vec3(0.0, 1.20, 0.0);
+            float th = rayBox(ro, rd, poleCtr, poleHsz, nrm);
+            if (th > 0.05 && th < bestT) {
+              bestT = th;
+              bestCol = vec3(0.04, 0.03, 0.05);
+            }
+            vec3 headHsz = vec3(0.18, 0.18, 0.18);
+            vec3 headCtr = base + vec3(0.0, 2.55, 0.0);
+            float th2 = rayBox(ro, rd, headCtr, headHsz, nrm);
+            if (th2 > 0.05 && th2 < bestT) {
+              bestT = th2;
+              float ph = mod(t + fi * 2.0, 9.0);
+              vec3 lit;
+              if (ph < 3.0) lit = vec3(1.00, 0.10, 0.10);
+              else if (ph < 5.0) lit = vec3(1.00, 0.85, 0.10);
+              else lit = vec3(0.10, 1.00, 0.30);
+              bestCol = vec3(0.04, 0.03, 0.05) + lit * 1.6;
+            }
+          }
+
+          return vec4(bestCol, bestT);
+        }
+
+        // ---- Neon night park: holographic urban green space ----
+        vec4 nightPark(vec3 ro, vec3 rd, float t) {
+          float bestT = 1e9;
+          vec3 bestCol = vec3(0.0);
+          vec3 nrm;
+          // Park sits inside the street ring (cars at r=13.8-15.5) so it
+          // reads as a clear foreground feature, and at azimuth -π/2 so it
+          // lands directly in front of the user (forward = -z, matching the
+          // hologram/sky azimuth convention atan(rd.x, -rd.z)).
+          float parkAng = -1.5708;
+          float parkR = 10.0;
+          vec3 pc = vec3(cos(parkAng) * parkR, -1.6, sin(parkAng) * parkR);
+
+          // Grass slab (6×6, 0.05 tall, emissive cyan-green).
+          float th = rayBox(ro, rd, pc + vec3(0.0, 0.025, 0.0),
+                            vec3(3.0, 0.025, 3.0), nrm);
+          if (th > 0.05 && th < bestT) {
+            bestT = th;
+            bestCol = vec3(0.04, 0.14, 0.10) * 1.3;
+          }
+
+          // Three holographic trees (trunk + canopy).
+          for (int i = 0; i < 3; i++) {
+            float fi = float(i);
+            float ta = -0.7 + fi * 0.7;
+            vec3 tb = pc + vec3(cos(ta) * 2.0, 0.0, sin(ta) * 2.0);
+            th = rayBox(ro, rd, tb + vec3(0.0, 0.75, 0.0),
+                        vec3(0.075, 0.75, 0.075), nrm);
+            if (th > 0.05 && th < bestT) {
+              bestT = th; bestCol = vec3(0.04, 0.03, 0.05);
+            }
+            th = rayBox(ro, rd, tb + vec3(0.0, 1.80, 0.0),
+                        vec3(0.45, 0.30, 0.45), nrm);
+            if (th > 0.05 && th < bestT) {
+              bestT = th;
+              float hue = sin(t * 0.3 + fi * 2.1) * 0.5 + 0.5;
+              bestCol = mix(vec3(1.00, 0.20, 0.80),
+                            vec3(0.20, 1.00, 0.90), hue) * 1.4;
+            }
+          }
+
+          // Holo-statue: tall emissive prism with colour drift.
+          th = rayBox(ro, rd, pc + vec3(0.0, 0.60, 0.0),
+                      vec3(0.15, 0.60, 0.15), nrm);
+          if (th > 0.05 && th < bestT) {
+            bestT = th;
+            vec3 hp = ro + rd * th - (pc + vec3(0.0, 0.60, 0.0));
+            float vGrad = (hp.y + 0.60) / 1.20;
+            float drift = sin(t * 0.5 + vGrad * 4.0) * 0.5 + 0.5;
+            bestCol = mix(vec3(0.20, 0.40, 1.00),
+                          vec3(1.00, 0.20, 0.90), drift) * 1.6;
+          }
+
+          // Two lamp posts (pole + glowing head).
+          for (int i = 0; i < 2; i++) {
+            float fi = float(i);
+            float la = -0.5 + fi * 1.0;
+            vec3 lb = pc + vec3(cos(la) * 2.8, 0.0, sin(la) * 2.8);
+            th = rayBox(ro, rd, lb + vec3(0.0, 1.10, 0.0),
+                        vec3(0.05, 1.10, 0.05), nrm);
+            if (th > 0.05 && th < bestT) {
+              bestT = th; bestCol = vec3(0.04, 0.03, 0.05);
+            }
+            th = rayBox(ro, rd, lb + vec3(0.0, 2.30, 0.0),
+                        vec3(0.12, 0.08, 0.12), nrm);
+            if (th > 0.05 && th < bestT) {
+              bestT = th; bestCol = vec3(1.00, 0.65, 0.20) * 1.5;
+            }
+          }
+
           return vec4(bestCol, bestT);
         }
 
@@ -390,9 +616,10 @@ export class CyberpunkImmersive extends THREE.Object3D {
         }
 
         // Wet street reflection: when looking down, mirror the sky/buildings.
+        // Plane sits at y = -1.6 to match the base of buildings/cars/peds.
         vec3 wetStreet(vec3 ro, vec3 rd, float t) {
           if (rd.y > -0.05) return vec3(0.0);
-          float gt = -ro.y / rd.y;
+          float gt = (-1.6 - ro.y) / rd.y;
           if (gt < 0.0 || gt > 60.0) return vec3(0.0);
           vec3 gp = ro + rd * gt;
           // Puddle pattern: brighter in puddle areas.
@@ -451,6 +678,16 @@ export class CyberpunkImmersive extends THREE.Object3D {
             opaqueT = boardHit.w;
             opaqueCol = boardHit.rgb;
           }
+          vec4 streetHit = streetLife(ro, rd, t);
+          if (streetHit.w < opaqueT) {
+            opaqueT = streetHit.w;
+            opaqueCol = streetHit.rgb;
+          }
+          vec4 parkHit = nightPark(ro, rd, t);
+          if (parkHit.w < opaqueT) {
+            opaqueT = parkHit.w;
+            opaqueCol = parkHit.rgb;
+          }
           if (opaqueT < 1e8) {
             float fogF = smoothstep(8.0, 50.0, opaqueT);
             col = mix(opaqueCol, col, fogF * 0.4);
@@ -467,7 +704,7 @@ export class CyberpunkImmersive extends THREE.Object3D {
 
           // ---- Wet street (looking down) ----
           if (rd.y < 0.0) {
-            float gt = -ro.y / rd.y;
+            float gt = (-1.6 - ro.y) / rd.y;
             if (gt > 0.0 && gt < opaqueT) {
               vec3 streetCol = wetStreet(ro, rd, t);
               float weight = smoothstep(0.0, -0.05, rd.y);

--- a/demos/portals/ForestImmersive.js
+++ b/demos/portals/ForestImmersive.js
@@ -284,6 +284,13 @@ export class ForestImmersive extends THREE.Object3D {
           vec3 rd = normalize(uViewRotation * vWorldDir);
           vec3 ro = uCamLocal;
 
+          // Forward-cone projection for 2D cinematic events (owl, comet, etc.).
+          // Same approach as CosmicImmersive: project ray onto a screen plane
+          // perpendicular to the entry-facing axis (-Z in portal-local space).
+          float forwardness = max(-rd.z, 0.0);
+          vec2 p = rd.xy / max(-rd.z, 0.15);
+          float fwdMask = smoothstep(0.0, 0.3, forwardness);
+
           // ---- Twilight sky gradient ----
           float skyT = clamp(rd.y * 0.5 + 0.5, 0.0, 1.0);
           vec3 skyTop = vec3(0.04, 0.03, 0.16);
@@ -407,6 +414,114 @@ export class ForestImmersive extends THREE.Object3D {
 
           // Fireflies (additive, in 3D).
           col += fireflies(ro, rd, uTime);
+
+          // ---- Owl gliding past every 12s (forward cone) ----
+          if (fwdMask > 0.0) {
+            float owlCycle = 12.0;
+            float owlK = floor(uTime / owlCycle);
+            float owlLocal = uTime - owlK * owlCycle;
+            float owlLife = smoothstep(0.0, 0.3, owlLocal)
+                          * smoothstep(owlCycle, owlCycle - 1.0, owlLocal);
+            if (owlLife > 0.0) {
+              float owlDir = (mod(owlK, 2.0) < 0.5) ? 1.0 : -1.0;
+              float owlBaseX = -1.6 * owlDir + owlDir * owlLocal * 0.32;
+              float owlBaseY = 0.20 + sin(owlLocal * 1.5 + owlK) * 0.03;
+              vec2 owlC = vec2(owlBaseX, owlBaseY);
+              vec2 owlD = p - owlC;
+              // Body silhouette
+              float owlBody = smoothstep(0.025, 0.020, length(owlD * vec2(1.4, 1.0)));
+              // Wings: two flapping arcs
+              float owlFlap = sin(uTime * 6.0 + owlK * 2.0);
+              for (int s = -1; s <= 1; s += 2) {
+                float fs = float(s);
+                vec2 wc = owlC + vec2(fs * 0.05, 0.0);
+                vec2 wd = p - wc;
+                float wAng = fs * (0.6 + owlFlap * 0.5);
+                float wx = wd.x * cos(wAng) - wd.y * sin(wAng);
+                float wy = wd.x * sin(wAng) + wd.y * cos(wAng);
+                float wing = smoothstep(0.05, 0.04, abs(wy))
+                           * smoothstep(0.07, 0.0, wx * fs)
+                           * step(0.0, wx * fs);
+                owlBody = max(owlBody, wing);
+              }
+              col = mix(col, vec3(0.04, 0.04, 0.05), owlBody * owlLife * fwdMask);
+              // Eye glints
+              float owlEye = smoothstep(0.005, 0.0,
+                  length(p - owlC - vec2(0.012, 0.005)))
+                + smoothstep(0.005, 0.0,
+                  length(p - owlC - vec2(-0.012, 0.005)));
+              col += vec3(1.0, 0.85, 0.20) * owlEye * owlLife * 1.5 * fwdMask;
+            }
+          }
+
+          // ---- Comet streaking through canopy every 16s (forward cone) ----
+          if (fwdMask > 0.0) {
+            float cometCycle = 16.0;
+            float cometK = floor(uTime / cometCycle);
+            float cometLocal = uTime - cometK * cometCycle;
+            float cometLife = smoothstep(0.0, 0.2, cometLocal)
+                            * smoothstep(2.5, 0.2, cometLocal);
+            if (cometLife > 0.0) {
+              vec2 cometStart = vec2(1.4, 0.9);
+              vec2 cometEnd   = vec2(-1.4, -0.2);
+              vec2 cometDir = normalize(cometEnd - cometStart);
+              vec2 cometPerp = vec2(-cometDir.y, cometDir.x);
+              vec2 cometPos = mix(cometStart, cometEnd,
+                                  clamp(cometLocal * 0.5, 0.0, 1.0));
+              vec2 cd = p - cometPos;
+              float cAlong = dot(cd, -cometDir);
+              float cAcross = dot(cd, cometPerp);
+              float cHead = smoothstep(0.02, 0.0, length(cd));
+              float cTail = smoothstep(0.005, 0.0, abs(cAcross))
+                          * smoothstep(0.55, 0.0, cAlong)
+                          * step(0.0, cAlong);
+              col += vec3(0.90, 0.85, 1.00) * (cHead * 2.5 + cTail * 1.1)
+                   * cometLife * fwdMask;
+              // Wide soft halo glow
+              col += vec3(0.40, 0.55, 0.85) * smoothstep(0.15, 0.0, length(cd))
+                   * cometLife * 0.4 * fwdMask;
+            }
+          }
+
+          // ---- Lightning storm flashes every 8s (forward cone) ----
+          if (fwdMask > 0.0) {
+            float ltCycle = 8.0;
+            float ltK = floor(uTime / ltCycle);
+            float ltLocal = uTime - ltK * ltCycle;
+            float ltFlash = smoothstep(0.0, 0.05, ltLocal)
+                          * smoothstep(0.5, 0.05, ltLocal);
+            ltFlash *= 0.5 + 0.5 * sin(ltLocal * 60.0);
+            if (ltFlash > 0.0) {
+              // Sky flash (upper region)
+              float ltUpper = smoothstep(-0.4, 0.5, p.y);
+              col += vec3(0.65, 0.75, 0.95) * ltFlash * ltUpper * 0.6 * fwdMask;
+              // Forked bolt on the horizon
+              float ltBx = (hash(vec2(ltK, 17.1)) - 0.5) * 1.4;
+              float ltBolt = smoothstep(0.005, 0.0,
+                  abs(p.x - (ltBx + sin(p.y * 18.0 + ltK) * 0.04)))
+                * smoothstep(0.4, -0.3, p.y) * step(-0.4, p.y);
+              col += vec3(1.0, 1.0, 1.10) * ltBolt * ltFlash * 3.0 * fwdMask;
+            }
+          }
+
+          // ---- Aurora ribbon every 24s (forward cone) ----
+          if (fwdMask > 0.0) {
+            float aurCycle = 24.0;
+            float aurK = floor(uTime / aurCycle);
+            float aurLocal = uTime - aurK * aurCycle;
+            float aurLife = smoothstep(0.0, 2.0, aurLocal)
+                          * smoothstep(8.0, 5.0, aurLocal);
+            if (aurLife > 0.001) {
+              float bandY = 0.55 + sin(p.x * 3.0 + uTime * 0.6) * 0.08
+                                 + sin(p.x * 7.0 + uTime * 0.4) * 0.04;
+              float band = exp(-pow((p.y - bandY) / 0.10, 2.0));
+              float streak = pow(fbm(vec2(p.x * 18.0, p.y * 6.0 - uTime * 0.8)), 1.4);
+              vec3 aurCol = mix(vec3(0.30, 1.00, 0.60),
+                                vec3(0.40, 0.55, 1.00),
+                                0.5 + 0.5 * sin(p.x * 2.0 + uTime * 0.5));
+              col += aurCol * band * streak * aurLife * 1.0 * fwdMask;
+            }
+          }
 
           // Subtle noise to break up bands.
           col += (hash(gl_FragCoord.xy + uTime) - 0.5) * 0.012;

--- a/demos/portals/ForestImmersive.js
+++ b/demos/portals/ForestImmersive.js
@@ -180,20 +180,23 @@ export class ForestImmersive extends THREE.Object3D {
 
         // Test ray against one tree at world xz = pos. Returns hit t (or -1)
         // and writes hit type via outId: 1=trunk, 2=canopy.
-        float rayTree(vec3 ro, vec3 rd, vec2 pos, float scale, out int outId) {
+        float rayTree(vec3 ro, vec3 rd, vec2 pos, float scale,
+                      vec2 lean, float sway, out int outId) {
           outId = 0;
           float best = 1e9;
-          // Trunk from ground up to canopy base.
           float trunkTopY = GROUND_Y + 1.4 * scale;
           float trunkR = 0.10 * scale;
           float t = rayCylinder(ro, rd, pos, trunkR, GROUND_Y, trunkTopY);
           if (t > 0.0 && t < best) { best = t; outId = 1; }
-          // Canopy: 4 stacked spheres, broad at base, narrow at top (pine).
           for (int k = 0; k < 4; k++) {
             float fk = float(k);
             float cy = trunkTopY + (0.4 + fk * 0.55) * scale;
-            float cr = (0.95 - fk * 0.18) * scale;
-            float ts = raySphere(ro, rd, vec3(pos.x, cy, pos.y), cr);
+            float rVar = 0.85 + 0.3 * hash(vec2(pos.x * 7.3 + fk, pos.y * 3.1));
+            float cr = (0.95 - fk * 0.18) * scale * rVar;
+            float hFrac = (fk + 1.0) / 4.0;
+            vec2 off = lean * hFrac + vec2(sway) * hFrac;
+            float ts = raySphere(ro, rd,
+              vec3(pos.x + off.x, cy, pos.y + off.y), cr);
             if (ts > 0.0 && ts < best) { best = ts; outId = 2; }
           }
           return (best < 1e9) ? best : -1.0;
@@ -214,8 +217,12 @@ export class ForestImmersive extends THREE.Object3D {
                 : mix(8.0, 13.0, hash(vec2(fi, 5.1)));
             vec2 pos = vec2(cos(ang), sin(ang)) * radius;
             float scale = 1.6 + hash(vec2(fi, 9.7)) * 1.4;
+            float lAng = hash(vec2(fi, 13.1)) * 6.28318;
+            float lAmt = (hash(vec2(fi, 17.3)) - 0.3) * 0.4 * scale;
+            vec2 lean = vec2(cos(lAng), sin(lAng)) * lAmt;
+            float sway = sin(uTime * 0.5 + hash(vec2(fi, 21.7)) * 6.28) * 0.12;
             int id;
-            float t = rayTree(ro, rd, pos, scale, id);
+            float t = rayTree(ro, rd, pos, scale, lean, sway, id);
             if (t > 0.0 && t < bestT) {
               bestT = t; bestId = id; bestPos = pos; bestScale = scale;
             }
@@ -237,7 +244,9 @@ export class ForestImmersive extends THREE.Object3D {
             float needles = fbm(hp.xz * 6.0 + hp.y * 3.0);
             vec3 base = mix(vec3(0.025, 0.050, 0.028),
                             vec3(0.055, 0.100, 0.050), needles);
-            col = base * (0.45 + topLight * 0.7);
+            float breathe = 0.92 + 0.08 * sin(uTime * 0.6
+              + bestPos.x * 1.3 + bestPos.y * 0.9);
+            col = base * (0.45 + topLight * 0.7) * breathe;
           }
           float fog = smoothstep(3.0, 16.0, bestT);
           col = mix(col, vec3(0.10, 0.08, 0.18), fog * 0.6);
@@ -337,6 +346,20 @@ export class ForestImmersive extends THREE.Object3D {
                 float gn = fbm(gp.xz * 0.4);
                 vec3 ground = mix(vec3(0.03, 0.04, 0.02),
                                   vec3(0.08, 0.07, 0.04), gn);
+                // Creek — winding stream on the forest floor
+                float creekPath = sin(gp.z * 0.7 + 1.5) * 1.8
+                                + sin(gp.z * 0.3) * 2.5;
+                float creekDist = abs(gp.x - creekPath);
+                float creekW = 0.35 + 0.1 * sin(gp.z * 1.2);
+                float creek = smoothstep(creekW, creekW * 0.4, creekDist);
+                if (creek > 0.01) {
+                  vec2 flowUV = gp.xz + vec2(0.0, uTime * 0.2);
+                  float ripple = fbm(flowUV * 4.0);
+                  vec3 water = mix(vec3(0.03, 0.05, 0.12),
+                                   vec3(0.06, 0.10, 0.20), ripple);
+                  water += vec3(0.04, 0.03, 0.08) * ripple;
+                  ground = mix(ground, water, creek);
+                }
                 float fog = smoothstep(0.0, 25.0, t);
                 col = mix(ground, col, fog * 0.7);
               }
@@ -349,6 +372,36 @@ export class ForestImmersive extends THREE.Object3D {
           if (forest.a > 0.0) {
             if (groundT < 0.0 || forest.a < groundT) {
               col = forest.rgb;
+            }
+          }
+
+          // Moonbeams — soft volumetric light shafts through canopy gaps
+          {
+            vec3 mLD = normalize(vec3(-0.45, -0.75, 0.55));
+            for (int b = 0; b < 3; b++) {
+              float fb = float(b);
+              vec3 bO = vec3(sin(fb * 2.4 + 0.8) * 3.5,
+                             GROUND_Y + 5.5,
+                             cos(fb * 2.4 + 0.8) * 3.0);
+              vec3 w = ro - bO;
+              float dd = dot(rd, mLD);
+              float den = 1.0 - dd * dd;
+              if (den > 0.001) {
+                float sC = (dd * dot(w, mLD) - dot(w, rd)) / den;
+                float tC = (dot(w, mLD) - dd * dot(w, rd)) / den;
+                if (sC > 0.5 && tC > 0.0) {
+                  vec3 pR = ro + rd * sC;
+                  vec3 pB = bO + mLD * tC;
+                  float dist = length(pR - pB);
+                  float beam = smoothstep(0.6, 0.0, dist) * 0.12;
+                  beam *= smoothstep(0.0, 1.5, tC) * smoothstep(8.0, 5.0, tC);
+                  beam *= smoothstep(GROUND_Y, GROUND_Y + 0.5, pR.y)
+                        * smoothstep(GROUND_Y + 5.0, GROUND_Y + 2.0, pR.y);
+                  beam *= smoothstep(20.0, 2.0, sC);
+                  if (forest.a > 0.0 && sC > forest.a) beam *= 0.2;
+                  col += vec3(0.50, 0.55, 0.75) * beam;
+                }
+              }
             }
           }
 

--- a/demos/portals/ForestImmersive.js
+++ b/demos/portals/ForestImmersive.js
@@ -1,0 +1,340 @@
+import * as THREE from 'three';
+
+const SPHERE_RADIUS = 50;
+const IMMERSIVE_SCALE = 4.0;
+
+/**
+ * Full-surround twilight forest for "walk-in" mode.
+ * Inverted sphere: twilight sky overhead, ring of pine silhouettes
+ * around the user, fireflies drifting in 3D, distant lightning + moon.
+ */
+export class ForestImmersive extends THREE.Object3D {
+  constructor() {
+    super();
+    this._time = 0;
+    this._buildSphere();
+  }
+
+  show(portalWorldMatrix) {
+    this._entryMatrix = portalWorldMatrix.clone();
+    this._entryMatrixInv = portalWorldMatrix.clone().invert();
+    this.visible = true;
+  }
+
+  hide() {
+    this.visible = false;
+  }
+
+  update(dt, camera) {
+    if (!this.visible) return;
+    this._time += dt;
+
+    const mat = this._sphere.material;
+    mat.uniforms.uTime.value = this._time;
+
+    if (camera) {
+      const camWorld = camera.getWorldPosition(new THREE.Vector3());
+      const camLocal = camWorld.clone().applyMatrix4(this._entryMatrixInv);
+      mat.uniforms.uCamLocal.value.copy(camLocal);
+
+      const portalQuat = new THREE.Quaternion().setFromRotationMatrix(
+        this._entryMatrix
+      );
+      const portalQuatInv = portalQuat.clone().invert();
+      const camQuat = camera.getWorldQuaternion(new THREE.Quaternion());
+      const localQuat = portalQuatInv.multiply(camQuat);
+      const rotMat4 = new THREE.Matrix4().makeRotationFromQuaternion(localQuat);
+      mat.uniforms.uViewRotation.value.setFromMatrix4(rotMat4);
+    }
+
+    if (camera) {
+      camera.getWorldPosition(this.position);
+    }
+  }
+
+  _buildSphere() {
+    const geom = new THREE.SphereGeometry(SPHERE_RADIUS, 64, 32);
+
+    const mat = new THREE.ShaderMaterial({
+      uniforms: {
+        uTime: {value: 0},
+        uCamLocal: {value: new THREE.Vector3(0, 0, 1.6)},
+        uViewRotation: {value: new THREE.Matrix3()},
+      },
+      vertexShader: /* glsl */ `
+        varying vec3 vWorldDir;
+        void main() {
+          vWorldDir = normalize(position);
+          gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        }
+      `,
+      fragmentShader: /* glsl */ `
+        precision highp float;
+        uniform float uTime;
+        uniform vec3 uCamLocal;
+        uniform mat3 uViewRotation;
+        varying vec3 vWorldDir;
+
+        float hash(vec2 p) {
+          p = fract(p * vec2(123.34, 456.21));
+          p += dot(p, p + 45.32);
+          return fract(p.x * p.y);
+        }
+        float hash3(vec3 p) {
+          p = fract(p * vec3(123.34, 456.21, 789.53));
+          p += dot(p, p.yzx + 45.32);
+          return fract(p.x * p.y * p.z);
+        }
+        float noise(vec2 p) {
+          vec2 i = floor(p);
+          vec2 f = fract(p);
+          float a = hash(i);
+          float b = hash(i + vec2(1.0, 0.0));
+          float c = hash(i + vec2(0.0, 1.0));
+          float d = hash(i + vec2(1.0, 1.0));
+          vec2 u = f * f * (3.0 - 2.0 * f);
+          return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x)
+                                + (d - b) * u.x * u.y;
+        }
+        float noise3(vec3 p) {
+          vec3 i = floor(p);
+          vec3 f = fract(p);
+          vec3 u = f * f * (3.0 - 2.0 * f);
+          return mix(
+            mix(mix(hash3(i), hash3(i + vec3(1,0,0)), u.x),
+                mix(hash3(i + vec3(0,1,0)), hash3(i + vec3(1,1,0)), u.x), u.y),
+            mix(mix(hash3(i + vec3(0,0,1)), hash3(i + vec3(1,0,1)), u.x),
+                mix(hash3(i + vec3(0,1,1)), hash3(i + vec3(1,1,1)), u.x), u.y),
+            u.z);
+        }
+        float fbm(vec2 p) {
+          float v = 0.0; float a = 0.5;
+          for (int i = 0; i < 4; i++) {
+            v += a * noise(p); p *= 2.07; a *= 0.5;
+          }
+          return v;
+        }
+        float fbm3(vec3 p) {
+          float v = 0.0; float a = 0.5;
+          for (int i = 0; i < 4; i++) {
+            v += a * noise3(p); p *= 2.07; a *= 0.5;
+          }
+          return v;
+        }
+
+        float starsLayer(vec3 rd, float density, float threshold) {
+          vec3 a = abs(rd);
+          float sum = a.x + a.y + a.z;
+          vec2 oct = rd.xz / sum;
+          if (rd.y < 0.0) {
+            oct = (1.0 - abs(oct.yx)) * vec2(oct.x >= 0.0 ? 1.0 : -1.0,
+                                              oct.y >= 0.0 ? 1.0 : -1.0);
+          }
+          vec2 uv = oct * 0.5 + 0.5;
+          vec2 g = floor(uv * density);
+          vec2 f = fract(uv * density);
+          float h = hash(g);
+          if (h < threshold) return 0.0;
+          vec2 jitter = vec2(hash(g + 1.7), hash(g + 7.3)) * 0.6 + 0.2;
+          float d = length(f - jitter);
+          return smoothstep(0.05, 0.0, d);
+        }
+
+        // Tree silhouette in cylindrical (azimuth, height) space.
+        // Returns ~1 inside trunk/canopy.
+        float treeAt(float az, float y, float seed, float dist) {
+          // Trunk centered at azimuth 0, with width that tapers up.
+          float trunkW = 0.012 * (1.0 - smoothstep(0.0, 0.85, y) * 0.55);
+          float trunk = step(abs(az), trunkW)
+                      * step(0.0, y) * step(y, 0.85);
+          // Pine canopy: triangular, broadest at base.
+          float canopyTop = 1.05 + hash(vec2(seed, 1.7)) * 0.20;
+          float canopyBase = 0.35;
+          float canopyH = canopyTop - canopyBase;
+          float canopySlope = (canopyTop - y) / canopyH;
+          float canopyW = 0.085 * canopySlope;
+          float canopy = step(abs(az), canopyW)
+                       * step(canopyBase, y) * step(y, canopyTop);
+          // Add slight noise jitter to canopy edge.
+          float edgeNoise = (hash(vec2(seed * 13.7, floor(y * 60.0))) - 0.5) * 0.012;
+          canopy *= step(abs(az) + edgeNoise, canopyW);
+          return clamp(trunk + canopy, 0.0, 1.0);
+        }
+
+        // Ring of trees around the user.
+        // azimuth in [-PI, PI], altitude in radians (0 = horizon).
+        // Returns combined silhouette mask (0..1), output greyscale tint.
+        vec3 forestRing(vec3 rd) {
+          float az = atan(rd.x, -rd.z);    // azimuth, 0 = forward
+          float alt = asin(clamp(rd.y, -1.0, 1.0));
+          // Project to cylindrical (treeY around 0..1.2 maps to alt 0..~0.5).
+          // Each tree occupies a slice of azimuth space.
+          float density = 28.0;            // trees around full circle
+          float slice = az * density / (2.0 * 3.14159265);
+          float cellIdx = floor(slice);
+          float local = fract(slice) - 0.5; // azimuth-within-slice in [-0.5, 0.5]
+          float seed = cellIdx + 17.0;
+          // Each tree gets a random horizontal jitter and depth (size).
+          float jitter = (hash(vec2(seed, 3.1)) - 0.5) * 0.5;
+          float distVar = 0.65 + hash(vec2(seed, 5.7)) * 0.7; // 0.65..1.35
+
+          // Map altitude to "tree height coord" (0 at horizon, ~1 at top of canopy).
+          // Closer trees rise higher in the FOV.
+          float y = alt / (0.32 / distVar);
+          float az2 = local * 0.18 * distVar;
+
+          float m = treeAt(az2, y, seed, distVar);
+          // Slight neighbour overlap for variety.
+          float seedR = cellIdx + 18.0;
+          float jitterR = (hash(vec2(seedR, 3.1)) - 0.5) * 0.5;
+          float distR = 0.65 + hash(vec2(seedR, 5.7)) * 0.7;
+          float yR = alt / (0.32 / distR);
+          float az2R = (local - 1.0) * 0.18 * distR;
+          float mR = treeAt(az2R, yR, seedR, distR);
+
+          float mask = max(m, mR);
+          // Color: very dark, slight green
+          vec3 trunkCol = vec3(0.020, 0.025, 0.015);
+          // Backlit edge: faint cool rim from sky behind.
+          float rim = (1.0 - mask) * 0.0;
+          return mix(vec3(0.0), trunkCol, mask) + vec3(0.0, rim * 0.04, rim * 0.06);
+        }
+
+        // Fireflies: cloud of point lights in a 3D volume around the user.
+        vec3 fireflies(vec3 ro, vec3 rd, float t) {
+          vec3 col = vec3(0.0);
+          // Step along ray for a few segments to find close fireflies.
+          for (int i = 0; i < 12; i++) {
+            float fi = float(i);
+            float seed = fi * 17.7;
+            // Position drifts slowly in 3D.
+            vec3 pos = vec3(
+              sin(t * 0.4 + seed) * 6.0 + cos(t * 0.13 + seed * 1.3) * 3.0,
+              0.4 + sin(t * 0.7 + seed * 0.9) * 0.6 + 0.4,
+              cos(t * 0.5 + seed * 1.1) * 6.0 + sin(t * 0.17 + seed) * 3.0);
+            // Closest distance from ray to fly.
+            vec3 oc = pos - ro;
+            float along = dot(oc, rd);
+            if (along < 0.2 || along > 12.0) continue;
+            vec3 proj = ro + rd * along;
+            float d = length(pos - proj);
+            float pulse = 0.6 + 0.4 * sin(t * 4.0 + seed * 7.0);
+            float intensity = smoothstep(0.08, 0.0, d) * pulse;
+            // Distance falloff
+            intensity *= 1.0 / (1.0 + along * 0.3);
+            col += vec3(0.85, 1.00, 0.45) * intensity * 0.8;
+          }
+          return col;
+        }
+
+        float raySphere(vec3 ro, vec3 rd, vec3 c, float rad) {
+          vec3 oc = ro - c;
+          float b = dot(oc, rd);
+          float d = b * b - (dot(oc, oc) - rad * rad);
+          if (d < 0.0) return -1.0;
+          return -b - sqrt(d);
+        }
+
+        void main() {
+          vec3 rd = normalize(uViewRotation * vWorldDir);
+          vec3 ro = uCamLocal;
+
+          // ---- Twilight sky gradient ----
+          float skyT = clamp(rd.y * 0.5 + 0.5, 0.0, 1.0);
+          vec3 skyTop = vec3(0.04, 0.03, 0.16);
+          vec3 skyMid = vec3(0.10, 0.07, 0.28);
+          vec3 skyLow = vec3(0.28, 0.16, 0.32);
+          vec3 col = mix(skyLow, skyMid, smoothstep(0.45, 0.65, skyT));
+          col = mix(col, skyTop, smoothstep(0.65, 1.0, skyT));
+
+          // Crescent moon high in the sky.
+          {
+            vec3 moonDir = normalize(vec3(0.45, 0.75, -0.55));
+            float ang = dot(rd, moonDir);
+            float halo = smoothstep(0.985, 1.0, ang);
+            float disc = smoothstep(0.997, 0.9985, ang);
+            // Crescent: subtract offset disc.
+            vec3 biteDir = normalize(moonDir + vec3(0.04, 0.02, 0.0));
+            float bite = smoothstep(0.997, 0.9985, dot(rd, biteDir));
+            col += vec3(0.85, 0.85, 1.00) * halo * 0.5;
+            col += vec3(1.00, 1.00, 0.95) * max(disc - bite, 0.0) * 1.3;
+          }
+
+          // Faint stars (only above horizon).
+          if (rd.y > 0.0) {
+            float s1 = starsLayer(rd, 80.0, 0.985);
+            float s2 = starsLayer(rd, 180.0, 0.992);
+            col += vec3(0.85, 0.90, 1.00) * (s1 * 0.6 + s2 * 0.45)
+                 * smoothstep(0.0, 0.4, rd.y);
+          }
+
+          // Distant lightning flashes on the horizon (occasional).
+          {
+            float beat = floor(uTime * 0.4);
+            float flashSeed = hash(vec2(beat, 11.3));
+            if (flashSeed > 0.78) {
+              float local = fract(uTime * 0.4);
+              float flash = exp(-local * 8.0) * smoothstep(0.0, 0.05, local);
+              float dirSeed = hash(vec2(beat, 23.7));
+              vec3 lightDir = normalize(vec3(
+                  sin(dirSeed * 6.28) * 0.9, 0.05, -cos(dirSeed * 6.28) * 0.9));
+              float ang = dot(rd, lightDir);
+              float glow = smoothstep(0.6, 1.0, ang) * smoothstep(-0.05, 0.15, rd.y);
+              col += vec3(0.55, 0.65, 1.00) * glow * flash * 0.8;
+            }
+          }
+
+          // ---- Drifting mist (low fog) ----
+          float mistY = smoothstep(0.15, -0.1, rd.y); // strongest near horizon and below
+          float mist = fbm3(rd * 4.0 + vec3(uTime * 0.05, 0.0, uTime * 0.03));
+          col = mix(col, vec3(0.12, 0.10, 0.20), mistY * mist * 0.55);
+
+          // ---- Ring of pine trees around the user ----
+          // Trees occupy lower hemisphere (rd.y < ~0.5).
+          if (rd.y < 0.6) {
+            vec3 forest = forestRing(rd);
+            // Only apply where forest is "in front" of sky band.
+            float forestMask = max(max(forest.r, forest.g), forest.b);
+            col = mix(col, forest, smoothstep(0.6, 0.5, rd.y));
+          }
+
+          // ---- Ground: very dark forest floor ----
+          if (rd.y < 0.0) {
+            // Raycast ray down to y=0 to find ground hit, then noise it.
+            float t = -ro.y / rd.y;
+            if (t > 0.0 && t < 200.0) {
+              vec3 gp = ro + rd * t;
+              float gn = fbm(gp.xz * 0.4);
+              vec3 ground = mix(vec3(0.03, 0.04, 0.02),
+                                vec3(0.08, 0.07, 0.04), gn);
+              // Distance fade into mist
+              float fog = smoothstep(0.0, 25.0, t);
+              col = mix(ground, col, fog * 0.7);
+            }
+          }
+
+          // Fireflies (additive, in 3D).
+          col += fireflies(ro, rd, uTime);
+
+          // Subtle noise to break up bands.
+          col += (hash(gl_FragCoord.xy + uTime) - 0.5) * 0.012;
+
+          // Tone-map.
+          col = col / (col + vec3(1.0));
+          col = pow(col, vec3(0.85));
+
+          gl_FragColor = vec4(col, 1.0);
+        }
+      `,
+      side: THREE.BackSide,
+      depthWrite: false,
+    });
+
+    this._sphere = new THREE.Mesh(geom, mat);
+    this._sphere.renderOrder = -100;
+    this._sphere.frustumCulled = false;
+    this._sphere.raycast = () => {};
+    this.add(this._sphere);
+    this.visible = false;
+  }
+}

--- a/demos/portals/ForestImmersive.js
+++ b/demos/portals/ForestImmersive.js
@@ -15,9 +15,15 @@ export class ForestImmersive extends THREE.Object3D {
     this._buildSphere();
   }
 
-  show(portalWorldMatrix) {
-    this._entryMatrix = portalWorldMatrix.clone();
-    this._entryMatrixInv = portalWorldMatrix.clone().invert();
+  show(portalWorldMatrix, fromSide = 'front') {
+    let m = portalWorldMatrix.clone();
+    if (fromSide === 'back') {
+      // User entered through the back face of the portal — apply a 180° yaw
+      // so they spawn facing the scene rather than the wall behind it.
+      m.multiply(new THREE.Matrix4().makeRotationY(Math.PI));
+    }
+    this._entryMatrix = m;
+    this._entryMatrixInv = m.clone().invert();
     this.visible = true;
   }
 

--- a/demos/portals/ForestImmersive.js
+++ b/demos/portals/ForestImmersive.js
@@ -429,31 +429,31 @@ export class ForestImmersive extends THREE.Object3D {
               vec2 owlC = vec2(owlBaseX, owlBaseY);
               vec2 owlD = p - owlC;
               // Body silhouette
-              float owlBody = smoothstep(0.10, 0.085, length(owlD * vec2(1.4, 1.0)));
+              float owlBody = smoothstep(0.025, 0.020, length(owlD * vec2(1.4, 1.0)));
               // Wings: two flapping arcs
               float owlFlap = sin(uTime * 6.0 + owlK * 2.0);
               for (int s = -1; s <= 1; s += 2) {
                 float fs = float(s);
-                vec2 wc = owlC + vec2(fs * 0.18, 0.0);
+                vec2 wc = owlC + vec2(fs * 0.05, 0.0);
                 vec2 wd = p - wc;
                 float wAng = fs * (0.6 + owlFlap * 0.5);
                 float wx = wd.x * cos(wAng) - wd.y * sin(wAng);
                 float wy = wd.x * sin(wAng) + wd.y * cos(wAng);
-                float wing = smoothstep(0.18, 0.14, abs(wy))
-                           * smoothstep(0.25, 0.0, wx * fs)
+                float wing = smoothstep(0.05, 0.04, abs(wy))
+                           * smoothstep(0.07, 0.0, wx * fs)
                            * step(0.0, wx * fs);
                 owlBody = max(owlBody, wing);
               }
               // Faint warm halo so the dark silhouette reads against night sky.
-              float owlHalo = smoothstep(0.32, 0.10,
+              float owlHalo = smoothstep(0.08, 0.025,
                   length(owlD * vec2(1.2, 1.0)));
-              col += vec3(0.25, 0.20, 0.12) * owlHalo * owlLife * fwdMask * 0.18;
+              col += vec3(0.25, 0.20, 0.12) * owlHalo * owlLife * fwdMask * 0.25;
               col = mix(col, vec3(0.04, 0.04, 0.05), owlBody * owlLife * fwdMask);
               // Eye glints
-              float owlEye = smoothstep(0.018, 0.0,
-                  length(p - owlC - vec2(0.045, 0.020)))
-                + smoothstep(0.018, 0.0,
-                  length(p - owlC - vec2(-0.045, 0.020)));
+              float owlEye = smoothstep(0.005, 0.0,
+                  length(p - owlC - vec2(0.012, 0.005)))
+                + smoothstep(0.005, 0.0,
+                  length(p - owlC - vec2(-0.012, 0.005)));
               col += vec3(1.0, 0.85, 0.20) * owlEye * owlLife * 1.5 * fwdMask;
             }
           }

--- a/demos/portals/ForestImmersive.js
+++ b/demos/portals/ForestImmersive.js
@@ -429,27 +429,31 @@ export class ForestImmersive extends THREE.Object3D {
               vec2 owlC = vec2(owlBaseX, owlBaseY);
               vec2 owlD = p - owlC;
               // Body silhouette
-              float owlBody = smoothstep(0.025, 0.020, length(owlD * vec2(1.4, 1.0)));
+              float owlBody = smoothstep(0.10, 0.085, length(owlD * vec2(1.4, 1.0)));
               // Wings: two flapping arcs
               float owlFlap = sin(uTime * 6.0 + owlK * 2.0);
               for (int s = -1; s <= 1; s += 2) {
                 float fs = float(s);
-                vec2 wc = owlC + vec2(fs * 0.05, 0.0);
+                vec2 wc = owlC + vec2(fs * 0.18, 0.0);
                 vec2 wd = p - wc;
                 float wAng = fs * (0.6 + owlFlap * 0.5);
                 float wx = wd.x * cos(wAng) - wd.y * sin(wAng);
                 float wy = wd.x * sin(wAng) + wd.y * cos(wAng);
-                float wing = smoothstep(0.05, 0.04, abs(wy))
-                           * smoothstep(0.07, 0.0, wx * fs)
+                float wing = smoothstep(0.18, 0.14, abs(wy))
+                           * smoothstep(0.25, 0.0, wx * fs)
                            * step(0.0, wx * fs);
                 owlBody = max(owlBody, wing);
               }
+              // Faint warm halo so the dark silhouette reads against night sky.
+              float owlHalo = smoothstep(0.32, 0.10,
+                  length(owlD * vec2(1.2, 1.0)));
+              col += vec3(0.25, 0.20, 0.12) * owlHalo * owlLife * fwdMask * 0.18;
               col = mix(col, vec3(0.04, 0.04, 0.05), owlBody * owlLife * fwdMask);
               // Eye glints
-              float owlEye = smoothstep(0.005, 0.0,
-                  length(p - owlC - vec2(0.012, 0.005)))
-                + smoothstep(0.005, 0.0,
-                  length(p - owlC - vec2(-0.012, 0.005)));
+              float owlEye = smoothstep(0.018, 0.0,
+                  length(p - owlC - vec2(0.045, 0.020)))
+                + smoothstep(0.018, 0.0,
+                  length(p - owlC - vec2(-0.045, 0.020)));
               col += vec3(1.0, 0.85, 0.20) * owlEye * owlLife * 1.5 * fwdMask;
             }
           }

--- a/demos/portals/ForestImmersive.js
+++ b/demos/portals/ForestImmersive.js
@@ -40,10 +40,13 @@ export class ForestImmersive extends THREE.Object3D {
       const portalQuat = new THREE.Quaternion().setFromRotationMatrix(
         this._entryMatrix
       );
+      // vWorldDir is in world space (sphere is at world position = camera with
+      // no rotation). To get a portal-local ray direction we only need to undo
+      // the portal's own rotation — the camera quaternion does NOT belong here.
       const portalQuatInv = portalQuat.clone().invert();
-      const camQuat = camera.getWorldQuaternion(new THREE.Quaternion());
-      const localQuat = portalQuatInv.multiply(camQuat);
-      const rotMat4 = new THREE.Matrix4().makeRotationFromQuaternion(localQuat);
+      const rotMat4 = new THREE.Matrix4().makeRotationFromQuaternion(
+        portalQuatInv
+      );
       mat.uniforms.uViewRotation.value.setFromMatrix4(rotMat4);
     }
 
@@ -140,64 +143,99 @@ export class ForestImmersive extends THREE.Object3D {
           return smoothstep(0.05, 0.0, d);
         }
 
-        // Tree silhouette in cylindrical (azimuth, height) space.
-        // Returns ~1 inside trunk/canopy.
-        float treeAt(float az, float y, float seed, float dist) {
-          // Trunk centered at azimuth 0, with width that tapers up.
-          float trunkW = 0.012 * (1.0 - smoothstep(0.0, 0.85, y) * 0.55);
-          float trunk = step(abs(az), trunkW)
-                      * step(0.0, y) * step(y, 0.85);
-          // Pine canopy: triangular, broadest at base.
-          float canopyTop = 1.05 + hash(vec2(seed, 1.7)) * 0.20;
-          float canopyBase = 0.35;
-          float canopyH = canopyTop - canopyBase;
-          float canopySlope = (canopyTop - y) / canopyH;
-          float canopyW = 0.085 * canopySlope;
-          float canopy = step(abs(az), canopyW)
-                       * step(canopyBase, y) * step(y, canopyTop);
-          // Add slight noise jitter to canopy edge.
-          float edgeNoise = (hash(vec2(seed * 13.7, floor(y * 60.0))) - 0.5) * 0.012;
-          canopy *= step(abs(az) + edgeNoise, canopyW);
-          return clamp(trunk + canopy, 0.0, 1.0);
+        float raySphere(vec3 ro, vec3 rd, vec3 c, float rad) {
+          vec3 oc = ro - c;
+          float b = dot(oc, rd);
+          float d = b * b - (dot(oc, oc) - rad * rad);
+          if (d < 0.0) return -1.0;
+          return -b - sqrt(d);
         }
 
-        // Ring of trees around the user.
-        // azimuth in [-PI, PI], altitude in radians (0 = horizon).
-        // Returns combined silhouette mask (0..1), output greyscale tint.
-        vec3 forestRing(vec3 rd) {
-          float az = atan(rd.x, -rd.z);    // azimuth, 0 = forward
-          float alt = asin(clamp(rd.y, -1.0, 1.0));
-          // Project to cylindrical (treeY around 0..1.2 maps to alt 0..~0.5).
-          // Each tree occupies a slice of azimuth space.
-          float density = 28.0;            // trees around full circle
-          float slice = az * density / (2.0 * 3.14159265);
-          float cellIdx = floor(slice);
-          float local = fract(slice) - 0.5; // azimuth-within-slice in [-0.5, 0.5]
-          float seed = cellIdx + 17.0;
-          // Each tree gets a random horizontal jitter and depth (size).
-          float jitter = (hash(vec2(seed, 3.1)) - 0.5) * 0.5;
-          float distVar = 0.65 + hash(vec2(seed, 5.7)) * 0.7; // 0.65..1.35
+        // Ray–vertical-cylinder intersection. Cylinder axis = Y, at xz=c,
+        // radius r, between yMin and yMax. Returns nearest positive t or -1.
+        float rayCylinder(vec3 ro, vec3 rd, vec2 c, float r,
+                          float yMin, float yMax) {
+          vec2 d = rd.xz;
+          vec2 oc = ro.xz - c;
+          float a = dot(d, d);
+          if (a < 1e-6) return -1.0;
+          float b = dot(oc, d);
+          float disc = b * b - a * (dot(oc, oc) - r * r);
+          if (disc < 0.0) return -1.0;
+          float t = (-b - sqrt(disc)) / a;
+          if (t < 0.0) return -1.0;
+          float hy = ro.y + rd.y * t;
+          if (hy < yMin || hy > yMax) return -1.0;
+          return t;
+        }
 
-          // Map altitude to "tree height coord" (0 at horizon, ~1 at top of canopy).
-          // Closer trees rise higher in the FOV.
-          float y = alt / (0.32 / distVar);
-          float az2 = local * 0.18 * distVar;
+        // GROUND_Y is 1.6m below eye level (portal-local origin = eye level).
+        const float GROUND_Y = -1.6;
 
-          float m = treeAt(az2, y, seed, distVar);
-          // Slight neighbour overlap for variety.
-          float seedR = cellIdx + 18.0;
-          float jitterR = (hash(vec2(seedR, 3.1)) - 0.5) * 0.5;
-          float distR = 0.65 + hash(vec2(seedR, 5.7)) * 0.7;
-          float yR = alt / (0.32 / distR);
-          float az2R = (local - 1.0) * 0.18 * distR;
-          float mR = treeAt(az2R, yR, seedR, distR);
+        // Test ray against one tree at world xz = pos. Returns hit t (or -1)
+        // and writes hit type via outId: 1=trunk, 2=canopy.
+        float rayTree(vec3 ro, vec3 rd, vec2 pos, float scale, out int outId) {
+          outId = 0;
+          float best = 1e9;
+          // Trunk from ground up to canopy base.
+          float trunkTopY = GROUND_Y + 1.4 * scale;
+          float trunkR = 0.10 * scale;
+          float t = rayCylinder(ro, rd, pos, trunkR, GROUND_Y, trunkTopY);
+          if (t > 0.0 && t < best) { best = t; outId = 1; }
+          // Canopy: 4 stacked spheres, broad at base, narrow at top (pine).
+          for (int k = 0; k < 4; k++) {
+            float fk = float(k);
+            float cy = trunkTopY + (0.4 + fk * 0.55) * scale;
+            float cr = (0.95 - fk * 0.18) * scale;
+            float ts = raySphere(ro, rd, vec3(pos.x, cy, pos.y), cr);
+            if (ts > 0.0 && ts < best) { best = ts; outId = 2; }
+          }
+          return (best < 1e9) ? best : -1.0;
+        }
 
-          float mask = max(m, mR);
-          // Color: very dark, slight green
-          vec3 trunkCol = vec3(0.020, 0.025, 0.015);
-          // Backlit edge: faint cool rim from sky behind.
-          float rim = (1.0 - mask) * 0.0;
-          return mix(vec3(0.0), trunkCol, mask) + vec3(0.0, rim * 0.04, rim * 0.06);
+        // Forest: 16 fixed trees around the portal-local origin. Positions are
+        // hashed from index, NOT relative to user — they stay put as user walks.
+        vec4 forest3D(vec3 ro, vec3 rd) {
+          float bestT = 1e9; int bestId = 0; vec2 bestPos = vec2(0.0);
+          float bestScale = 1.0;
+          for (int i = 0; i < 18; i++) {
+            float fi = float(i);
+            // Two concentric rings of trees: 8 inner (4-7m), 10 outer (8-13m).
+            float ringT = (fi < 8.0) ? fi / 8.0 : (fi - 8.0) / 10.0;
+            float ang = ringT * 6.28318 + hash(vec2(fi, 1.7)) * 0.6;
+            float radius = (fi < 8.0)
+                ? mix(4.0, 7.0, hash(vec2(fi, 3.3)))
+                : mix(8.0, 13.0, hash(vec2(fi, 5.1)));
+            vec2 pos = vec2(cos(ang), sin(ang)) * radius;
+            float scale = 1.6 + hash(vec2(fi, 9.7)) * 1.4;
+            int id;
+            float t = rayTree(ro, rd, pos, scale, id);
+            if (t > 0.0 && t < bestT) {
+              bestT = t; bestId = id; bestPos = pos; bestScale = scale;
+            }
+          }
+          if (bestId == 0) return vec4(0.0, 0.0, 0.0, -1.0);
+          vec3 hp = ro + rd * bestT;
+          vec3 col;
+          if (bestId == 1) {
+            float bark = fbm(vec2(hp.y * 6.0,
+                            atan(hp.z - bestPos.y, hp.x - bestPos.x) * 4.0));
+            col = mix(vec3(0.030, 0.022, 0.015),
+                      vec3(0.075, 0.055, 0.035), bark);
+          } else {
+            vec3 trunkTop = vec3(bestPos.x,
+                                 GROUND_Y + 1.4 * bestScale,
+                                 bestPos.y);
+            vec3 n = normalize(hp - trunkTop);
+            float topLight = max(n.y, 0.0);
+            float needles = fbm(hp.xz * 6.0 + hp.y * 3.0);
+            vec3 base = mix(vec3(0.025, 0.050, 0.028),
+                            vec3(0.055, 0.100, 0.050), needles);
+            col = base * (0.45 + topLight * 0.7);
+          }
+          float fog = smoothstep(3.0, 16.0, bestT);
+          col = mix(col, vec3(0.10, 0.08, 0.18), fog * 0.6);
+          return vec4(col, bestT);
         }
 
         // Fireflies: cloud of point lights in a 3D volume around the user.
@@ -225,14 +263,6 @@ export class ForestImmersive extends THREE.Object3D {
             col += vec3(0.85, 1.00, 0.45) * intensity * 0.8;
           }
           return col;
-        }
-
-        float raySphere(vec3 ro, vec3 rd, vec3 c, float rad) {
-          vec3 oc = ro - c;
-          float b = dot(oc, rd);
-          float d = b * b - (dot(oc, oc) - rad * rad);
-          if (d < 0.0) return -1.0;
-          return -b - sqrt(d);
         }
 
         void main() {
@@ -289,27 +319,30 @@ export class ForestImmersive extends THREE.Object3D {
           float mist = fbm3(rd * 4.0 + vec3(uTime * 0.05, 0.0, uTime * 0.03));
           col = mix(col, vec3(0.12, 0.10, 0.20), mistY * mist * 0.55);
 
-          // ---- Ring of pine trees around the user ----
-          // Trees occupy lower hemisphere (rd.y < ~0.5).
-          if (rd.y < 0.6) {
-            vec3 forest = forestRing(rd);
-            // Only apply where forest is "in front" of sky band.
-            float forestMask = max(max(forest.r, forest.g), forest.b);
-            col = mix(col, forest, smoothstep(0.6, 0.5, rd.y));
+          // ---- Ground at y=-1.6 (1.6m below eye level) ----
+          float groundT = -1.0;
+          {
+            float gy = -1.6;
+            if (rd.y < -0.001 && ro.y > gy) {
+              float t = (gy - ro.y) / rd.y;
+              if (t > 0.0 && t < 200.0) {
+                groundT = t;
+                vec3 gp = ro + rd * t;
+                float gn = fbm(gp.xz * 0.4);
+                vec3 ground = mix(vec3(0.03, 0.04, 0.02),
+                                  vec3(0.08, 0.07, 0.04), gn);
+                float fog = smoothstep(0.0, 25.0, t);
+                col = mix(ground, col, fog * 0.7);
+              }
+            }
           }
 
-          // ---- Ground: very dark forest floor ----
-          if (rd.y < 0.0) {
-            // Raycast ray down to y=0 to find ground hit, then noise it.
-            float t = -ro.y / rd.y;
-            if (t > 0.0 && t < 200.0) {
-              vec3 gp = ro + rd * t;
-              float gn = fbm(gp.xz * 0.4);
-              vec3 ground = mix(vec3(0.03, 0.04, 0.02),
-                                vec3(0.08, 0.07, 0.04), gn);
-              // Distance fade into mist
-              float fog = smoothstep(0.0, 25.0, t);
-              col = mix(ground, col, fog * 0.7);
+          // ---- 3D pine trees scattered around user (real raycast) ----
+          // Trees occlude sky AND ground when nearer than groundT.
+          vec4 forest = forest3D(ro, rd);
+          if (forest.a > 0.0) {
+            if (groundT < 0.0 || forest.a < groundT) {
+              col = forest.rgb;
             }
           }
 

--- a/demos/portals/LavaImmersive.js
+++ b/demos/portals/LavaImmersive.js
@@ -41,9 +41,9 @@ export class LavaImmersive extends THREE.Object3D {
         this._entryMatrix
       );
       const portalQuatInv = portalQuat.clone().invert();
-      const camQuat = camera.getWorldQuaternion(new THREE.Quaternion());
-      const localQuat = portalQuatInv.multiply(camQuat);
-      const rotMat4 = new THREE.Matrix4().makeRotationFromQuaternion(localQuat);
+      const rotMat4 = new THREE.Matrix4().makeRotationFromQuaternion(
+        portalQuatInv
+      );
       mat.uniforms.uViewRotation.value.setFromMatrix4(rotMat4);
     }
 
@@ -172,6 +172,112 @@ export class LavaImmersive extends THREE.Object3D {
           return -b - sqrt(d);
         }
 
+        // Ray vs axis-aligned ellipsoid centered at origin.
+        float rayEllip(vec3 oc, vec3 rd, vec3 ax) {
+          vec3 ocS = oc / ax;
+          vec3 rdS = rd / ax;
+          float a = dot(rdS, rdS);
+          float b = dot(ocS, rdS);
+          float c = dot(ocS, ocS) - 1.0;
+          float d = b * b - a * c;
+          if (d < 0.0) return -1.0;
+          float t = (-b - sqrt(d)) / a;
+          return t;
+        }
+
+        // 3D volcano: stacked ellipsoid mounds tapering upward, with crater
+        // glow on top and lava streaks running down the slopes.
+        // Returns vec4(rgb, t) — t = bestT (large = no hit).
+        vec4 volcano3D(vec3 ro, vec3 rd, vec3 base, float t,
+                       float scaleR, float scaleH) {
+          vec3 sunDir = normalize(vec3(0.3, 0.6, -0.7));
+          float bestT = 1e9;
+          vec3 bestCol = vec3(0.0);
+          vec3 bestN = vec3(0.0);
+          vec3 bestHp = vec3(0.0);
+          int bestLayer = -1;
+          for (int i = 0; i < 4; i++) {
+            float fi = float(i);
+            float r = (3.4 - fi * 0.75) * scaleR;
+            float ry = 0.9 * scaleH;
+            vec3 ax = vec3(r, ry, r);
+            vec3 ctr = base + vec3(0.0, 0.5 * scaleH + fi * 1.4 * scaleH, 0.0);
+            float th = rayEllip(ro - ctr, rd, ax);
+            if (th > 0.5 && th < bestT) {
+              bestT = th;
+              bestHp = ro + rd * th - ctr;
+              bestN = normalize(bestHp / (ax * ax));
+              bestLayer = i;
+              bestCol = vec3(1.0);  // marker
+            }
+          }
+          if (bestT >= 1e9) return vec4(0.0, 0.0, 0.0, 1e9);
+          // Rock base color with noise variation.
+          float noiseTex = fbm3(bestHp * 1.6);
+          vec3 rock = mix(vec3(0.10, 0.05, 0.04),
+                          vec3(0.22, 0.11, 0.08), noiseTex);
+          // Lava streaks running down (more on lower layers).
+          float streakNoise = fbm(vec2(atan(bestHp.x, bestHp.z) * 8.0,
+                                        bestHp.y * 0.8 - t * 0.15));
+          float streakMask = smoothstep(0.62, 0.78, streakNoise);
+          // Streaks fade out near the top.
+          float layerFrac = float(bestLayer) / 3.0;
+          streakMask *= (1.0 - layerFrac * 0.6);
+          vec3 lava = vec3(1.00, 0.45, 0.10);
+          vec3 col = mix(rock, lava, streakMask * 0.85);
+          // Crater glow on top layer.
+          if (bestLayer == 3) {
+            float craterUp = max(bestN.y, 0.0);
+            col = mix(col, vec3(1.0, 0.65, 0.15), craterUp * craterUp);
+          }
+          // Lighting.
+          float lamb = max(dot(bestN, sunDir), 0.0);
+          float rim = pow(1.0 - max(dot(bestN, -rd), 0.0), 2.5);
+          col = col * (0.30 + lamb * 0.85)
+              + vec3(0.6, 0.3, 0.2) * rim * 0.20;
+          return vec4(col, bestT);
+        }
+
+        // Foreground lava rocks scattered around the user.
+        vec4 lavaRocks(vec3 ro, vec3 rd, float t) {
+          vec3 sunDir = normalize(vec3(0.3, 0.6, -0.7));
+          float bestT = 1e9;
+          vec3 bestCol = vec3(0.0);
+          vec3 bestN = vec3(0.0);
+          for (int i = 0; i < 8; i++) {
+            float fi = float(i);
+            float ang = fi * 0.91;
+            float dist = 4.5 + mod(fi * 1.7, 4.0);
+            vec3 base = vec3(cos(ang) * dist, -1.6,
+                              sin(ang) * dist);
+            float ry = 0.35 + 0.18 * sin(fi * 2.3);
+            vec3 ax = vec3(0.7 + 0.2 * cos(fi * 1.7),
+                            ry,
+                            0.6 + 0.2 * sin(fi * 1.7));
+            vec3 ctr = base + vec3(0.0, ry, 0.0);
+            float th = rayEllip(ro - ctr, rd, ax);
+            if (th > 0.3 && th < bestT) {
+              bestT = th;
+              vec3 hp = ro + rd * th - ctr;
+              bestN = normalize(hp / (ax * ax));
+              float n = fbm3(hp * 4.0 + fi);
+              vec3 rock = mix(vec3(0.06, 0.03, 0.02),
+                              vec3(0.18, 0.09, 0.07), n);
+              // Glowing crack underneath.
+              float crack = smoothstep(0.55, 0.7,
+                                        fbm(hp.xz * 9.0 + t * 0.2));
+              crack *= max(-bestN.y, 0.0);  // crack glow on undersides
+              bestCol = mix(rock, vec3(1.0, 0.42, 0.08), crack * 0.6);
+            }
+          }
+          if (bestT >= 1e9) return vec4(0.0, 0.0, 0.0, 1e9);
+          float lamb = max(dot(bestN, sunDir), 0.0);
+          float rim = pow(1.0 - max(dot(bestN, -rd), 0.0), 2.5);
+          vec3 col = bestCol * (0.30 + lamb * 0.85)
+                   + vec3(1.0, 0.5, 0.2) * rim * 0.18;
+          return vec4(col, bestT);
+        }
+
         // Rising ember columns: small fast glowing particles around user.
         vec3 embers(vec3 ro, vec3 rd, float t) {
           vec3 col = vec3(0.0);
@@ -284,38 +390,33 @@ export class LavaImmersive extends THREE.Object3D {
             col += vec3(1.0, 0.85, 0.55) * sparks * 0.6;
           }
 
-          // ---- Distant volcano silhouettes (3 around the horizon) ----
-          float dist1 = 1.4;
-          vec2 v1 = volcanoAt(rd, 2.4, dist1, t);
-          if (v1.x > 0.5) {
-            // Volcano body: dark with subtle texture.
-            float az = atan(rd.x, -rd.z);
-            vec3 vbody = mix(vec3(0.05, 0.02, 0.04),
-                             vec3(0.18, 0.08, 0.06),
-                             fbm(vec2(az * 30.0, asin(rd.y) * 30.0)));
-            // Add lava streaks down the slope.
-            float streak = fbm(vec2(az * 80.0, -asin(rd.y) * 6.0 + t * 0.4));
-            vec3 lava = vec3(1.00, 0.40, 0.05);
-            float streakMask = smoothstep(0.7, 0.85, streak)
-                             * smoothstep(0.0, 0.06, asin(rd.y));
-            vbody = mix(vbody, lava, streakMask * 0.8);
-            // Crater glow (bright orange at top).
-            vbody = mix(vbody, vec3(1.0, 0.7, 0.2), v1.y * 1.4);
-            col = vbody;
+          // ---- 3D raycast volcanoes (parallax correctly as user walks) ----
+          // Track best opaque hit (volcanoes + rocks).
+          float opaqueT = 1e9;
+          vec3 opaqueCol = vec3(0.0);
+          vec4 v1Hit = volcano3D(ro, rd, vec3(14.0, -1.6, -8.0), t, 1.0, 1.0);
+          if (v1Hit.w < opaqueT) {
+            opaqueT = v1Hit.w;
+            opaqueCol = v1Hit.rgb;
           }
-          // Smaller volcano on opposite side.
-          vec2 v2 = volcanoAt(rd, -1.8, 2.2, t);
-          if (v2.x > 0.5) {
-            float az = atan(rd.x, -rd.z);
-            vec3 vbody = mix(vec3(0.04, 0.02, 0.03),
-                             vec3(0.14, 0.06, 0.05),
-                             fbm(vec2(az * 30.0, asin(rd.y) * 30.0)));
-            vbody = mix(vbody, vec3(1.0, 0.65, 0.18), v2.y * 1.2);
-            col = vbody;
+          vec4 v2Hit = volcano3D(ro, rd, vec3(-18.0, -1.6, 9.0), t, 0.85, 0.9);
+          if (v2Hit.w < opaqueT) {
+            opaqueT = v2Hit.w;
+            opaqueCol = v2Hit.rgb;
+          }
+          vec4 rocksHit = lavaRocks(ro, rd, t);
+          if (rocksHit.w < opaqueT) {
+            opaqueT = rocksHit.w;
+            opaqueCol = rocksHit.rgb;
+          }
+          if (opaqueT < 1e8) {
+            // Atmospheric fog blends distant volcanoes into smoky sky.
+            float fogF = smoothstep(4.0, 60.0, opaqueT);
+            col = mix(opaqueCol, col, fogF * 0.55);
           }
 
           // Ash plumes rising from the main volcano.
-          col += ashPlume(rd, 2.4, dist1, t);
+          col += ashPlume(rd, atan(-8.0, 14.0), 1.4, t);
 
           // ---- Lava bombs (raymarched glowing spheres) ----
           col += lavaBombs(ro, rd, t);
@@ -326,7 +427,7 @@ export class LavaImmersive extends THREE.Object3D {
           // ---- Lava ground beneath user (looking down) ----
           if (rd.y < -0.05) {
             float gt = -ro.y / rd.y;
-            if (gt > 0.0 && gt < 60.0) {
+            if (gt > 0.0 && gt < 60.0 && gt < opaqueT) {
               vec3 gp = ro + rd * gt;
               // Solidified crust with hot crack pattern.
               float crust = fbm(gp.xz * 0.4);

--- a/demos/portals/LavaImmersive.js
+++ b/demos/portals/LavaImmersive.js
@@ -185,57 +185,108 @@ export class LavaImmersive extends THREE.Object3D {
           return t;
         }
 
-        // 3D volcano: stacked ellipsoid mounds tapering upward, with crater
-        // glow on top and lava streaks running down the slopes.
-        // Returns vec4(rgb, t) — t = bestT (large = no hit).
-        vec4 volcano3D(vec3 ro, vec3 rd, vec3 base, float t,
-                       float scaleR, float scaleH) {
+        // Ray vs truncated cone (volcano with flat-top crater).
+        // base: world position of the base center; topY: vertical height to
+        // crater plateau; bottomR: base radius; topR: crater radius.
+        // Returns vec4(rgb, t) — t = 1e9 on miss.
+        vec4 volcanoCone(vec3 ro, vec3 rd, vec3 base, float topY,
+                         float bottomR, float topR, float t) {
           vec3 sunDir = normalize(vec3(0.3, 0.6, -0.7));
-          float bestT = 1e9;
-          vec3 bestCol = vec3(0.0);
-          vec3 bestN = vec3(0.0);
-          vec3 bestHp = vec3(0.0);
-          int bestLayer = -1;
-          for (int i = 0; i < 4; i++) {
-            float fi = float(i);
-            float r = (3.4 - fi * 0.75) * scaleR;
-            float ry = 0.9 * scaleH;
-            vec3 ax = vec3(r, ry, r);
-            vec3 ctr = base + vec3(0.0, 0.5 * scaleH + fi * 1.4 * scaleH, 0.0);
-            float th = rayEllip(ro - ctr, rd, ax);
-            if (th > 0.5 && th < bestT) {
-              bestT = th;
-              bestHp = ro + rd * th - ctr;
-              bestN = normalize(bestHp / (ax * ax));
-              bestLayer = i;
-              bestCol = vec3(1.0);  // marker
+          // Virtual apex (where extended sides converge).
+          float craterOffset = topR * topY / max(bottomR - topR, 0.001);
+          vec3 apex = base + vec3(0.0, topY + craterOffset, 0.0);
+          float tanT = bottomR / (topY + craterOffset);
+          float tan2 = tanT * tanT;
+          vec3 oc = ro - apex;
+          float a = rd.x * rd.x + rd.z * rd.z - tan2 * rd.y * rd.y;
+          float b = oc.x * rd.x + oc.z * rd.z - tan2 * oc.y * rd.y;
+          float c = oc.x * oc.x + oc.z * oc.z - tan2 * oc.y * oc.y;
+          float tCone = 1e9;
+          if (abs(a) > 1e-5) {
+            float disc = b * b - a * c;
+            if (disc > 0.0) {
+              float sq = sqrt(disc);
+              float t0 = (-b - sq) / a;
+              float t1 = (-b + sq) / a;
+              for (int k = 0; k < 2; k++) {
+                float ti = (k == 0) ? t0 : t1;
+                if (ti > 0.5 && ti < tCone) {
+                  float py = ro.y + rd.y * ti;
+                  if (py >= base.y && py <= base.y + topY) tCone = ti;
+                }
+              }
             }
           }
-          if (bestT >= 1e9) return vec4(0.0, 0.0, 0.0, 1e9);
-          // Rock base color with noise variation.
-          float noiseTex = fbm3(bestHp * 1.6);
-          vec3 rock = mix(vec3(0.10, 0.05, 0.04),
-                          vec3(0.22, 0.11, 0.08), noiseTex);
-          // Lava streaks running down (more on lower layers).
-          float streakNoise = fbm(vec2(atan(bestHp.x, bestHp.z) * 8.0,
-                                        bestHp.y * 0.8 - t * 0.15));
-          float streakMask = smoothstep(0.62, 0.78, streakNoise);
-          // Streaks fade out near the top.
-          float layerFrac = float(bestLayer) / 3.0;
-          streakMask *= (1.0 - layerFrac * 0.6);
-          vec3 lava = vec3(1.00, 0.45, 0.10);
-          vec3 col = mix(rock, lava, streakMask * 0.85);
-          // Crater glow on top layer.
-          if (bestLayer == 3) {
-            float craterUp = max(bestN.y, 0.0);
-            col = mix(col, vec3(1.0, 0.65, 0.15), craterUp * craterUp);
+          float tPlat = 1e9;
+          if (abs(rd.y) > 1e-5) {
+            float plateauY = base.y + topY;
+            float tp = (plateauY - ro.y) / rd.y;
+            if (tp > 0.5) {
+              vec3 hp = ro + rd * tp;
+              float r = length(hp.xz - apex.xz);
+              if (r <= topR) tPlat = tp;
+            }
           }
-          // Lighting.
-          float lamb = max(dot(bestN, sunDir), 0.0);
-          float rim = pow(1.0 - max(dot(bestN, -rd), 0.0), 2.5);
-          col = col * (0.30 + lamb * 0.85)
-              + vec3(0.6, 0.3, 0.2) * rim * 0.20;
-          return vec4(col, bestT);
+          float tBest = min(tCone, tPlat);
+          if (tBest >= 1e9) return vec4(0.0, 0.0, 0.0, 1e9);
+          bool hitPlat = (tPlat <= tCone);
+          vec3 hp = ro + rd * tBest;
+          vec3 nrm;
+          if (hitPlat) {
+            nrm = vec3(0.0, 1.0, 0.0);
+          } else {
+            vec3 op = hp - apex;
+            nrm = normalize(vec3(op.x, -tan2 * op.y, op.z));
+          }
+          vec3 col;
+          if (hitPlat) {
+            // Cracked dark crust with glowing molten fissures.
+            float r = length(hp.xz - apex.xz) / topR;
+            float crustNoise = fbm3(hp * 1.8 + vec3(0.0, t * 0.15, 0.0));
+            float fissure = fbm3(hp * 3.5 + vec3(t * 0.25, 0.0, t * 0.2));
+            float crackMask = smoothstep(0.48, 0.60, fissure);
+            vec3 crust = mix(vec3(0.06, 0.03, 0.02),
+                             vec3(0.16, 0.08, 0.05), crustNoise);
+            vec3 hotLava = mix(vec3(1.00, 0.55, 0.10),
+                               vec3(1.00, 0.95, 0.55),
+                               smoothstep(0.55, 0.75, fissure));
+            col = mix(crust, hotLava, crackMask);
+            // Brighter near center where it's hottest.
+            col *= mix(1.4, 0.85, r);
+          } else {
+            float h = clamp((hp.y - base.y) / topY, 0.0, 1.0);
+            float ang = atan(hp.x - apex.x, hp.z - apex.z);
+            // Layered strata using vertical bands.
+            float strata = fbm3(vec3(ang * 1.5, h * 6.0, 0.0));
+            float pebble = fbm3(hp * 3.5);
+            vec3 darkRock = vec3(0.07, 0.04, 0.03);
+            vec3 midRock = vec3(0.20, 0.11, 0.07);
+            vec3 ashRock = vec3(0.32, 0.26, 0.22);
+            vec3 rock = mix(darkRock, midRock, strata);
+            rock = mix(rock, ashRock, smoothstep(0.55, 0.95, h) * 0.55);
+            rock = mix(rock * 0.85, rock * 1.15, pebble);
+            // Discrete lava channels: a few angular bands that gain near top.
+            float chan = abs(fract(ang * 1.9 + fbm3(hp * 0.6) * 0.4) - 0.5);
+            float channelMask = smoothstep(0.04, 0.0, chan)
+                              * smoothstep(0.15, 0.65, h);
+            float trickle = fbm(vec2(ang * 8.0, h * 4.5 - t * 0.18));
+            channelMask *= smoothstep(0.35, 0.75, trickle);
+            vec3 lavaHot = mix(vec3(0.85, 0.18, 0.04),
+                               vec3(1.00, 0.70, 0.20),
+                               smoothstep(0.6, 1.0, h));
+            col = mix(rock, lavaHot, channelMask);
+            // Hot rim glow just below the crater edge.
+            float rimGlow = smoothstep(0.88, 1.0, h);
+            col += vec3(1.00, 0.50, 0.10) * rimGlow * 0.55;
+            float lamb = max(dot(nrm, sunDir), 0.0);
+            float ao = mix(0.6, 1.0, h);
+            col = col * (0.22 + lamb * 0.95) * ao;
+            float rim = pow(1.0 - max(dot(nrm, -rd), 0.0), 2.5);
+            col += vec3(0.55, 0.28, 0.18) * rim * 0.20;
+            // Lava channels emit even in shadow.
+            col += lavaHot * channelMask * 0.55;
+          }
+          return vec4(col, tBest);
         }
 
         // Foreground lava rocks scattered around the user.
@@ -394,12 +445,16 @@ export class LavaImmersive extends THREE.Object3D {
           // Track best opaque hit (volcanoes + rocks).
           float opaqueT = 1e9;
           vec3 opaqueCol = vec3(0.0);
-          vec4 v1Hit = volcano3D(ro, rd, vec3(14.0, -1.6, -8.0), t, 1.0, 1.0);
+          // ---- 3D raycast volcanoes (true cone shape with crater) ----
+          // base, topY (height), bottomR, topR (crater radius).
+          vec4 v1Hit = volcanoCone(ro, rd, vec3(2.0, -1.6, -16.0), 6.0,
+                                    8.5, 2.6, t);
           if (v1Hit.w < opaqueT) {
             opaqueT = v1Hit.w;
             opaqueCol = v1Hit.rgb;
           }
-          vec4 v2Hit = volcano3D(ro, rd, vec3(-18.0, -1.6, 9.0), t, 0.85, 0.9);
+          vec4 v2Hit = volcanoCone(ro, rd, vec3(-15.0, -1.6, 8.0), 4.2,
+                                    6.0, 1.8, t);
           if (v2Hit.w < opaqueT) {
             opaqueT = v2Hit.w;
             opaqueCol = v2Hit.rgb;
@@ -415,6 +470,64 @@ export class LavaImmersive extends THREE.Object3D {
             col = mix(opaqueCol, col, fogF * 0.55);
           }
 
+          // ---- Animated plume + lava spurts above each volcano apex ----
+          for (int v = 0; v < 2; v++) {
+            vec3 apexW = (v == 0) ? vec3(2.0, 4.4, -16.0)
+                                   : vec3(-15.0, 2.6, 8.0);
+            for (int i = 0; i < 14; i++) {
+              float h = float(i) * 0.65;
+              float ty = apexW.y + h;
+              if (abs(rd.y) < 0.001) continue;
+              float ti = (ty - ro.y) / rd.y;
+              if (ti < 0.5 || ti > opaqueT) continue;
+              vec3 p = ro + rd * ti;
+              vec2 d = p.xz - apexW.xz;
+              float r = length(d);
+              float radius = 1.6 + h * 0.55;
+              float mask = smoothstep(radius, radius * 0.35, r);
+              float n = fbm3(vec3(d.x * 0.45, h * 0.6 - t * 0.5,
+                                   d.y * 0.45));
+              vec3 ashHot = vec3(0.55, 0.30, 0.18);
+              vec3 ashCold = vec3(0.20, 0.16, 0.18);
+              vec3 ashCol = mix(ashHot, ashCold, smoothstep(0.0, 6.0, h));
+              ashCol = mix(ashCol * 0.4, ashCol, n);
+              col += ashCol * mask * (0.06 + n * 0.10);
+              if (h < 1.5) {
+                col += vec3(1.0, 0.55, 0.20) * mask * (1.5 - h) * 0.07;
+              }
+            }
+            for (int b = 0; b < 5; b++) {
+              float fb = float(b) + float(v) * 11.3;
+              float cycle = 2.6 + fb * 0.31;
+              float phase = mod(t + fb * 0.7, cycle) / cycle;
+              float ck = floor((t + fb * 0.7) / cycle);
+              float ang = hash(vec2(fb, ck)) * 6.28318;
+              float spread = 0.5 + hash(vec2(fb + 3.1, ck)) * 0.8;
+              float peakH = 2.5 + hash(vec2(fb + 7.7, ck)) * 2.0;
+              vec3 dir = vec3(cos(ang) * spread, 0.0, sin(ang) * spread);
+              vec3 pos = apexW + dir * phase
+                       + vec3(0.0,
+                              peakH * 4.0 * phase * (1.0 - phase), 0.0);
+              vec3 oc2 = ro - pos;
+              float rad = 0.18;
+              float bSp = dot(oc2, rd);
+              float cSp = dot(oc2, oc2) - rad * rad;
+              float disc = bSp * bSp - cSp;
+              if (disc > 0.0) {
+                float ts = -bSp - sqrt(disc);
+                if (ts > 0.5 && ts < opaqueT) {
+                  vec3 lavaC = mix(vec3(1.0, 0.95, 0.55),
+                                   vec3(0.95, 0.30, 0.05), phase);
+                  col = mix(col, lavaC * 1.6, 0.95);
+                }
+              }
+              vec3 tp = ro + rd * max(dot(pos - ro, rd), 0.5);
+              float trail = exp(-length(tp - pos) * 4.0)
+                          * smoothstep(0.0, 0.6, phase);
+              col += vec3(1.0, 0.55, 0.20) * trail * 0.4;
+            }
+          }
+
           // Ash plumes rising from the main volcano.
           col += ashPlume(rd, atan(-8.0, 14.0), 1.4, t);
 
@@ -425,8 +538,11 @@ export class LavaImmersive extends THREE.Object3D {
           col += embers(ro, rd, t);
 
           // ---- Lava ground beneath user (looking down) ----
+          // Ground sits at y = -1.6 so the user's head (ro.y ~ 0) is roughly
+          // standing height above it instead of half-buried in it.
           if (rd.y < -0.05) {
-            float gt = -ro.y / rd.y;
+            float groundY = -1.6;
+            float gt = (groundY - ro.y) / rd.y;
             if (gt > 0.0 && gt < 60.0 && gt < opaqueT) {
               vec3 gp = ro + rd * gt;
               // Solidified crust with hot crack pattern.

--- a/demos/portals/LavaImmersive.js
+++ b/demos/portals/LavaImmersive.js
@@ -145,31 +145,6 @@ export class LavaImmersive extends THREE.Object3D {
           return vec2(mask, crater);
         }
 
-        // Distant ash plume rising from volcano top: animated noise.
-        vec3 ashPlume(vec3 rd, float az0, float dist, float t) {
-          float az = atan(rd.x, -rd.z);
-          float alt = asin(clamp(rd.y, -1.0, 1.0));
-          float dAz = az - az0;
-          if (dAz > 3.14159) dAz -= 6.28318;
-          if (dAz < -3.14159) dAz += 6.28318;
-          float plumeW = 0.30 / dist;
-          float plumeBase = 0.22 / dist;
-          if (alt < plumeBase || abs(dAz) > plumeW) return vec3(0.0);
-          float h = (alt - plumeBase) / 0.6;
-          float widthFactor = mix(0.4, 1.4, smoothstep(0.0, 0.7, h));
-          float dxNorm = abs(dAz) / (plumeW * widthFactor);
-          if (dxNorm > 1.0) return vec3(0.0);
-          float density = fbm(vec2(dAz * 30.0 - t * 0.15, h * 4.0 - t * 0.3));
-          density *= (1.0 - dxNorm) * smoothstep(0.0, 0.2, h)
-                   * smoothstep(1.0, 0.6, h);
-          // Ash is dark grey with orange underlit.
-          vec3 dark = vec3(0.10, 0.06, 0.08);
-          vec3 lit = vec3(0.65, 0.30, 0.10);
-          float underlight = smoothstep(0.4, 0.0, h);
-          vec3 ash = mix(dark, lit, underlight);
-          return ash * density * 0.9;
-        }
-
         float raySphere(vec3 ro, vec3 rd, vec3 c, float rad) {
           vec3 oc = ro - c;
           float b = dot(oc, rd);
@@ -363,47 +338,6 @@ export class LavaImmersive extends THREE.Object3D {
           return col;
         }
 
-        // Lava bombs: large glowing spheres on parabolic trajectories.
-        vec3 lavaBombs(vec3 ro, vec3 rd, float t) {
-          vec3 col = vec3(0.0);
-          for (int i = 0; i < 4; i++) {
-            float fi = float(i);
-            float seed = fi * 23.7;
-            float cycle = mod(t * 0.4 + seed, 5.0);
-            // Parabolic path from volcano direction toward user/horizon.
-            float az0 = 2.5 + sin(seed) * 0.8;
-            vec3 origin = vec3(sin(az0) * 25.0, 6.0, -cos(az0) * 25.0);
-            vec3 dir = normalize(vec3(-sin(az0) * 0.6, 0.0, cos(az0) * 0.6)
-                               + vec3(sin(seed * 3.7) * 0.3, 0.0,
-                                      cos(seed * 3.7) * 0.3));
-            vec3 pos = origin + dir * cycle * 6.0
-                     + vec3(0.0, cycle * 4.0 - cycle * cycle * 1.2, 0.0);
-            vec3 oc = pos - ro;
-            float along = dot(oc, rd);
-            if (along < 0.5 || along > 30.0) continue;
-            vec3 proj = ro + rd * along;
-            float d = length(pos - proj);
-            float r = 0.18;
-            float bomb = smoothstep(r, 0.0, d);
-            float halo = smoothstep(r * 6.0, r, d) * 0.25;
-            float fade = 1.0 / (1.0 + along * 0.08);
-            col += vec3(1.00, 0.50, 0.10) * (bomb * 1.5 + halo) * fade;
-            // Trailing smoke
-            for (int j = 1; j <= 3; j++) {
-              float fj = float(j);
-              vec3 trailPos = pos - dir * fj * 0.4
-                            - vec3(0.0, fj * 0.1, 0.0);
-              vec3 oc2 = trailPos - ro;
-              float a2 = dot(oc2, rd);
-              if (a2 < 0.5 || a2 > 30.0) continue;
-              vec3 pj = ro + rd * a2;
-              float dj = length(trailPos - pj);
-              float trail = smoothstep(r * 0.7, 0.0, dj) * 0.18 / fj;
-              col += vec3(0.30, 0.18, 0.18) * trail;
-            }
-          }
-          return col;
-        }
 
         void main() {
           vec3 rd = normalize(uViewRotation * vWorldDir);
@@ -533,12 +467,6 @@ export class LavaImmersive extends THREE.Object3D {
               col += vec3(1.0, 0.55, 0.20) * trail * 0.4;
             }
           }
-
-          // Ash plumes rising from the main volcano.
-          col += ashPlume(rd, atan(-8.0, 14.0), 1.4, t);
-
-          // ---- Lava bombs (raymarched glowing spheres) ----
-          col += lavaBombs(ro, rd, t);
 
           // ---- Embers ----
           col += embers(ro, rd, t);

--- a/demos/portals/LavaImmersive.js
+++ b/demos/portals/LavaImmersive.js
@@ -15,9 +15,15 @@ export class LavaImmersive extends THREE.Object3D {
     this._buildSphere();
   }
 
-  show(portalWorldMatrix) {
-    this._entryMatrix = portalWorldMatrix.clone();
-    this._entryMatrixInv = portalWorldMatrix.clone().invert();
+  show(portalWorldMatrix, fromSide = 'front') {
+    let m = portalWorldMatrix.clone();
+    if (fromSide === 'back') {
+      // User entered through the back face of the portal — apply a 180° yaw
+      // so they spawn facing the scene rather than the wall behind it.
+      m.multiply(new THREE.Matrix4().makeRotationY(Math.PI));
+    }
+    this._entryMatrix = m;
+    this._entryMatrixInv = m.clone().invert();
     this.visible = true;
   }
 

--- a/demos/portals/LavaImmersive.js
+++ b/demos/portals/LavaImmersive.js
@@ -1,0 +1,382 @@
+import * as THREE from 'three';
+
+const SPHERE_RADIUS = 50;
+
+/**
+ * Full-surround volcanic landscape for "walk-in" mode.
+ * Inverted sphere: smoky red/orange sky with ash plume + lightning,
+ * distant volcano silhouette with glowing crater, rising ember columns
+ * in 3D, lava bombs arcing past, glowing magma ground beneath.
+ */
+export class LavaImmersive extends THREE.Object3D {
+  constructor() {
+    super();
+    this._time = 0;
+    this._buildSphere();
+  }
+
+  show(portalWorldMatrix) {
+    this._entryMatrix = portalWorldMatrix.clone();
+    this._entryMatrixInv = portalWorldMatrix.clone().invert();
+    this.visible = true;
+  }
+
+  hide() {
+    this.visible = false;
+  }
+
+  update(dt, camera) {
+    if (!this.visible) return;
+    this._time += dt;
+
+    const mat = this._sphere.material;
+    mat.uniforms.uTime.value = this._time;
+
+    if (camera) {
+      const camWorld = camera.getWorldPosition(new THREE.Vector3());
+      const camLocal = camWorld.clone().applyMatrix4(this._entryMatrixInv);
+      mat.uniforms.uCamLocal.value.copy(camLocal);
+
+      const portalQuat = new THREE.Quaternion().setFromRotationMatrix(
+        this._entryMatrix
+      );
+      const portalQuatInv = portalQuat.clone().invert();
+      const camQuat = camera.getWorldQuaternion(new THREE.Quaternion());
+      const localQuat = portalQuatInv.multiply(camQuat);
+      const rotMat4 = new THREE.Matrix4().makeRotationFromQuaternion(localQuat);
+      mat.uniforms.uViewRotation.value.setFromMatrix4(rotMat4);
+    }
+
+    if (camera) {
+      camera.getWorldPosition(this.position);
+    }
+  }
+
+  _buildSphere() {
+    const geom = new THREE.SphereGeometry(SPHERE_RADIUS, 64, 32);
+
+    const mat = new THREE.ShaderMaterial({
+      uniforms: {
+        uTime: {value: 0},
+        uCamLocal: {value: new THREE.Vector3(0, 0, 1.6)},
+        uViewRotation: {value: new THREE.Matrix3()},
+      },
+      vertexShader: /* glsl */ `
+        varying vec3 vWorldDir;
+        void main() {
+          vWorldDir = normalize(position);
+          gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        }
+      `,
+      fragmentShader: /* glsl */ `
+        precision highp float;
+        uniform float uTime;
+        uniform vec3 uCamLocal;
+        uniform mat3 uViewRotation;
+        varying vec3 vWorldDir;
+
+        float hash(vec2 p) {
+          p = fract(p * vec2(123.34, 456.21));
+          p += dot(p, p + 45.32);
+          return fract(p.x * p.y);
+        }
+        float hash3(vec3 p) {
+          p = fract(p * vec3(123.34, 456.21, 789.53));
+          p += dot(p, p.yzx + 45.32);
+          return fract(p.x * p.y * p.z);
+        }
+        float noise(vec2 p) {
+          vec2 i = floor(p); vec2 f = fract(p);
+          float a = hash(i); float b = hash(i + vec2(1,0));
+          float c = hash(i + vec2(0,1)); float d = hash(i + vec2(1,1));
+          vec2 u = f * f * (3.0 - 2.0 * f);
+          return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x)
+                                + (d - b) * u.x * u.y;
+        }
+        float noise3(vec3 p) {
+          vec3 i = floor(p); vec3 f = fract(p);
+          vec3 u = f * f * (3.0 - 2.0 * f);
+          return mix(
+            mix(mix(hash3(i), hash3(i + vec3(1,0,0)), u.x),
+                mix(hash3(i + vec3(0,1,0)), hash3(i + vec3(1,1,0)), u.x), u.y),
+            mix(mix(hash3(i + vec3(0,0,1)), hash3(i + vec3(1,0,1)), u.x),
+                mix(hash3(i + vec3(0,1,1)), hash3(i + vec3(1,1,1)), u.x), u.y),
+            u.z);
+        }
+        float fbm(vec2 p) {
+          float v = 0.0; float a = 0.5;
+          for (int i = 0; i < 4; i++) { v += a * noise(p); p *= 2.07; a *= 0.5; }
+          return v;
+        }
+        float fbm3(vec3 p) {
+          float v = 0.0; float a = 0.5;
+          for (int i = 0; i < 4; i++) { v += a * noise3(p); p *= 2.07; a *= 0.5; }
+          return v;
+        }
+
+        // Volcano silhouette mask in cylindrical (azimuth, altitude) coords.
+        // Returns mask 0..1 for "inside cone", plus crater glow factor.
+        vec2 volcanoAt(vec3 rd, float az0, float dist, float t) {
+          float az = atan(rd.x, -rd.z);
+          float alt = asin(clamp(rd.y, -1.0, 1.0));
+          // Center the volcano at az0.
+          float dAz = az - az0;
+          if (dAz > 3.14159) dAz -= 6.28318;
+          if (dAz < -3.14159) dAz += 6.28318;
+          // Distance scales the cone size.
+          float coneW = 0.18 / dist;
+          float coneTop = 0.22 / dist;
+          // Cone profile: triangular.
+          float dxNorm = abs(dAz) / coneW;
+          float topAlt = coneTop * (1.0 - dxNorm);
+          // Add jagged top noise.
+          float jagged = (noise(vec2(dAz * 50.0, t * 0.05)) - 0.5) * 0.012;
+          topAlt += jagged;
+          float mask = step(alt, topAlt) * step(0.0, alt) * step(dxNorm, 1.0);
+          // Crater glow: bright top center.
+          float crater = exp(-dxNorm * 8.0)
+                       * smoothstep(coneTop * 0.5, coneTop, alt) * mask;
+          return vec2(mask, crater);
+        }
+
+        // Distant ash plume rising from volcano top: animated noise.
+        vec3 ashPlume(vec3 rd, float az0, float dist, float t) {
+          float az = atan(rd.x, -rd.z);
+          float alt = asin(clamp(rd.y, -1.0, 1.0));
+          float dAz = az - az0;
+          if (dAz > 3.14159) dAz -= 6.28318;
+          if (dAz < -3.14159) dAz += 6.28318;
+          float plumeW = 0.30 / dist;
+          float plumeBase = 0.22 / dist;
+          if (alt < plumeBase || abs(dAz) > plumeW) return vec3(0.0);
+          float h = (alt - plumeBase) / 0.6;
+          float widthFactor = mix(0.4, 1.4, smoothstep(0.0, 0.7, h));
+          float dxNorm = abs(dAz) / (plumeW * widthFactor);
+          if (dxNorm > 1.0) return vec3(0.0);
+          float density = fbm(vec2(dAz * 30.0 - t * 0.15, h * 4.0 - t * 0.3));
+          density *= (1.0 - dxNorm) * smoothstep(0.0, 0.2, h)
+                   * smoothstep(1.0, 0.6, h);
+          // Ash is dark grey with orange underlit.
+          vec3 dark = vec3(0.10, 0.06, 0.08);
+          vec3 lit = vec3(0.65, 0.30, 0.10);
+          float underlight = smoothstep(0.4, 0.0, h);
+          vec3 ash = mix(dark, lit, underlight);
+          return ash * density * 0.9;
+        }
+
+        float raySphere(vec3 ro, vec3 rd, vec3 c, float rad) {
+          vec3 oc = ro - c;
+          float b = dot(oc, rd);
+          float d = b * b - (dot(oc, oc) - rad * rad);
+          if (d < 0.0) return -1.0;
+          return -b - sqrt(d);
+        }
+
+        // Rising ember columns: small fast glowing particles around user.
+        vec3 embers(vec3 ro, vec3 rd, float t) {
+          vec3 col = vec3(0.0);
+          for (int i = 0; i < 14; i++) {
+            float fi = float(i);
+            float seed = fi * 9.7;
+            // Column base xz (close to user).
+            vec2 base = vec2(sin(seed) * 4.0 + cos(seed * 1.7) * 2.5,
+                             cos(seed * 0.9) * 4.0 + sin(seed * 1.3) * 2.5);
+            // Ember height cycles upward fast.
+            float eh = mod(t * 2.5 + seed * 5.0, 4.0);
+            vec3 pos = vec3(base.x + sin(eh * 2.0 + seed) * 0.2,
+                            -1.0 + eh,
+                            base.y + cos(eh * 2.0 + seed) * 0.2);
+            vec3 oc = pos - ro;
+            float along = dot(oc, rd);
+            if (along < 0.3 || along > 12.0) continue;
+            vec3 proj = ro + rd * along;
+            float d = length(pos - proj);
+            float r = 0.06;
+            float spark = smoothstep(r, 0.0, d);
+            float pulse = 0.7 + 0.3 * sin(eh * 8.0 + seed);
+            float fade = (1.0 - eh / 4.0) / (1.0 + along * 0.2);
+            col += vec3(1.00, 0.55, 0.15) * spark * pulse * fade * 1.2;
+          }
+          return col;
+        }
+
+        // Lava bombs: large glowing spheres on parabolic trajectories.
+        vec3 lavaBombs(vec3 ro, vec3 rd, float t) {
+          vec3 col = vec3(0.0);
+          for (int i = 0; i < 4; i++) {
+            float fi = float(i);
+            float seed = fi * 23.7;
+            float cycle = mod(t * 0.4 + seed, 5.0);
+            // Parabolic path from volcano direction toward user/horizon.
+            float az0 = 2.5 + sin(seed) * 0.8;
+            vec3 origin = vec3(sin(az0) * 25.0, 6.0, -cos(az0) * 25.0);
+            vec3 dir = normalize(vec3(-sin(az0) * 0.6, 0.0, cos(az0) * 0.6)
+                               + vec3(sin(seed * 3.7) * 0.3, 0.0,
+                                      cos(seed * 3.7) * 0.3));
+            vec3 pos = origin + dir * cycle * 6.0
+                     + vec3(0.0, cycle * 4.0 - cycle * cycle * 1.2, 0.0);
+            vec3 oc = pos - ro;
+            float along = dot(oc, rd);
+            if (along < 0.5 || along > 30.0) continue;
+            vec3 proj = ro + rd * along;
+            float d = length(pos - proj);
+            float r = 0.18;
+            float bomb = smoothstep(r, 0.0, d);
+            float halo = smoothstep(r * 6.0, r, d) * 0.25;
+            float fade = 1.0 / (1.0 + along * 0.08);
+            col += vec3(1.00, 0.50, 0.10) * (bomb * 1.5 + halo) * fade;
+            // Trailing smoke
+            for (int j = 1; j <= 3; j++) {
+              float fj = float(j);
+              vec3 trailPos = pos - dir * fj * 0.4
+                            - vec3(0.0, fj * 0.1, 0.0);
+              vec3 oc2 = trailPos - ro;
+              float a2 = dot(oc2, rd);
+              if (a2 < 0.5 || a2 > 30.0) continue;
+              vec3 pj = ro + rd * a2;
+              float dj = length(trailPos - pj);
+              float trail = smoothstep(r * 0.7, 0.0, dj) * 0.18 / fj;
+              col += vec3(0.30, 0.18, 0.18) * trail;
+            }
+          }
+          return col;
+        }
+
+        void main() {
+          vec3 rd = normalize(uViewRotation * vWorldDir);
+          vec3 ro = uCamLocal;
+          float t = uTime;
+
+          // ---- Smoky red sky gradient ----
+          float skyT = clamp(rd.y * 0.5 + 0.5, 0.0, 1.0);
+          vec3 lowSky = vec3(0.95, 0.45, 0.15);
+          vec3 midSky = vec3(0.55, 0.15, 0.10);
+          vec3 highSky = vec3(0.18, 0.04, 0.12);
+          vec3 col = mix(lowSky, midSky, smoothstep(0.45, 0.65, skyT));
+          col = mix(col, highSky, smoothstep(0.65, 1.0, skyT));
+
+          // Drifting ash clouds (3D noise based on direction).
+          float ash = fbm3(rd * 2.5 + vec3(t * 0.05, 0.0, t * 0.04));
+          ash *= smoothstep(0.0, 0.4, rd.y);
+          col = mix(col, vec3(0.10, 0.05, 0.10), ash * 0.55);
+
+          // Distant glowing sparks high in the sky.
+          if (rd.y > 0.0) {
+            // Octahedral mapping for seamless grid.
+            vec3 a = abs(rd);
+            float sum = a.x + a.y + a.z;
+            vec2 oct = rd.xz / sum;
+            if (rd.y < 0.0) {
+              oct = (1.0 - abs(oct.yx)) * vec2(oct.x >= 0.0 ? 1.0 : -1.0,
+                                                oct.y >= 0.0 ? 1.0 : -1.0);
+            }
+            vec2 uv = oct * 0.5 + 0.5;
+            float sparks = 0.0;
+            for (int k = 0; k < 1; k++) {
+              vec2 g = floor(uv * 80.0);
+              vec2 f = fract(uv * 80.0);
+              float h = hash(g);
+              if (h > 0.992) {
+                vec2 jit = vec2(hash(g + 1.7), hash(g + 7.3)) * 0.6 + 0.2;
+                sparks = smoothstep(0.05, 0.0, length(f - jit));
+              }
+            }
+            col += vec3(1.0, 0.85, 0.55) * sparks * 0.6;
+          }
+
+          // ---- Distant volcano silhouettes (3 around the horizon) ----
+          float dist1 = 1.4;
+          vec2 v1 = volcanoAt(rd, 2.4, dist1, t);
+          if (v1.x > 0.5) {
+            // Volcano body: dark with subtle texture.
+            float az = atan(rd.x, -rd.z);
+            vec3 vbody = mix(vec3(0.05, 0.02, 0.04),
+                             vec3(0.18, 0.08, 0.06),
+                             fbm(vec2(az * 30.0, asin(rd.y) * 30.0)));
+            // Add lava streaks down the slope.
+            float streak = fbm(vec2(az * 80.0, -asin(rd.y) * 6.0 + t * 0.4));
+            vec3 lava = vec3(1.00, 0.40, 0.05);
+            float streakMask = smoothstep(0.7, 0.85, streak)
+                             * smoothstep(0.0, 0.06, asin(rd.y));
+            vbody = mix(vbody, lava, streakMask * 0.8);
+            // Crater glow (bright orange at top).
+            vbody = mix(vbody, vec3(1.0, 0.7, 0.2), v1.y * 1.4);
+            col = vbody;
+          }
+          // Smaller volcano on opposite side.
+          vec2 v2 = volcanoAt(rd, -1.8, 2.2, t);
+          if (v2.x > 0.5) {
+            float az = atan(rd.x, -rd.z);
+            vec3 vbody = mix(vec3(0.04, 0.02, 0.03),
+                             vec3(0.14, 0.06, 0.05),
+                             fbm(vec2(az * 30.0, asin(rd.y) * 30.0)));
+            vbody = mix(vbody, vec3(1.0, 0.65, 0.18), v2.y * 1.2);
+            col = vbody;
+          }
+
+          // Ash plumes rising from the main volcano.
+          col += ashPlume(rd, 2.4, dist1, t);
+
+          // ---- Lava bombs (raymarched glowing spheres) ----
+          col += lavaBombs(ro, rd, t);
+
+          // ---- Embers ----
+          col += embers(ro, rd, t);
+
+          // ---- Lava ground beneath user (looking down) ----
+          if (rd.y < -0.05) {
+            float gt = -ro.y / rd.y;
+            if (gt > 0.0 && gt < 60.0) {
+              vec3 gp = ro + rd * gt;
+              // Solidified crust with hot crack pattern.
+              float crust = fbm(gp.xz * 0.4);
+              float cracks = fbm(gp.xz * 1.5 + t * 0.05);
+              float crackMask = smoothstep(0.55, 0.65, cracks)
+                              - smoothstep(0.65, 0.75, cracks);
+              vec3 ground = mix(vec3(0.04, 0.02, 0.02),
+                                vec3(0.15, 0.08, 0.06), crust);
+              vec3 crackCol = vec3(1.00, 0.45, 0.10)
+                            * (0.7 + 0.3 * sin(t * 3.0 + dot(gp.xz, vec2(2.0))));
+              ground = mix(ground, crackCol, crackMask * 1.2);
+              float fog = smoothstep(0.0, 25.0, gt);
+              col = mix(ground, col, fog * 0.7);
+            }
+          }
+
+          // ---- Lightning flashes in ash plume ----
+          {
+            float beat = floor(t * 0.5);
+            float flashSeed = hash(vec2(beat, 31.7));
+            if (flashSeed > 0.7) {
+              float local = fract(t * 0.5);
+              float flash = exp(-local * 12.0) * smoothstep(0.0, 0.04, local);
+              vec3 flashDir = normalize(vec3(sin(2.4) * 0.7, 0.5,
+                                             -cos(2.4) * 0.7));
+              float ang = max(dot(rd, flashDir), 0.0);
+              col += vec3(0.95, 0.85, 1.00) * smoothstep(0.85, 1.0, ang)
+                   * flash * 1.6;
+            }
+          }
+
+          // Atmospheric glow tint (warm lift).
+          col = mix(col, vec3(0.55, 0.20, 0.10), 0.08);
+
+          // Tone-map.
+          col = col / (col + vec3(1.0));
+          col = pow(col, vec3(0.85));
+
+          gl_FragColor = vec4(col, 1.0);
+        }
+      `,
+      side: THREE.BackSide,
+      depthWrite: false,
+    });
+
+    this._sphere = new THREE.Mesh(geom, mat);
+    this._sphere.renderOrder = -100;
+    this._sphere.frustumCulled = false;
+    this._sphere.raycast = () => {};
+    this.add(this._sphere);
+    this.visible = false;
+  }
+}

--- a/demos/portals/Portal.js
+++ b/demos/portals/Portal.js
@@ -88,12 +88,11 @@ export class Portal extends THREE.Object3D {
 
     if (this._disc.material.uniforms) {
       this._disc.material.uniforms.uTime.value = this._t;
-      if (camera) {
-        camera.getWorldPosition(this._tmpVec);
-        this.worldToLocal(this._tmpVec);
-        this._disc.material.uniforms.uCamLocal.value.copy(this._tmpVec);
-      }
     }
+    // Note: uCamLocal is updated per-eye in the disc's onBeforeRender so XR
+    // gets correct stereo parallax inside the portal. The `camera` arg here
+    // (mono) would clobber that, so we deliberately don't write uCamLocal
+    // from update().
     if (this._ring.material.uniforms) {
       this._ring.material.uniforms.uTime.value = this._t;
     }
@@ -238,6 +237,16 @@ export class Portal extends THREE.Object3D {
     });
     this._disc = new THREE.Mesh(geom, mat);
     this._disc.renderOrder = 1;
+    // Per-eye stereo: three.js calls onBeforeRender once per camera, including
+    // each sub-camera of an XR ArrayCamera. Updating uCamLocal here means each
+    // eye gets its own ray origin and the world inside the disc has real
+    // parallax depth instead of looking flat.
+    const tmpEye = new THREE.Vector3();
+    this._disc.onBeforeRender = (renderer, sceneArg, camera) => {
+      camera.getWorldPosition(tmpEye);
+      this.worldToLocal(tmpEye);
+      mat.uniforms.uCamLocal.value.copy(tmpEye);
+    };
     this.add(this._disc);
   }
 

--- a/demos/portals/Portal.js
+++ b/demos/portals/Portal.js
@@ -110,6 +110,7 @@ export class Portal extends THREE.Object3D {
     this._ringWarm = ringWarm;
     this._haloInner = haloInner;
     this._haloOuter = haloOuter;
+    this._ringColorExpr = s.ringColorExpr || 'mix(cool, warm, band)';
 
     const sceneUniforms = s.uniforms || {};
     const sceneUniformDecls = Object.entries(sceneUniforms)
@@ -264,11 +265,15 @@ export class Portal extends THREE.Object3D {
       fragmentShader: /* glsl */ `
         uniform float uTime;
         varying vec2 vUv;
+        vec3 hsv2rgb(vec3 c) {
+          vec3 p = abs(fract(c.xxx + vec3(0.0, 2.0/3.0, 1.0/3.0)) * 6.0 - 3.0);
+          return c.z * mix(vec3(1.0), clamp(p - 1.0, 0.0, 1.0), c.y);
+        }
         void main() {
           float band = sin(vUv.x * 30.0 - uTime * 3.0) * 0.5 + 0.5;
           vec3 cool = ${this._ringCool};
           vec3 warm = ${this._ringWarm};
-          vec3 col = mix(cool, warm, band);
+          vec3 col = ${this._ringColorExpr};
           float rim = smoothstep(0.0, 0.5, vUv.y) *
                       smoothstep(1.0, 0.5, vUv.y);
           gl_FragColor = vec4(col * (1.5 + rim * 1.2), 1.0);

--- a/demos/portals/PortalGalleryScene.js
+++ b/demos/portals/PortalGalleryScene.js
@@ -52,7 +52,7 @@ const TRANSITION_COOLDOWN_MS = 600; // Lock new transitions briefly after each
 export class PortalGalleryScene extends xb.Script {
   portals = [];
   labels = [];
-  immersives = []; // index → ImmersiveInstance | null
+  immersives = []; // index -> ImmersiveInstance | null
   clock = new THREE.Clock();
   _held = null;
   _activeIndex = -1; // Portal index user has walked into, or -1.
@@ -167,9 +167,9 @@ export class PortalGalleryScene extends xb.Script {
 
     // Immersive worlds (one per scene that supports walk-in).
     for (let i = 0; i < SCENES.length; i++) {
-      const Cls = IMMERSIVE_BY_NAME[SCENES[i].name];
-      if (Cls) {
-        const inst = new Cls();
+      const ImmersiveClass = IMMERSIVE_BY_NAME[SCENES[i].name];
+      if (ImmersiveClass) {
+        const inst = new ImmersiveClass();
         this.add(inst);
         this.immersives.push(inst);
       } else {

--- a/demos/portals/PortalGalleryScene.js
+++ b/demos/portals/PortalGalleryScene.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import * as xb from 'xrblocks';
 
+import {CosmicImmersive} from './CosmicImmersive.js';
 import {Portal} from './Portal.js';
 import {CosmicScene} from './scenes/CosmicScene.js';
 import {CyberpunkScene} from './scenes/CyberpunkScene.js';
@@ -19,6 +20,9 @@ const SCENES = [
 const ARC_RADIUS = 2.2; // distance from user to each portal (meters)
 const ARC_SPAN = Math.PI * 0.85; // total arc span (~150°)
 
+const COSMIC_INDEX = 2; // CosmicScene is at index 2 in SCENES array.
+const ENTRY_THRESHOLD = 0.9; // Portal radius * factor for plane-crossing check.
+
 /**
  * A gallery of 5 portals arranged in a gentle arc in front of the user.
  * Each portal renders a fully different cinematic world.
@@ -28,12 +32,24 @@ const ARC_SPAN = Math.PI * 0.85; // total arc span (~150°)
  *   2. Click anywhere on the depth mesh to drop it there, snapped to the
  *      surface normal.
  *   3. Click the held portal again (or click empty space twice) to cancel.
+ *   4. Walk through the Cosmic portal to enter immersive space mode.
  */
 export class PortalGalleryScene extends xb.Script {
   portals = [];
   labels = [];
   clock = new THREE.Clock();
   _held = null;
+  _immersive = null;
+  _insidePortal = false;
+  _prevCamLocalZ = 1.0; // Positive = in front of portal.
+  _exitReady = false; // True once user is clearly behind portal after entry.
+  _exitRT = null; // Render target for exit portal view.
+  _exitMat = null; // Material showing the room texture on the disc.
+  _origDiscMat = null; // Original disc material to restore on exit.
+  _exitCam = null; // Virtual camera for exit portal rendering.
+  _fadeSphere = null; // Transition fade overlay.
+  _fadeTarget = 0; // Target opacity (0 = transparent, 1 = opaque).
+  _fadeCallback = null; // Called when fade reaches 1.0 (fully opaque).
 
   init() {
     const userY = xb.user?.height ?? 1.6;
@@ -80,9 +96,60 @@ export class PortalGalleryScene extends xb.Script {
 
     this.add(new THREE.AmbientLight(0x223355, 0.6));
     xb.showReticleOnDepthMesh?.(true);
+
+    // Exit label shown above cosmic portal in immersive mode.
+    this._exitLabel = new xb.SpatialPanel({
+      width: 0.45,
+      height: 0.14,
+      backgroundColor: '#44ff88cc',
+      draggable: false,
+      useBorderlessShader: true,
+    });
+    const exitGrid = this._exitLabel.addGrid();
+    exitGrid.addRow({weight: 0.15});
+    exitGrid.addRow({weight: 0.7}).addText({
+      text: '↩ EXIT',
+      fontColor: '#ffffff',
+      fontSize: 0.09,
+      textAlign: 'center',
+    });
+    exitGrid.addRow({weight: 0.15});
+    this._exitLabel.visible = false;
+    this.add(this._exitLabel);
+
+    // Render target for exit portal view (shows the room the user came from).
+    this._exitRT = new THREE.WebGLRenderTarget(512, 512);
+    this._exitMat = new THREE.MeshBasicMaterial({
+      map: this._exitRT.texture,
+      side: THREE.DoubleSide,
+    });
+    this._exitCam = new THREE.PerspectiveCamera(110, 1, 0.1, 100);
+
+    // Fade sphere for teleport transition.
+    const fadeMat = new THREE.MeshBasicMaterial({
+      color: 0xffffff,
+      transparent: true,
+      opacity: 0,
+      depthTest: false,
+      side: THREE.BackSide,
+    });
+    this._fadeSphere = new THREE.Mesh(
+      new THREE.SphereGeometry(0.5, 16, 16), fadeMat
+    );
+    this._fadeSphere.renderOrder = 9999;
+    this._fadeSphere.frustumCulled = false;
+    this._fadeSphere.raycast = () => {}; // Don't intercept clicks.
+    this.add(this._fadeSphere);
+
+    // Immersive cosmic environment (hidden until walk-in).
+    this._immersive = new CosmicImmersive();
+    this.add(this._immersive);
   }
 
   onSelectStart(event) {
+    // In immersive mode, clicks should not interact with portals.
+    if (this._insidePortal) return;
+
     const controller = event.target;
 
     // If a portal is already held, this click places it on the depth mesh
@@ -125,7 +192,56 @@ export class PortalGalleryScene extends xb.Script {
   update() {
     const dt = Math.min(this.clock.getDelta(), 0.05);
     const cam = xb.core.camera;
+
+    // Animate fade transition and keep it centered on camera.
+    if (cam && this._fadeSphere) {
+      this._fadeSphere.position.copy(cam.position);
+      const mat = this._fadeSphere.material;
+      if (mat.opacity !== this._fadeTarget) {
+        const speed = 26.0; // Fade speed (higher = faster).
+        mat.opacity = THREE.MathUtils.lerp(mat.opacity, this._fadeTarget, dt * speed);
+        if (Math.abs(mat.opacity - this._fadeTarget) < 0.02) {
+          mat.opacity = this._fadeTarget;
+          if (this._fadeTarget === 1 && this._fadeCallback) {
+            this._fadeCallback();
+            this._fadeCallback = null;
+            this._fadeTarget = 0; // Fade back out.
+          }
+        }
+      }
+    }
+
+    // Immersive mode: update sky sphere and check for exit.
+    if (this._insidePortal) {
+      this._immersive.update(dt, cam);
+      if (cam) {
+        this._checkExit(cam);
+        if (!this._insidePortal) return; // Exit just triggered, skip rest.
+        // Billboard exit label toward camera.
+        const portal = this.portals[COSMIC_INDEX];
+        this._exitLabel.position.set(
+          portal.position.x,
+          portal.position.y + Portal.RADIUS + 0.18,
+          portal.position.z
+        );
+        this._exitLabel.lookAt(cam.position);
+        // Keep the cosmic portal's ring animating.
+        portal.update(dt, cam);
+        // Real-time render of the room into exit portal (parallax as user moves).
+        this._captureExitSnapshot(cam);
+      }
+      return;
+    }
+
     for (const p of this.portals) p.update(dt, cam);
+
+    // Continuously update exit snapshot with current camera view.
+    if (cam) this._captureExitSnapshot(cam);
+
+    // Check if user walks through the cosmic portal.
+    if (cam) {
+      this._checkEntry(cam);
+    }
 
     // Make labels face the camera (billboard) and follow their portal's bob.
     if (cam) {
@@ -138,5 +254,125 @@ export class PortalGalleryScene extends xb.Script {
         l.lookAt(cam.position);
       }
     }
+  }
+
+  _checkEntry(cam) {
+    if (this._fadeTarget === 1) return; // Fade in progress.
+    const portal = this.portals[COSMIC_INDEX];
+    // Camera position in portal's local space.
+    const camWorld = cam.getWorldPosition(new THREE.Vector3());
+    const local = portal.worldToLocal(camWorld.clone());
+
+    const radialDist = Math.hypot(local.x, local.y);
+    const curZ = local.z;
+
+    // Crossed from front (z>0) to behind (z<=0) while within disc radius.
+    if (this._prevCamLocalZ > 0 && curZ <= 0 &&
+        radialDist < Portal.RADIUS * ENTRY_THRESHOLD) {
+      this._enterImmersive(portal);
+    }
+
+    this._prevCamLocalZ = curZ;
+  }
+
+  _checkExit(cam) {
+    const portal = this.portals[COSMIC_INDEX];
+    const camWorld = cam.getWorldPosition(new THREE.Vector3());
+    const local = portal.worldToLocal(camWorld.clone());
+
+    const radialDist = Math.hypot(local.x, local.y);
+    const curZ = local.z;
+
+    // After entry, wait until user is clearly behind portal before arming exit.
+    if (!this._exitReady) {
+      if (curZ < -0.05) this._exitReady = true;
+      this._prevCamLocalZ = curZ;
+      return;
+    }
+
+    // Crossed back from behind (z<0) to front (z>=0) within a generous radius.
+    if (this._prevCamLocalZ < 0 && curZ >= 0 &&
+        radialDist < Portal.RADIUS * 1.5) {
+      this._exitImmersive();
+    }
+
+    this._prevCamLocalZ = curZ;
+  }
+
+  _enterImmersive(portal) {
+    // Fade to white, then switch to immersive, then fade back.
+    this._fadeTarget = 1;
+    this._fadeCallback = () => {
+      this._insidePortal = true;
+      this._immersive.show(portal.matrixWorld);
+      this._exitReady = false;
+      this._prevCamLocalZ = -1;
+
+      // Swap cosmic disc to show the room render target.
+      this._origDiscMat = portal._disc.material;
+      portal._disc.material = this._exitMat;
+      portal._disc.visible = true;
+      portal._disc.renderOrder = -1;
+
+      // Hide other portals and all labels.
+      for (let i = 0; i < this.portals.length; i++) {
+        if (i !== COSMIC_INDEX) {
+          this.portals[i].visible = false;
+        }
+        this.labels[i].visible = false;
+      }
+      this._exitLabel.visible = true;
+    };
+  }
+
+  _exitImmersive() {
+    // Fade to white, then switch back to gallery, then fade back.
+    this._fadeTarget = 1;
+    this._fadeCallback = () => {
+      this._insidePortal = false;
+      this._immersive.hide();
+      this._exitLabel.visible = false;
+
+      // Restore original disc material and render order.
+      this.portals[COSMIC_INDEX]._disc.material = this._origDiscMat;
+      this.portals[COSMIC_INDEX]._disc.renderOrder = 0;
+
+      // Show gallery.
+      for (const p of this.portals) p.visible = true;
+      for (const l of this.labels) l.visible = true;
+    };
+  }
+
+  /** Render the simulator room into the exit portal texture with dampened parallax. */
+  _captureExitSnapshot(cam) {
+    const renderer = xb.core.renderer;
+    if (!renderer) return;
+
+    const simScene = xb.core.simulator?.simulatorScene;
+    if (!simScene) return;
+
+    const portal = this.portals[COSMIC_INDEX];
+    const portalPos = portal.getWorldPosition(new THREE.Vector3());
+    const camPos = cam.getWorldPosition(new THREE.Vector3());
+
+    // Place exit camera in front of portal (room side), offset slightly by user movement.
+    // Portal local +Z points toward room center, so step forward from portal.
+    const forward = new THREE.Vector3(0, 0, 1).applyQuaternion(portal.quaternion);
+    const roomCamBase = portalPos.clone().add(forward.clone().multiplyScalar(0.3));
+
+    const PARALLAX_FACTOR = 0.15;
+    this._exitCam.position.set(
+      roomCamBase.x + (camPos.x - portalPos.x) * PARALLAX_FACTOR,
+      roomCamBase.y + (camPos.y - portalPos.y) * PARALLAX_FACTOR,
+      roomCamBase.z
+    );
+    // Look in the same direction (deeper into room).
+    this._exitCam.lookAt(this._exitCam.position.clone().add(forward));
+
+    const oldRT = renderer.getRenderTarget();
+    renderer.setRenderTarget(this._exitRT);
+    renderer.clear();
+    renderer.render(simScene, this._exitCam);
+    renderer.setRenderTarget(oldRT);
   }
 }

--- a/demos/portals/PortalGalleryScene.js
+++ b/demos/portals/PortalGalleryScene.js
@@ -35,6 +35,8 @@ const ARC_RADIUS = 2.2; // distance from user to each portal (meters)
 const ARC_SPAN = Math.PI * 0.85; // total arc span (~150°)
 
 const ENTRY_THRESHOLD = 0.9; // Portal radius * factor for plane-crossing check.
+const TRANSITION_COOLDOWN_MS = 600; // Lock new transitions briefly after each
+// fade so the very-next frame doesn't reverse-cross and snap us back.
 
 /**
  * A gallery of 5 portals arranged in a gentle arc in front of the user.
@@ -65,6 +67,7 @@ export class PortalGalleryScene extends xb.Script {
   _fadeSphere = null; // Transition fade overlay.
   _fadeTarget = 0; // Target opacity (0 = transparent, 1 = opaque).
   _fadeCallback = null; // Called when fade reaches 1.0 (fully opaque).
+  _transitionCooldownUntil = 0; // performance.now() timestamp; before this, no transitions fire.
 
   init() {
     const userY = xb.user?.height ?? 1.6;
@@ -243,6 +246,11 @@ export class PortalGalleryScene extends xb.Script {
     if (this._insidePortal) {
       this._activeImmersive.update(dt, cam);
       if (cam) {
+        // Real-time render of the room into exit portal (parallax as user moves).
+        // Only needed while in immersive mode — the disc shows the room snapshot
+        // here. In gallery mode the disc shows its scene shader, so the snapshot
+        // would be a wasted render pass.
+        this._captureExitSnapshot(cam, this.portals[this._activeIndex]);
         this._checkExit(cam);
         if (!this._insidePortal) return; // Exit just triggered, skip rest.
         // Billboard exit label toward camera.
@@ -255,24 +263,11 @@ export class PortalGalleryScene extends xb.Script {
         this._exitLabel.lookAt(cam.position);
         // Keep the active portal's ring animating.
         portal.update(dt, cam);
-        // Real-time render of the room into exit portal (parallax as user moves).
-        this._captureExitSnapshot(cam, portal);
       }
       return;
     }
 
     for (const p of this.portals) p.update(dt, cam);
-
-    // Continuously update exit snapshot for any portal that supports walk-in.
-    // (Picks the closest walk-in portal so its disc shows live room view.)
-    if (cam) {
-      for (let i = 0; i < this.portals.length; i++) {
-        if (this.immersives[i]) {
-          this._captureExitSnapshot(cam, this.portals[i]);
-          break;
-        }
-      }
-    }
 
     // Check if user walks through any walk-in capable portal.
     if (cam) {
@@ -294,24 +289,30 @@ export class PortalGalleryScene extends xb.Script {
 
   _checkEntry(cam) {
     if (this._fadeTarget === 1) return; // Fade in progress.
+    if (performance.now() < this._transitionCooldownUntil) return;
     const camWorld = cam.getWorldPosition(new THREE.Vector3());
 
     // Check each walk-in capable portal. First crossing wins.
+    // Crossing in EITHER direction triggers entry; fromSide tells the
+    // immersive which way the user was facing so it can spawn them
+    // pointing into the scene rather than at the back wall.
     for (let i = 0; i < this.portals.length; i++) {
       if (!this.immersives[i]) continue;
       const portal = this.portals[i];
       const local = portal.worldToLocal(camWorld.clone());
       const radialDist = Math.hypot(local.x, local.y);
       const curZ = local.z;
-      const prevZ = portal._prevCamLocalZ ?? 1.0;
+      const prevZ = portal._prevCamLocalZ ?? curZ;
 
+      const crossedFront = prevZ > 0 && curZ <= 0;
+      const crossedBack = prevZ < 0 && curZ >= 0;
       if (
-        prevZ > 0 &&
-        curZ <= 0 &&
+        (crossedFront || crossedBack) &&
         radialDist < Portal.RADIUS * ENTRY_THRESHOLD
       ) {
         portal._prevCamLocalZ = curZ;
-        this._enterImmersive(portal, i);
+        const fromSide = crossedFront ? 'front' : 'back';
+        this._enterImmersive(portal, i, fromSide);
         return;
       }
       portal._prevCamLocalZ = curZ;
@@ -319,6 +320,7 @@ export class PortalGalleryScene extends xb.Script {
   }
 
   _checkExit(cam) {
+    if (performance.now() < this._transitionCooldownUntil) return;
     const portal = this.portals[this._activeIndex];
     const camWorld = cam.getWorldPosition(new THREE.Vector3());
     const local = portal.worldToLocal(camWorld.clone());
@@ -326,35 +328,39 @@ export class PortalGalleryScene extends xb.Script {
     const radialDist = Math.hypot(local.x, local.y);
     const curZ = local.z;
 
-    // After entry, wait until user is clearly behind portal before arming exit.
+    // After entry, wait until user is clearly off the portal plane (either
+    // side) before arming exit. This avoids firing on the entry transition
+    // itself.
     if (!this._exitReady) {
-      if (curZ < -0.05) this._exitReady = true;
+      if (Math.abs(curZ) > 0.05) this._exitReady = true;
       this._prevCamLocalZ = curZ;
       return;
     }
 
-    // Crossed back from behind (z<0) to front (z>=0) within a generous radius.
-    if (
-      this._prevCamLocalZ < 0 &&
-      curZ >= 0 &&
-      radialDist < Portal.RADIUS * 1.5
-    ) {
+    // Any zero-crossing in z (front↔back, either direction) within a
+    // generous radius triggers exit.
+    const crossed =
+      (this._prevCamLocalZ > 0 && curZ <= 0) ||
+      (this._prevCamLocalZ < 0 && curZ >= 0);
+    if (crossed && radialDist < Portal.RADIUS * 1.5) {
       this._exitImmersive();
     }
 
     this._prevCamLocalZ = curZ;
   }
 
-  _enterImmersive(portal, index) {
+  _enterImmersive(portal, index, fromSide) {
     // Fade to white, then switch to immersive, then fade back.
     this._fadeTarget = 1;
     this._fadeCallback = () => {
       this._insidePortal = true;
       this._activeIndex = index;
       this._activeImmersive = this.immersives[index];
-      this._activeImmersive.show(portal.matrixWorld);
+      this._activeImmersive.show(portal.matrixWorld, fromSide);
       this._exitReady = false;
-      this._prevCamLocalZ = -1;
+      this._prevCamLocalZ = fromSide === 'front' ? -1 : 1;
+      this._transitionCooldownUntil =
+        performance.now() + TRANSITION_COOLDOWN_MS;
 
       // Swap active portal's disc to show the room render target.
       this._origDiscMat = portal._disc.material;
@@ -380,11 +386,18 @@ export class PortalGalleryScene extends xb.Script {
       this._insidePortal = false;
       this._activeImmersive.hide();
       this._exitLabel.visible = false;
+      this._transitionCooldownUntil =
+        performance.now() + TRANSITION_COOLDOWN_MS;
 
-      // Restore original disc material and render order.
+      // Restore original disc material and render order (matches the value
+      // set in Portal._buildDisc — must be 1, not 0, or the disc sorts
+      // behind other portals' rings/halos after the first cycle).
       const portal = this.portals[this._activeIndex];
       portal._disc.material = this._origDiscMat;
-      portal._disc.renderOrder = 0;
+      portal._disc.renderOrder = 1;
+      // Reset crossing state on every portal so the user can immediately
+      // re-enter without a phantom prevZ from before entry firing.
+      for (const p of this.portals) p._prevCamLocalZ = undefined;
 
       this._activeIndex = -1;
       this._activeImmersive = null;

--- a/demos/portals/PortalGalleryScene.js
+++ b/demos/portals/PortalGalleryScene.js
@@ -3,6 +3,7 @@ import * as xb from 'xrblocks';
 
 import {CosmicImmersive} from './CosmicImmersive.js';
 import {ForestImmersive} from './ForestImmersive.js';
+import {LavaImmersive} from './LavaImmersive.js';
 import {Portal} from './Portal.js';
 import {CosmicScene} from './scenes/CosmicScene.js';
 import {CyberpunkScene} from './scenes/CyberpunkScene.js';
@@ -25,6 +26,7 @@ const IMMERSIVE_BY_NAME = {
   Cosmic: CosmicImmersive,
   Forest: ForestImmersive,
   Underwater: UnderwaterImmersive,
+  Volcano: LavaImmersive,
 };
 
 const ARC_RADIUS = 2.2; // distance from user to each portal (meters)

--- a/demos/portals/PortalGalleryScene.js
+++ b/demos/portals/PortalGalleryScene.js
@@ -68,6 +68,11 @@ export class PortalGalleryScene extends xb.Script {
   _fadeTarget = 0; // Target opacity (0 = transparent, 1 = opaque).
   _fadeCallback = null; // Called when fade reaches 1.0 (fully opaque).
   _transitionCooldownUntil = 0; // performance.now() timestamp; before this, no transitions fire.
+  _exitFrameTick = 0; // Counter to throttle exit-snapshot RT renders.
+  _tmpV1 = new THREE.Vector3();
+  _tmpV2 = new THREE.Vector3();
+  _tmpV3 = new THREE.Vector3();
+  _tmpV4 = new THREE.Vector3();
 
   init() {
     const userY = xb.user?.height ?? 1.6;
@@ -136,7 +141,7 @@ export class PortalGalleryScene extends xb.Script {
     this.add(this._exitLabel);
 
     // Render target for exit portal view (shows the room the user came from).
-    this._exitRT = new THREE.WebGLRenderTarget(512, 512);
+    this._exitRT = new THREE.WebGLRenderTarget(256, 256);
     this._exitMat = new THREE.MeshBasicMaterial({
       map: this._exitRT.texture,
       side: THREE.DoubleSide,
@@ -290,7 +295,7 @@ export class PortalGalleryScene extends xb.Script {
   _checkEntry(cam) {
     if (this._fadeTarget === 1) return; // Fade in progress.
     if (performance.now() < this._transitionCooldownUntil) return;
-    const camWorld = cam.getWorldPosition(new THREE.Vector3());
+    const camWorld = cam.getWorldPosition(this._tmpV1);
 
     // Check each walk-in capable portal. First crossing wins.
     // Crossing in EITHER direction triggers entry; fromSide tells the
@@ -299,7 +304,7 @@ export class PortalGalleryScene extends xb.Script {
     for (let i = 0; i < this.portals.length; i++) {
       if (!this.immersives[i]) continue;
       const portal = this.portals[i];
-      const local = portal.worldToLocal(camWorld.clone());
+      const local = portal.worldToLocal(this._tmpV2.copy(camWorld));
       const radialDist = Math.hypot(local.x, local.y);
       const curZ = local.z;
       const prevZ = portal._prevCamLocalZ ?? curZ;
@@ -322,8 +327,8 @@ export class PortalGalleryScene extends xb.Script {
   _checkExit(cam) {
     if (performance.now() < this._transitionCooldownUntil) return;
     const portal = this.portals[this._activeIndex];
-    const camWorld = cam.getWorldPosition(new THREE.Vector3());
-    const local = portal.worldToLocal(camWorld.clone());
+    const camWorld = cam.getWorldPosition(this._tmpV1);
+    const local = portal.worldToLocal(this._tmpV2.copy(camWorld));
 
     const radialDist = Math.hypot(local.x, local.y);
     const curZ = local.z;
@@ -410,23 +415,26 @@ export class PortalGalleryScene extends xb.Script {
 
   /** Render the simulator room into the exit portal texture with dampened parallax. */
   _captureExitSnapshot(cam, portal) {
+    // Throttle to every other frame — the room behind the user is mostly
+    // static so a half-rate update is visually indistinguishable.
+    this._exitFrameTick = (this._exitFrameTick + 1) % 2;
+    if (this._exitFrameTick !== 0) return;
+
     const renderer = xb.core.renderer;
     if (!renderer) return;
 
     const simScene = xb.core.simulator?.simulatorScene;
     if (!simScene) return;
 
-    const portalPos = portal.getWorldPosition(new THREE.Vector3());
-    const camPos = cam.getWorldPosition(new THREE.Vector3());
+    const portalPos = portal.getWorldPosition(this._tmpV1);
+    const camPos = cam.getWorldPosition(this._tmpV2);
 
     // Place exit camera in front of portal (room side), offset slightly by user movement.
     // Portal local +Z points toward room center, so step forward from portal.
-    const forward = new THREE.Vector3(0, 0, 1).applyQuaternion(
-      portal.quaternion
-    );
-    const roomCamBase = portalPos
-      .clone()
-      .add(forward.clone().multiplyScalar(0.3));
+    const forward = this._tmpV3.set(0, 0, 1).applyQuaternion(portal.quaternion);
+    const roomCamBase = this._tmpV4
+      .copy(portalPos)
+      .addScaledVector(forward, 0.3);
 
     const PARALLAX_FACTOR = 0.15;
     this._exitCam.position.set(
@@ -435,7 +443,11 @@ export class PortalGalleryScene extends xb.Script {
       roomCamBase.z
     );
     // Look in the same direction (deeper into room).
-    this._exitCam.lookAt(this._exitCam.position.clone().add(forward));
+    this._exitCam.lookAt(
+      this._exitCam.position.x + forward.x,
+      this._exitCam.position.y + forward.y,
+      this._exitCam.position.z + forward.z
+    );
 
     const oldRT = renderer.getRenderTarget();
     renderer.setRenderTarget(this._exitRT);

--- a/demos/portals/PortalGalleryScene.js
+++ b/demos/portals/PortalGalleryScene.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import * as xb from 'xrblocks';
 
 import {CosmicImmersive} from './CosmicImmersive.js';
+import {CyberpunkImmersive} from './CyberpunkImmersive.js';
 import {ForestImmersive} from './ForestImmersive.js';
 import {LavaImmersive} from './LavaImmersive.js';
 import {Portal} from './Portal.js';
@@ -27,6 +28,7 @@ const IMMERSIVE_BY_NAME = {
   Forest: ForestImmersive,
   Underwater: UnderwaterImmersive,
   Volcano: LavaImmersive,
+  Cyberpunk: CyberpunkImmersive,
 };
 
 const ARC_RADIUS = 2.2; // distance from user to each portal (meters)

--- a/demos/portals/PortalGalleryScene.js
+++ b/demos/portals/PortalGalleryScene.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import * as xb from 'xrblocks';
 
 import {CosmicImmersive} from './CosmicImmersive.js';
+import {ForestImmersive} from './ForestImmersive.js';
 import {Portal} from './Portal.js';
 import {CosmicScene} from './scenes/CosmicScene.js';
 import {CyberpunkScene} from './scenes/CyberpunkScene.js';
@@ -17,10 +18,16 @@ const SCENES = [
   CyberpunkScene,
 ];
 
+// Map scene name → walk-in immersive class. Scenes without an entry
+// behave as decorative portals only (no walk-in).
+const IMMERSIVE_BY_NAME = {
+  Cosmic: CosmicImmersive,
+  Forest: ForestImmersive,
+};
+
 const ARC_RADIUS = 2.2; // distance from user to each portal (meters)
 const ARC_SPAN = Math.PI * 0.85; // total arc span (~150°)
 
-const COSMIC_INDEX = 2; // CosmicScene is at index 2 in SCENES array.
 const ENTRY_THRESHOLD = 0.9; // Portal radius * factor for plane-crossing check.
 
 /**
@@ -37,9 +44,11 @@ const ENTRY_THRESHOLD = 0.9; // Portal radius * factor for plane-crossing check.
 export class PortalGalleryScene extends xb.Script {
   portals = [];
   labels = [];
+  immersives = []; // index → ImmersiveInstance | null
   clock = new THREE.Clock();
   _held = null;
-  _immersive = null;
+  _activeIndex = -1; // Portal index user has walked into, or -1.
+  _activeImmersive = null;
   _insidePortal = false;
   _prevCamLocalZ = 1.0; // Positive = in front of portal.
   _exitReady = false; // True once user is clearly behind portal after entry.
@@ -134,16 +143,25 @@ export class PortalGalleryScene extends xb.Script {
       side: THREE.BackSide,
     });
     this._fadeSphere = new THREE.Mesh(
-      new THREE.SphereGeometry(0.5, 16, 16), fadeMat
+      new THREE.SphereGeometry(0.5, 16, 16),
+      fadeMat
     );
     this._fadeSphere.renderOrder = 9999;
     this._fadeSphere.frustumCulled = false;
     this._fadeSphere.raycast = () => {}; // Don't intercept clicks.
     this.add(this._fadeSphere);
 
-    // Immersive cosmic environment (hidden until walk-in).
-    this._immersive = new CosmicImmersive();
-    this.add(this._immersive);
+    // Immersive worlds (one per scene that supports walk-in).
+    for (let i = 0; i < SCENES.length; i++) {
+      const Cls = IMMERSIVE_BY_NAME[SCENES[i].name];
+      if (Cls) {
+        const inst = new Cls();
+        this.add(inst);
+        this.immersives.push(inst);
+      } else {
+        this.immersives.push(null);
+      }
+    }
   }
 
   onSelectStart(event) {
@@ -199,7 +217,11 @@ export class PortalGalleryScene extends xb.Script {
       const mat = this._fadeSphere.material;
       if (mat.opacity !== this._fadeTarget) {
         const speed = 26.0; // Fade speed (higher = faster).
-        mat.opacity = THREE.MathUtils.lerp(mat.opacity, this._fadeTarget, dt * speed);
+        mat.opacity = THREE.MathUtils.lerp(
+          mat.opacity,
+          this._fadeTarget,
+          dt * speed
+        );
         if (Math.abs(mat.opacity - this._fadeTarget) < 0.02) {
           mat.opacity = this._fadeTarget;
           if (this._fadeTarget === 1 && this._fadeCallback) {
@@ -213,32 +235,40 @@ export class PortalGalleryScene extends xb.Script {
 
     // Immersive mode: update sky sphere and check for exit.
     if (this._insidePortal) {
-      this._immersive.update(dt, cam);
+      this._activeImmersive.update(dt, cam);
       if (cam) {
         this._checkExit(cam);
         if (!this._insidePortal) return; // Exit just triggered, skip rest.
         // Billboard exit label toward camera.
-        const portal = this.portals[COSMIC_INDEX];
+        const portal = this.portals[this._activeIndex];
         this._exitLabel.position.set(
           portal.position.x,
           portal.position.y + Portal.RADIUS + 0.18,
           portal.position.z
         );
         this._exitLabel.lookAt(cam.position);
-        // Keep the cosmic portal's ring animating.
+        // Keep the active portal's ring animating.
         portal.update(dt, cam);
         // Real-time render of the room into exit portal (parallax as user moves).
-        this._captureExitSnapshot(cam);
+        this._captureExitSnapshot(cam, portal);
       }
       return;
     }
 
     for (const p of this.portals) p.update(dt, cam);
 
-    // Continuously update exit snapshot with current camera view.
-    if (cam) this._captureExitSnapshot(cam);
+    // Continuously update exit snapshot for any portal that supports walk-in.
+    // (Picks the closest walk-in portal so its disc shows live room view.)
+    if (cam) {
+      for (let i = 0; i < this.portals.length; i++) {
+        if (this.immersives[i]) {
+          this._captureExitSnapshot(cam, this.portals[i]);
+          break;
+        }
+      }
+    }
 
-    // Check if user walks through the cosmic portal.
+    // Check if user walks through any walk-in capable portal.
     if (cam) {
       this._checkEntry(cam);
     }
@@ -258,25 +288,32 @@ export class PortalGalleryScene extends xb.Script {
 
   _checkEntry(cam) {
     if (this._fadeTarget === 1) return; // Fade in progress.
-    const portal = this.portals[COSMIC_INDEX];
-    // Camera position in portal's local space.
     const camWorld = cam.getWorldPosition(new THREE.Vector3());
-    const local = portal.worldToLocal(camWorld.clone());
 
-    const radialDist = Math.hypot(local.x, local.y);
-    const curZ = local.z;
+    // Check each walk-in capable portal. First crossing wins.
+    for (let i = 0; i < this.portals.length; i++) {
+      if (!this.immersives[i]) continue;
+      const portal = this.portals[i];
+      const local = portal.worldToLocal(camWorld.clone());
+      const radialDist = Math.hypot(local.x, local.y);
+      const curZ = local.z;
+      const prevZ = portal._prevCamLocalZ ?? 1.0;
 
-    // Crossed from front (z>0) to behind (z<=0) while within disc radius.
-    if (this._prevCamLocalZ > 0 && curZ <= 0 &&
-        radialDist < Portal.RADIUS * ENTRY_THRESHOLD) {
-      this._enterImmersive(portal);
+      if (
+        prevZ > 0 &&
+        curZ <= 0 &&
+        radialDist < Portal.RADIUS * ENTRY_THRESHOLD
+      ) {
+        portal._prevCamLocalZ = curZ;
+        this._enterImmersive(portal, i);
+        return;
+      }
+      portal._prevCamLocalZ = curZ;
     }
-
-    this._prevCamLocalZ = curZ;
   }
 
   _checkExit(cam) {
-    const portal = this.portals[COSMIC_INDEX];
+    const portal = this.portals[this._activeIndex];
     const camWorld = cam.getWorldPosition(new THREE.Vector3());
     const local = portal.worldToLocal(camWorld.clone());
 
@@ -291,24 +328,29 @@ export class PortalGalleryScene extends xb.Script {
     }
 
     // Crossed back from behind (z<0) to front (z>=0) within a generous radius.
-    if (this._prevCamLocalZ < 0 && curZ >= 0 &&
-        radialDist < Portal.RADIUS * 1.5) {
+    if (
+      this._prevCamLocalZ < 0 &&
+      curZ >= 0 &&
+      radialDist < Portal.RADIUS * 1.5
+    ) {
       this._exitImmersive();
     }
 
     this._prevCamLocalZ = curZ;
   }
 
-  _enterImmersive(portal) {
+  _enterImmersive(portal, index) {
     // Fade to white, then switch to immersive, then fade back.
     this._fadeTarget = 1;
     this._fadeCallback = () => {
       this._insidePortal = true;
-      this._immersive.show(portal.matrixWorld);
+      this._activeIndex = index;
+      this._activeImmersive = this.immersives[index];
+      this._activeImmersive.show(portal.matrixWorld);
       this._exitReady = false;
       this._prevCamLocalZ = -1;
 
-      // Swap cosmic disc to show the room render target.
+      // Swap active portal's disc to show the room render target.
       this._origDiscMat = portal._disc.material;
       portal._disc.material = this._exitMat;
       portal._disc.visible = true;
@@ -316,7 +358,7 @@ export class PortalGalleryScene extends xb.Script {
 
       // Hide other portals and all labels.
       for (let i = 0; i < this.portals.length; i++) {
-        if (i !== COSMIC_INDEX) {
+        if (i !== index) {
           this.portals[i].visible = false;
         }
         this.labels[i].visible = false;
@@ -330,12 +372,16 @@ export class PortalGalleryScene extends xb.Script {
     this._fadeTarget = 1;
     this._fadeCallback = () => {
       this._insidePortal = false;
-      this._immersive.hide();
+      this._activeImmersive.hide();
       this._exitLabel.visible = false;
 
       // Restore original disc material and render order.
-      this.portals[COSMIC_INDEX]._disc.material = this._origDiscMat;
-      this.portals[COSMIC_INDEX]._disc.renderOrder = 0;
+      const portal = this.portals[this._activeIndex];
+      portal._disc.material = this._origDiscMat;
+      portal._disc.renderOrder = 0;
+
+      this._activeIndex = -1;
+      this._activeImmersive = null;
 
       // Show gallery.
       for (const p of this.portals) p.visible = true;
@@ -344,21 +390,24 @@ export class PortalGalleryScene extends xb.Script {
   }
 
   /** Render the simulator room into the exit portal texture with dampened parallax. */
-  _captureExitSnapshot(cam) {
+  _captureExitSnapshot(cam, portal) {
     const renderer = xb.core.renderer;
     if (!renderer) return;
 
     const simScene = xb.core.simulator?.simulatorScene;
     if (!simScene) return;
 
-    const portal = this.portals[COSMIC_INDEX];
     const portalPos = portal.getWorldPosition(new THREE.Vector3());
     const camPos = cam.getWorldPosition(new THREE.Vector3());
 
     // Place exit camera in front of portal (room side), offset slightly by user movement.
     // Portal local +Z points toward room center, so step forward from portal.
-    const forward = new THREE.Vector3(0, 0, 1).applyQuaternion(portal.quaternion);
-    const roomCamBase = portalPos.clone().add(forward.clone().multiplyScalar(0.3));
+    const forward = new THREE.Vector3(0, 0, 1).applyQuaternion(
+      portal.quaternion
+    );
+    const roomCamBase = portalPos
+      .clone()
+      .add(forward.clone().multiplyScalar(0.3));
 
     const PARALLAX_FACTOR = 0.15;
     this._exitCam.position.set(

--- a/demos/portals/PortalGalleryScene.js
+++ b/demos/portals/PortalGalleryScene.js
@@ -9,6 +9,7 @@ import {CyberpunkScene} from './scenes/CyberpunkScene.js';
 import {ForestScene} from './scenes/ForestScene.js';
 import {LavaScene} from './scenes/LavaScene.js';
 import {UnderwaterScene} from './scenes/UnderwaterScene.js';
+import {UnderwaterImmersive} from './UnderwaterImmersive.js';
 
 const SCENES = [
   UnderwaterScene,
@@ -23,6 +24,7 @@ const SCENES = [
 const IMMERSIVE_BY_NAME = {
   Cosmic: CosmicImmersive,
   Forest: ForestImmersive,
+  Underwater: UnderwaterImmersive,
 };
 
 const ARC_RADIUS = 2.2; // distance from user to each portal (meters)

--- a/demos/portals/PortalGalleryScene.js
+++ b/demos/portals/PortalGalleryScene.js
@@ -114,8 +114,8 @@ export class PortalGalleryScene extends xb.Script {
 
     // Exit label shown above cosmic portal in immersive mode.
     this._exitLabel = new xb.SpatialPanel({
-      width: 0.45,
-      height: 0.14,
+      width: 0.7,
+      height: 0.22,
       backgroundColor: '#44ff88cc',
       draggable: false,
       useBorderlessShader: true,
@@ -125,7 +125,7 @@ export class PortalGalleryScene extends xb.Script {
     exitGrid.addRow({weight: 0.7}).addText({
       text: '↩ EXIT',
       fontColor: '#ffffff',
-      fontSize: 0.09,
+      fontSize: 0.16,
       textAlign: 'center',
     });
     exitGrid.addRow({weight: 0.15});

--- a/demos/portals/UnderwaterImmersive.js
+++ b/demos/portals/UnderwaterImmersive.js
@@ -134,22 +134,57 @@ export class UnderwaterImmersive extends THREE.Object3D {
           return -b - sqrt(d);
         }
 
-        // Drifting jellyfish: ellipsoidal bell + faint trailing tendrils.
-        // Returns additive color contribution along the ray.
+        // Drifting jellyfish: glowing bell on top + trailing tendrils below.
         vec3 jellyfish(vec3 ro, vec3 rd, vec3 pos, float t, float seed) {
           vec3 oc = pos - ro;
           float along = dot(oc, rd);
           if (along < 0.5 || along > 25.0) return vec3(0.0);
-          vec3 proj = ro + rd * along;
-          float d = length(pos - proj);
-          float bellR = 0.5 + 0.1 * sin(t * 1.2 + seed * 7.0);
-          float bell = smoothstep(bellR, 0.0, d) * 0.55;
-          // Glow halo
-          float halo = smoothstep(bellR * 3.0, bellR, d) * 0.18;
           float fade = 1.0 / (1.0 + along * 0.08);
+          float pulse = 0.5 + 0.5 * sin(t * 1.2 + seed * 7.0);
           vec3 color = mix(vec3(0.4, 0.85, 1.0), vec3(0.85, 0.55, 1.0),
                            sin(t + seed) * 0.5 + 0.5);
-          return color * (bell + halo) * fade;
+
+          // ---- Bell (upper hemisphere of a sphere) ----
+          float bellR = 0.28 + 0.04 * pulse;
+          float th = raySphere(ro, rd, pos, bellR);
+          float bellHit = 0.0;
+          if (th > 0.0) {
+            vec3 hp = ro + rd * th;
+            vec3 n = normalize(hp - pos);
+            // Only the dome (top half).
+            if (n.y > -0.05) {
+              // Edge glow: fresnel-ish (rim brighter).
+              float rim = pow(1.0 - max(-dot(rd, n), 0.0), 2.5);
+              // Translucent fill (brighter near top center).
+              float fill = smoothstep(-0.1, 1.0, n.y) * 0.6;
+              bellHit = (fill + rim * 0.9) * (0.7 + pulse * 0.4);
+            }
+          }
+
+          // ---- Tendrils: 6 vertical streamers hanging below bell ----
+          float tendril = 0.0;
+          vec3 proj = ro + rd * along;
+          vec3 d = proj - pos;
+          // Sample only if ray passes near bell center horizontally and below it.
+          float horizD = length(d.xz);
+          if (horizD < bellR * 1.4 && d.y < 0.0 && d.y > -1.0) {
+            for (int k = 0; k < 6; k++) {
+              float fk = float(k);
+              float ang = fk / 6.0 * 6.28318;
+              vec2 base = vec2(cos(ang), sin(ang)) * bellR * 0.6;
+              // Sway tendrils.
+              base += vec2(sin(t * 1.5 + fk + seed) * 0.02,
+                           cos(t * 1.3 + fk * 1.7) * 0.02);
+              float dx = length(d.xz - base);
+              tendril += smoothstep(0.025, 0.0, dx)
+                       * smoothstep(0.0, -0.8, d.y);
+            }
+          }
+
+          // ---- Soft halo behind the whole creature ----
+          float halo = smoothstep(bellR * 3.0, bellR, length(d)) * 0.18;
+
+          return color * (bellHit + tendril * 0.5 + halo) * fade;
         }
 
         // Whale shark silhouette swimming past: oriented body, falls dim.
@@ -202,6 +237,383 @@ export class UnderwaterImmersive extends THREE.Object3D {
             float bubble = smoothstep(r, 0.0, d) * 0.4;
             float fade = 1.0 / (1.0 + along * 0.15);
             col += vec3(0.85, 0.95, 1.00) * bubble * fade;
+          }
+          return col;
+        }
+
+        // Schools of clownfish: ray-ellipsoid body with proper shading,
+        // black/white bands, eye, and tail fin. Lit by surface sunlight.
+        // Ray-ellipsoid: returns nearest t, or -1.
+        float rayEllip(vec3 ro, vec3 rd, vec3 axes) {
+          vec3 roS = ro / axes;
+          vec3 rdS = rd / axes;
+          float A = dot(rdS, rdS);
+          float B = dot(roS, rdS);
+          float C = dot(roS, roS) - 1.0;
+          float d = B * B - A * C;
+          if (d < 0.0) return -1.0;
+          return (-B - sqrt(d)) / A;
+        }
+
+        // Detailed clownfish: body + peduncle + dorsal + 2 pectoral fins +
+        // forked caudal. Lit by surface sun. 2 schools x 3 fish.
+        vec3 clownfishSchool(vec3 ro, vec3 rd, float t) {
+          vec3 col = vec3(0.0);
+          vec3 sunDir = normalize(vec3(0.2, 1.0, -0.3));
+          vec3 bodyAxes = vec3(0.28, 0.16, 0.105);
+          vec3 tailAxes = vec3(0.10, 0.07, 0.028);
+          vec3 dorsalAxes = vec3(0.13, 0.11, 0.013);
+          vec3 pectAxes = vec3(0.08, 0.018, 0.06);
+          for (int s = 0; s < 2; s++) {
+            float fs = float(s);
+            vec3 schoolC = vec3(
+                sin(t * 0.04 + fs * 2.1) * 2.5 + cos(fs * 3.7) * 1.5,
+                -0.3 + sin(t * 0.05 + fs) * 0.4,
+                cos(t * 0.045 + fs * 1.7) * 2.5 + sin(fs * 2.3) * 1.2);
+            vec3 fwd = normalize(vec3(
+                cos(t * 0.04 + fs * 2.1) * 2.5,
+                0.0,
+                -sin(t * 0.045 + fs * 1.7) * 2.5) + vec3(0.001));
+            vec3 sideAx = normalize(cross(fwd, vec3(0.0, 1.0, 0.0)));
+            for (int i = 0; i < 3; i++) {
+              float fi = float(i);
+              float seed = fs * 7.0 + fi * 1.3;
+              vec3 off = vec3(
+                  cos(seed) * 0.9 + sin(seed * 3.7) * 0.3,
+                  sin(seed * 1.7) * 0.20,
+                  sin(seed) * 0.9 + cos(seed * 2.1) * 0.3);
+              vec3 pos = schoolC + off;
+              float wig = sin(t * 3.5 + seed * 4.0) * 0.05;
+              vec3 fwdW = normalize(fwd + sideAx * wig);
+              vec3 sideW = normalize(cross(fwdW, vec3(0.0, 1.0, 0.0)));
+              vec3 upW = normalize(cross(sideW, fwdW));
+
+              vec3 oc = ro - pos;
+              vec3 roL = vec3(dot(oc, fwdW), dot(oc, upW), dot(oc, sideW));
+              vec3 rdL = vec3(dot(rd, fwdW), dot(rd, upW), dot(rd, sideW));
+
+              // Body ellipsoid (head pointing +x).
+              vec3 bodyOff = vec3(0.05, 0.0, 0.0);
+              float tBody = rayEllip(roL - bodyOff, rdL, bodyAxes);
+              // Tail peduncle.
+              vec3 tailOff = vec3(-0.18, 0.0, 0.0);
+              float tTail = rayEllip(roL - tailOff, rdL, tailAxes);
+              // Dorsal fin (thin in z, tall in y, on top).
+              vec3 dorsalOff = vec3(0.02, 0.20, 0.0);
+              float tDor = rayEllip(roL - dorsalOff, rdL, dorsalAxes);
+              // Pectoral fins (left & right, swept slightly back).
+              vec3 pectOffL = vec3(0.06, -0.05, 0.10);
+              vec3 pectOffR = vec3(0.06, -0.05, -0.10);
+              float tPL = rayEllip(roL - pectOffL, rdL, pectAxes);
+              float tPR = rayEllip(roL - pectOffR, rdL, pectAxes);
+
+              // Closest hit + which part.
+              float tH = -1.0;
+              int which = 0;
+              if (tBody > 0.3 && tBody < 18.0) { tH = tBody; which = 1; }
+              if (tTail > 0.3 && tTail < 18.0 &&
+                  (tH < 0.0 || tTail < tH)) { tH = tTail; which = 2; }
+              if (tDor > 0.3 && tDor < 18.0 &&
+                  (tH < 0.0 || tDor < tH)) { tH = tDor; which = 3; }
+              if (tPL > 0.3 && tPL < 18.0 &&
+                  (tH < 0.0 || tPL < tH)) { tH = tPL; which = 4; }
+              if (tPR > 0.3 && tPR < 18.0 &&
+                  (tH < 0.0 || tPR < tH)) { tH = tPR; which = 5; }
+
+              if (which > 0) {
+                vec3 hpL = roL + rdL * tH;
+                vec3 nL;
+                if (which == 1) {
+                  nL = normalize((hpL - bodyOff) / (bodyAxes * bodyAxes));
+                } else if (which == 2) {
+                  nL = normalize((hpL - tailOff) / (tailAxes * tailAxes));
+                } else if (which == 3) {
+                  nL = normalize((hpL - dorsalOff) / (dorsalAxes * dorsalAxes));
+                } else if (which == 4) {
+                  nL = normalize((hpL - pectOffL) / (pectAxes * pectAxes));
+                } else {
+                  nL = normalize((hpL - pectOffR) / (pectAxes * pectAxes));
+                }
+                vec3 nW = sideW * nL.z + upW * nL.y + fwdW * nL.x;
+                float u = hpL.x / 0.30;
+                float v = hpL.y / 0.16;
+                vec3 base = vec3(1.00, 0.45, 0.05);
+                if (which == 1) {
+                  // Three white bands w/ black trim, only on body.
+                  float bandD = min(min(abs(u - 0.55), abs(u - 0.05)),
+                                    abs(u + 0.4));
+                  float white = smoothstep(0.16, 0.10, bandD);
+                  float black = smoothstep(0.22, 0.16, bandD)
+                              - smoothstep(0.16, 0.10, bandD);
+                  base = mix(base, vec3(0.04, 0.04, 0.04), black);
+                  base = mix(base, vec3(1.00, 1.00, 1.00), white);
+                  // Eye on side of head.
+                  float eyeD = length(vec2(u - 0.72, v - 0.20));
+                  base = mix(base, vec3(0.02, 0.02, 0.02),
+                             smoothstep(0.08, 0.05, eyeD));
+                  base = mix(base, vec3(1.0, 1.0, 1.0),
+                             smoothstep(0.035, 0.018, eyeD));
+                  // Mouth: small dark curve at front.
+                  float mouthD = abs(u - 0.95) + abs(v + 0.05) * 0.5;
+                  base = mix(base, vec3(0.05, 0.02, 0.0),
+                             smoothstep(0.10, 0.05, mouthD));
+                  // Lighter belly.
+                  base = mix(base, base * 1.5,
+                             smoothstep(0.0, -0.7, v));
+                } else if (which == 3 || which == 4 || which == 5) {
+                  // Fins: black margin near outer edge.
+                  float edge;
+                  if (which == 3) edge = abs(hpL.y - dorsalOff.y) / dorsalAxes.y;
+                  else edge = abs(hpL.x - bodyOff.x) / 0.10;
+                  base = mix(base, vec3(0.04, 0.04, 0.04),
+                             smoothstep(0.78, 0.95, edge));
+                }
+                float lamb = max(dot(nW, sunDir), 0.0);
+                float rim = pow(1.0 - max(dot(nW, -rd), 0.0), 2.5);
+                vec3 fishCol = base * (0.35 + lamb * 0.85)
+                             + vec3(0.4, 0.6, 0.8) * rim * 0.25;
+                col += fishCol * 1.6 / (1.0 + tH * 0.1);
+              }
+
+              // Forked caudal fin: upper + lower triangular slabs.
+              float denom = dot(rd, sideW);
+              if (abs(denom) > 1e-4) {
+                for (int k = 0; k < 2; k++) {
+                  float kk = float(k);
+                  // Upper lobe k=0 (centered above), lower k=1 (below).
+                  float yC = (kk == 0.0) ? 0.06 : -0.06;
+                  vec3 finC = pos + fwdW * (-0.32) + upW * yC;
+                  float tFin = dot(finC - ro, sideW) / denom;
+                  if (tFin > 0.3 && tFin < 18.0 &&
+                      (tH < 0.0 || tFin < tH)) {
+                    vec3 fp = ro + rd * tFin - finC;
+                    float fu = dot(fp, fwdW);
+                    float fv = dot(fp, upW);
+                    // Triangular lobe widening backward.
+                    float yLo = (kk == 0.0) ? 0.0 : -0.10 - fu * 0.5;
+                    float yHi = (kk == 0.0) ? 0.10 + fu * 0.5 + 0.06 : 0.0;
+                    float finMask = step(fu, 0.0) * step(-0.16, fu)
+                                  * step(yLo, fv) * step(fv, yHi);
+                    if (finMask > 0.0) {
+                      vec3 finBase = vec3(1.00, 0.45, 0.05);
+                      // Black trailing edge.
+                      float trail = step(fu, -0.13);
+                      finBase = mix(finBase, vec3(0.04, 0.04, 0.04), trail);
+                      col += finBase * 1.4 / (1.0 + tFin * 0.1);
+                    }
+                  }
+                }
+              }
+            }
+          }
+          return col;
+        }
+
+        // Coral reef: 5 colorful clusters with trunk + tilted branches + bumpy
+        // surface noise.
+        vec3 coralReef(vec3 ro, vec3 rd) {
+          vec3 sunDir = normalize(vec3(0.2, 1.0, -0.3));
+          float bestT = 100.0;
+          vec3 bestCol = vec3(0.0);
+          vec3 bestN = vec3(0.0);
+          vec3 bestHp = vec3(0.0);
+          for (int c = 0; c < 5; c++) {
+            float fc = float(c);
+            vec3 base = vec3(
+                cos(fc * 1.7 + 0.5) * 5.5,
+                -6.0,
+                sin(fc * 1.7 + 0.5) * 5.5);
+            vec3 palette;
+            if (c == 0) palette = vec3(1.00, 0.30, 0.55);
+            else if (c == 1) palette = vec3(1.00, 0.55, 0.10);
+            else if (c == 2) palette = vec3(0.60, 0.25, 0.90);
+            else if (c == 3) palette = vec3(1.00, 0.85, 0.20);
+            else palette = vec3(0.20, 0.85, 0.70);
+            // Trunk.
+            vec3 trunkAx = vec3(0.10, 0.55, 0.10);
+            vec3 trunkCtr = base + vec3(0.0, 0.55, 0.0);
+            float tT = rayEllip(ro - trunkCtr, rd, trunkAx);
+            if (tT > 0.3 && tT < bestT) {
+              bestT = tT;
+              bestHp = ro + rd * tT - trunkCtr;
+              bestN = normalize(bestHp / (trunkAx * trunkAx));
+              bestCol = palette;
+            }
+            // 6 tilted branches radiating up and out.
+            for (int b = 0; b < 6; b++) {
+              float fb = float(b);
+              float ang = fb * 1.04 + fc * 0.7;
+              float tilt = 0.7 + sin(fb + fc) * 0.2;
+              vec3 dir = normalize(vec3(cos(ang), tilt, sin(ang)));
+              vec3 side = normalize(
+                  cross(dir, vec3(0.0, 1.0, 0.0)) + vec3(0.001));
+              vec3 up = normalize(cross(side, dir));
+              vec3 ctr = base + vec3(0.0, 0.55, 0.0) + dir * 0.35;
+              vec3 oc = ro - ctr;
+              vec3 roL = vec3(dot(oc, dir), dot(oc, up), dot(oc, side));
+              vec3 rdL = vec3(dot(rd, dir), dot(rd, up), dot(rd, side));
+              vec3 ax = vec3(0.32, 0.07, 0.07);
+              float tB = rayEllip(roL, rdL, ax);
+              if (tB > 0.3 && tB < bestT) {
+                bestT = tB;
+                vec3 hpL = roL + rdL * tB;
+                vec3 nL = normalize(hpL / (ax * ax));
+                bestN = side * nL.z + up * nL.y + dir * nL.x;
+                bestHp = ro + rd * tB - ctr;
+                bestCol = palette;
+              }
+            }
+          }
+          if (bestT >= 100.0) return vec3(0.0);
+          // Bumpy organic surface from fbm.
+          float bumpy = fbm3(bestHp * 8.0);
+          vec3 base = bestCol * mix(0.75, 1.10, bumpy);
+          float lamb = max(dot(bestN, sunDir), 0.0);
+          float rim = pow(1.0 - max(dot(bestN, -rd), 0.0), 2.5);
+          vec3 col = base * (0.35 + lamb * 0.85)
+                   + vec3(0.5, 0.7, 0.9) * rim * 0.25;
+          return col / (1.0 + bestT * 0.06);
+        }
+
+        // Blue tang school: Dory-style. Tall blue body, yellow tail, palette mark.
+        vec3 blueTangSchool(vec3 ro, vec3 rd, float t) {
+          vec3 col = vec3(0.0);
+          vec3 sunDir = normalize(vec3(0.2, 1.0, -0.3));
+          vec3 bodyAxes = vec3(0.26, 0.22, 0.085);
+          vec3 tailAxes = vec3(0.10, 0.09, 0.025);
+          vec3 dorsalAxes = vec3(0.13, 0.13, 0.012);
+          vec3 pectAxes = vec3(0.07, 0.018, 0.05);
+          vec3 schoolC = vec3(
+              sin(t * 0.06) * 3.0 + 1.5,
+              0.5 + sin(t * 0.07) * 0.3,
+              cos(t * 0.07) * 3.0 - 1.5);
+          vec3 fwd = normalize(vec3(
+              cos(t * 0.06) * 3.0, 0.0,
+              -sin(t * 0.07) * 3.0) + vec3(0.001));
+          vec3 sideAx = normalize(cross(fwd, vec3(0.0, 1.0, 0.0)));
+          for (int i = 0; i < 4; i++) {
+            float seed = float(i) * 1.7 + 3.3;
+            vec3 off = vec3(
+                cos(seed) * 0.7 + sin(seed * 2.1) * 0.25,
+                sin(seed * 1.7) * 0.20,
+                sin(seed) * 0.7);
+            vec3 pos = schoolC + off;
+            float wig = sin(t * 3.5 + seed * 4.0) * 0.05;
+            vec3 fwdW = normalize(fwd + sideAx * wig);
+            vec3 sideW = normalize(cross(fwdW, vec3(0.0, 1.0, 0.0)));
+            vec3 upW = normalize(cross(sideW, fwdW));
+            vec3 oc = ro - pos;
+            vec3 roL = vec3(dot(oc, fwdW), dot(oc, upW), dot(oc, sideW));
+            vec3 rdL = vec3(dot(rd, fwdW), dot(rd, upW), dot(rd, sideW));
+
+            vec3 bodyOff = vec3(0.04, 0.0, 0.0);
+            float tBody = rayEllip(roL - bodyOff, rdL, bodyAxes);
+            vec3 tailOff = vec3(-0.18, 0.0, 0.0);
+            float tTail = rayEllip(roL - tailOff, rdL, tailAxes);
+            vec3 dorsalOff = vec3(0.02, 0.24, 0.0);
+            float tDor = rayEllip(roL - dorsalOff, rdL, dorsalAxes);
+            vec3 pectOffL = vec3(0.06, -0.04, 0.10);
+            vec3 pectOffR = vec3(0.06, -0.04, -0.10);
+            float tPL = rayEllip(roL - pectOffL, rdL, pectAxes);
+            float tPR = rayEllip(roL - pectOffR, rdL, pectAxes);
+
+            float tH = -1.0;
+            int which = 0;
+            if (tBody > 0.3 && tBody < 18.0) { tH = tBody; which = 1; }
+            if (tTail > 0.3 && tTail < 18.0 &&
+                (tH < 0.0 || tTail < tH)) { tH = tTail; which = 2; }
+            if (tDor > 0.3 && tDor < 18.0 &&
+                (tH < 0.0 || tDor < tH)) { tH = tDor; which = 3; }
+            if (tPL > 0.3 && tPL < 18.0 &&
+                (tH < 0.0 || tPL < tH)) { tH = tPL; which = 4; }
+            if (tPR > 0.3 && tPR < 18.0 &&
+                (tH < 0.0 || tPR < tH)) { tH = tPR; which = 5; }
+
+            if (which > 0) {
+              vec3 hpL = roL + rdL * tH;
+              vec3 nL;
+              if (which == 1) {
+                nL = normalize((hpL - bodyOff) / (bodyAxes * bodyAxes));
+              } else if (which == 2) {
+                nL = normalize((hpL - tailOff) / (tailAxes * tailAxes));
+              } else if (which == 3) {
+                nL = normalize((hpL - dorsalOff) / (dorsalAxes * dorsalAxes));
+              } else if (which == 4) {
+                nL = normalize((hpL - pectOffL) / (pectAxes * pectAxes));
+              } else {
+                nL = normalize((hpL - pectOffR) / (pectAxes * pectAxes));
+              }
+              vec3 nW = sideW * nL.z + upW * nL.y + fwdW * nL.x;
+              float u = hpL.x / 0.30;
+              float v = hpL.y / 0.22;
+              vec3 base = vec3(0.10, 0.40, 0.95);
+              if (which == 1) {
+                // Black palette / "6" mark on upper body.
+                float bd = length(vec2((u + 0.05) * 1.2, (v - 0.20) * 0.9));
+                base = mix(base, vec3(0.03, 0.03, 0.10),
+                           smoothstep(0.55, 0.30, bd));
+                // Yellow tail/back third.
+                base = mix(base, vec3(1.0, 0.85, 0.10),
+                           smoothstep(-0.30, -0.65, u));
+                // Eye on head.
+                float eyeD = length(vec2(u - 0.65, v - 0.10));
+                base = mix(base, vec3(0.02, 0.02, 0.05),
+                           smoothstep(0.08, 0.05, eyeD));
+                base = mix(base, vec3(1.0, 1.0, 1.0),
+                           smoothstep(0.035, 0.018, eyeD));
+                // Mouth.
+                float mouthD = abs(u - 0.95) + abs(v + 0.05) * 0.5;
+                base = mix(base, vec3(0.05, 0.02, 0.0),
+                           smoothstep(0.10, 0.05, mouthD));
+              } else if (which == 2) {
+                // Tail peduncle is yellow.
+                base = vec3(1.0, 0.85, 0.10);
+              } else if (which == 3) {
+                // Dorsal fin: blue with yellow tip.
+                float topness = (hpL.y - dorsalOff.y) / dorsalAxes.y;
+                base = mix(vec3(0.10, 0.40, 0.95),
+                           vec3(1.0, 0.85, 0.10),
+                           smoothstep(0.4, 0.95, topness));
+              } else {
+                // Pectorals: blue with darker edge.
+                float edge = abs(hpL.x - bodyOff.x) / 0.10;
+                base = mix(vec3(0.10, 0.40, 0.95),
+                           vec3(0.04, 0.04, 0.10),
+                           smoothstep(0.78, 0.95, edge));
+              }
+              float lamb = max(dot(nW, sunDir), 0.0);
+              float rim = pow(1.0 - max(dot(nW, -rd), 0.0), 2.5);
+              vec3 fishCol = base * (0.35 + lamb * 0.85)
+                           + vec3(0.4, 0.6, 0.9) * rim * 0.25;
+              col += fishCol * 1.6 / (1.0 + tH * 0.1);
+            }
+
+            // Forked yellow caudal fin.
+            float denom = dot(rd, sideW);
+            if (abs(denom) > 1e-4) {
+              for (int k = 0; k < 2; k++) {
+                float kk = float(k);
+                float yC = (kk == 0.0) ? 0.06 : -0.06;
+                vec3 finC = pos + fwdW * (-0.32) + upW * yC;
+                float tFin = dot(finC - ro, sideW) / denom;
+                if (tFin > 0.3 && tFin < 18.0 &&
+                    (tH < 0.0 || tFin < tH)) {
+                  vec3 fp = ro + rd * tFin - finC;
+                  float fu = dot(fp, fwdW);
+                  float fv = dot(fp, upW);
+                  float yLo = (kk == 0.0) ? 0.0 : -0.10 - fu * 0.5;
+                  float yHi = (kk == 0.0) ? 0.10 + fu * 0.5 + 0.06 : 0.0;
+                  float finMask = step(fu, 0.0) * step(-0.16, fu)
+                                * step(yLo, fv) * step(fv, yHi);
+                  if (finMask > 0.0) {
+                    vec3 finBase = vec3(1.0, 0.85, 0.10);
+                    float trail = step(fu, -0.13);
+                    finBase = mix(finBase, vec3(0.04, 0.04, 0.10), trail);
+                    col += finBase * 1.4 / (1.0 + tFin * 0.1);
+                  }
+                }
+              }
+            }
           }
           return col;
         }
@@ -317,6 +729,15 @@ export class UnderwaterImmersive extends THREE.Object3D {
 
           // ---- Rising bubble columns ----
           col += bubbles(ro, rd, t);
+
+          // ---- Coral reef on the floor ----
+          col += coralReef(ro, rd);
+
+          // ---- Clownfish schools ----
+          col += clownfishSchool(ro, rd, t);
+
+          // ---- Blue tang school ----
+          col += blueTangSchool(ro, rd, t);
 
           // ---- Marine snow ----
           col += vec3(0.95, 0.98, 1.00) * marineSnow(ro, rd, t);

--- a/demos/portals/UnderwaterImmersive.js
+++ b/demos/portals/UnderwaterImmersive.js
@@ -41,9 +41,9 @@ export class UnderwaterImmersive extends THREE.Object3D {
         this._entryMatrix
       );
       const portalQuatInv = portalQuat.clone().invert();
-      const camQuat = camera.getWorldQuaternion(new THREE.Quaternion());
-      const localQuat = portalQuatInv.multiply(camQuat);
-      const rotMat4 = new THREE.Matrix4().makeRotationFromQuaternion(localQuat);
+      const rotMat4 = new THREE.Matrix4().makeRotationFromQuaternion(
+        portalQuatInv
+      );
       mat.uniforms.uViewRotation.value.setFromMatrix4(rotMat4);
     }
 

--- a/demos/portals/UnderwaterImmersive.js
+++ b/demos/portals/UnderwaterImmersive.js
@@ -15,9 +15,15 @@ export class UnderwaterImmersive extends THREE.Object3D {
     this._buildSphere();
   }
 
-  show(portalWorldMatrix) {
-    this._entryMatrix = portalWorldMatrix.clone();
-    this._entryMatrixInv = portalWorldMatrix.clone().invert();
+  show(portalWorldMatrix, fromSide = 'front') {
+    let m = portalWorldMatrix.clone();
+    if (fromSide === 'back') {
+      // User entered through the back face of the portal — apply a 180° yaw
+      // so they spawn facing the scene rather than the wall behind it.
+      m.multiply(new THREE.Matrix4().makeRotationY(Math.PI));
+    }
+    this._entryMatrix = m;
+    this._entryMatrixInv = m.clone().invert();
     this.visible = true;
   }
 

--- a/demos/portals/UnderwaterImmersive.js
+++ b/demos/portals/UnderwaterImmersive.js
@@ -688,6 +688,9 @@ export class UnderwaterImmersive extends THREE.Object3D {
             float kt = (surfaceY - ro.y) / rd.y;
             if (kt > 0.0) {
               vec3 sp = ro + rd * kt;
+              // Gentle refractive wobble on the surface plane.
+              sp.xz += vec2(sin(t * 0.3 + sp.x * 0.5) * 0.4,
+                            cos(t * 0.25 + sp.z * 0.5) * 0.4);
               float c = caustic(sp.xz, t);
               col = mix(col, vec3(0.95, 1.00, 0.75),
                         c * smoothstep(0.3, 0.95, rd.y) * 0.55);
@@ -712,8 +715,8 @@ export class UnderwaterImmersive extends THREE.Object3D {
             if (t2 > 0.0 && t2 < 80.0) {
               vec3 gp = ro + rd * t2;
               float gn = fbm(gp.xz * 0.15);
-              vec3 ground = mix(vec3(0.05, 0.10, 0.12),
-                                vec3(0.10, 0.18, 0.20), gn);
+              vec3 ground = mix(vec3(0.18, 0.14, 0.08),
+                                vec3(0.30, 0.25, 0.15), gn);
               float fog = smoothstep(0.0, 35.0, t2);
               col = mix(ground, col, fog);
             }
@@ -748,11 +751,12 @@ export class UnderwaterImmersive extends THREE.Object3D {
           // ---- Marine snow ----
           col += vec3(0.95, 0.98, 1.00) * marineSnow(ro, rd, t);
 
-          // ---- Distance haze (blue scattering) ----
-          // Simulate water absorption by mixing toward the depth color
-          // based on view-distance estimate (use ray length to 50m).
-          float haze = 0.55;
-          col = mix(col, midCol, haze * 0.25);
+          // ---- Depth-distance haze (blue scattering) ----
+          // Horizontal rays travel through more water — fade toward deep teal.
+          vec3 deepFog = vec3(0.02, 0.12, 0.22);
+          float viewDist = clamp(1.0 - abs(rd.y), 0.0, 1.0);
+          float haze = viewDist * viewDist * 0.35;
+          col = mix(col, deepFog, haze);
 
           // Tone-map.
           col = col / (col + vec3(1.0));

--- a/demos/portals/UnderwaterImmersive.js
+++ b/demos/portals/UnderwaterImmersive.js
@@ -1,0 +1,348 @@
+import * as THREE from 'three';
+
+const SPHERE_RADIUS = 50;
+
+/**
+ * Full-surround deep ocean for "walk-in" mode.
+ * Inverted sphere: surface caustics + sunbeams up top, marine snow + abyss
+ * below, drifting jellyfish and a passing whale shark in mid-water,
+ * rising bubble columns.
+ */
+export class UnderwaterImmersive extends THREE.Object3D {
+  constructor() {
+    super();
+    this._time = 0;
+    this._buildSphere();
+  }
+
+  show(portalWorldMatrix) {
+    this._entryMatrix = portalWorldMatrix.clone();
+    this._entryMatrixInv = portalWorldMatrix.clone().invert();
+    this.visible = true;
+  }
+
+  hide() {
+    this.visible = false;
+  }
+
+  update(dt, camera) {
+    if (!this.visible) return;
+    this._time += dt;
+
+    const mat = this._sphere.material;
+    mat.uniforms.uTime.value = this._time;
+
+    if (camera) {
+      const camWorld = camera.getWorldPosition(new THREE.Vector3());
+      const camLocal = camWorld.clone().applyMatrix4(this._entryMatrixInv);
+      mat.uniforms.uCamLocal.value.copy(camLocal);
+
+      const portalQuat = new THREE.Quaternion().setFromRotationMatrix(
+        this._entryMatrix
+      );
+      const portalQuatInv = portalQuat.clone().invert();
+      const camQuat = camera.getWorldQuaternion(new THREE.Quaternion());
+      const localQuat = portalQuatInv.multiply(camQuat);
+      const rotMat4 = new THREE.Matrix4().makeRotationFromQuaternion(localQuat);
+      mat.uniforms.uViewRotation.value.setFromMatrix4(rotMat4);
+    }
+
+    if (camera) {
+      camera.getWorldPosition(this.position);
+    }
+  }
+
+  _buildSphere() {
+    const geom = new THREE.SphereGeometry(SPHERE_RADIUS, 64, 32);
+
+    const mat = new THREE.ShaderMaterial({
+      uniforms: {
+        uTime: {value: 0},
+        uCamLocal: {value: new THREE.Vector3(0, 0, 1.6)},
+        uViewRotation: {value: new THREE.Matrix3()},
+      },
+      vertexShader: /* glsl */ `
+        varying vec3 vWorldDir;
+        void main() {
+          vWorldDir = normalize(position);
+          gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        }
+      `,
+      fragmentShader: /* glsl */ `
+        precision highp float;
+        uniform float uTime;
+        uniform vec3 uCamLocal;
+        uniform mat3 uViewRotation;
+        varying vec3 vWorldDir;
+
+        float hash(vec2 p) {
+          p = fract(p * vec2(123.34, 456.21));
+          p += dot(p, p + 45.32);
+          return fract(p.x * p.y);
+        }
+        float hash3(vec3 p) {
+          p = fract(p * vec3(123.34, 456.21, 789.53));
+          p += dot(p, p.yzx + 45.32);
+          return fract(p.x * p.y * p.z);
+        }
+        float noise(vec2 p) {
+          vec2 i = floor(p); vec2 f = fract(p);
+          float a = hash(i); float b = hash(i + vec2(1,0));
+          float c = hash(i + vec2(0,1)); float d = hash(i + vec2(1,1));
+          vec2 u = f * f * (3.0 - 2.0 * f);
+          return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x)
+                                + (d - b) * u.x * u.y;
+        }
+        float noise3(vec3 p) {
+          vec3 i = floor(p); vec3 f = fract(p);
+          vec3 u = f * f * (3.0 - 2.0 * f);
+          return mix(
+            mix(mix(hash3(i), hash3(i + vec3(1,0,0)), u.x),
+                mix(hash3(i + vec3(0,1,0)), hash3(i + vec3(1,1,0)), u.x), u.y),
+            mix(mix(hash3(i + vec3(0,0,1)), hash3(i + vec3(1,0,1)), u.x),
+                mix(hash3(i + vec3(0,1,1)), hash3(i + vec3(1,1,1)), u.x), u.y),
+            u.z);
+        }
+        float fbm(vec2 p) {
+          float v = 0.0; float a = 0.5;
+          for (int i = 0; i < 4; i++) { v += a * noise(p); p *= 2.07; a *= 0.5; }
+          return v;
+        }
+        float fbm3(vec3 p) {
+          float v = 0.0; float a = 0.5;
+          for (int i = 0; i < 4; i++) { v += a * noise3(p); p *= 2.07; a *= 0.5; }
+          return v;
+        }
+
+        // Voronoi-ish caustic pattern at world position xz.
+        float caustic(vec2 uv, float t) {
+          vec2 p = uv * 0.6;
+          float v = 0.0;
+          for (int i = 0; i < 3; i++) {
+            float fi = float(i);
+            v += sin(p.x * (1.0 + fi * 0.4) + t * (0.7 + fi * 0.2))
+               * sin(p.y * (1.3 + fi * 0.3) + t * (0.9 - fi * 0.15));
+          }
+          return pow(max(v * 0.33 + 0.5, 0.0), 2.5);
+        }
+
+        float raySphere(vec3 ro, vec3 rd, vec3 c, float rad) {
+          vec3 oc = ro - c;
+          float b = dot(oc, rd);
+          float d = b * b - (dot(oc, oc) - rad * rad);
+          if (d < 0.0) return -1.0;
+          return -b - sqrt(d);
+        }
+
+        // Drifting jellyfish: ellipsoidal bell + faint trailing tendrils.
+        // Returns additive color contribution along the ray.
+        vec3 jellyfish(vec3 ro, vec3 rd, vec3 pos, float t, float seed) {
+          vec3 oc = pos - ro;
+          float along = dot(oc, rd);
+          if (along < 0.5 || along > 25.0) return vec3(0.0);
+          vec3 proj = ro + rd * along;
+          float d = length(pos - proj);
+          float bellR = 0.5 + 0.1 * sin(t * 1.2 + seed * 7.0);
+          float bell = smoothstep(bellR, 0.0, d) * 0.55;
+          // Glow halo
+          float halo = smoothstep(bellR * 3.0, bellR, d) * 0.18;
+          float fade = 1.0 / (1.0 + along * 0.08);
+          vec3 color = mix(vec3(0.4, 0.85, 1.0), vec3(0.85, 0.55, 1.0),
+                           sin(t + seed) * 0.5 + 0.5);
+          return color * (bell + halo) * fade;
+        }
+
+        // Whale shark silhouette swimming past: oriented body, falls dim.
+        vec3 whaleShark(vec3 ro, vec3 rd, float t) {
+          // Position: slow horizontal arc across the user's view.
+          float phase = t * 0.04;
+          vec3 pos = vec3(sin(phase) * 18.0, -3.0 + sin(t * 0.1) * 0.5,
+                          cos(phase) * 18.0 - 4.0);
+          vec3 oc = pos - ro;
+          float along = dot(oc, rd);
+          if (along < 1.0 || along > 40.0) return vec3(0.0);
+          vec3 proj = ro + rd * along;
+          vec3 d = pos - proj;
+          // Stretched ellipsoid: longer along forward of motion.
+          vec3 fwd = vec3(cos(phase), 0.0, -sin(phase));
+          float along2 = dot(d, fwd);
+          vec3 perp = d - fwd * along2;
+          // Body shape
+          float body = smoothstep(0.6, 0.0, length(vec2(along2 / 4.0, length(perp))));
+          // Tail wedge
+          float tail = smoothstep(0.6, 0.0, length(vec2((along2 - 4.0) / 1.5, length(perp) * 2.0)));
+          float silhouette = max(body, tail * 0.7);
+          float fade = 1.0 / (1.0 + along * 0.05);
+          // Dark grey with subtle white spots.
+          vec3 spot = vec3(noise(perp.xy * 6.0 + along2));
+          vec3 bodyCol = mix(vec3(0.06, 0.10, 0.14), vec3(0.18, 0.25, 0.30), spot.r);
+          return bodyCol * silhouette * fade;
+        }
+
+        // Rising bubble columns: vertical streams at hashed xz positions.
+        vec3 bubbles(vec3 ro, vec3 rd, float t) {
+          vec3 col = vec3(0.0);
+          for (int i = 0; i < 8; i++) {
+            float fi = float(i);
+            float seed = fi * 13.7;
+            // Column base at fixed xz.
+            vec2 base = vec2(sin(seed) * 8.0 + cos(seed * 1.3) * 4.0,
+                             cos(seed * 0.7) * 8.0 + sin(seed * 1.1) * 4.0);
+            // Bubble height: cycles upward over time.
+            float bh = mod(t * 1.5 + seed * 3.0, 6.0) - 1.0;
+            vec3 pos = vec3(base.x + sin(bh + seed) * 0.15,
+                            -2.5 + bh,
+                            base.y + cos(bh + seed) * 0.15);
+            vec3 oc = pos - ro;
+            float along = dot(oc, rd);
+            if (along < 0.3 || along > 20.0) continue;
+            vec3 proj = ro + rd * along;
+            float d = length(pos - proj);
+            float r = 0.05 + 0.02 * sin(bh * 4.0 + seed);
+            float bubble = smoothstep(r, 0.0, d) * 0.4;
+            float fade = 1.0 / (1.0 + along * 0.15);
+            col += vec3(0.85, 0.95, 1.00) * bubble * fade;
+          }
+          return col;
+        }
+
+        // Marine snow: fine particles drifting downward.
+        float marineSnow(vec3 ro, vec3 rd, float t) {
+          float v = 0.0;
+          for (int i = 0; i < 16; i++) {
+            float fi = float(i);
+            float seed = fi * 7.13;
+            float along = mix(2.0, 18.0, fract(seed * 0.37));
+            vec3 sample_p = ro + rd * along;
+            // Slow drift downward.
+            sample_p.y += t * 0.3 + seed;
+            vec3 cell = floor(sample_p * 1.5);
+            vec3 fc = fract(sample_p * 1.5);
+            float h = hash3(cell);
+            if (h > 0.985) {
+              float d = length(fc - 0.5);
+              v += smoothstep(0.05, 0.0, d) * 0.4 / (1.0 + along * 0.3);
+            }
+          }
+          return v;
+        }
+
+        // Sunbeam shafts from above: density along ray scales by surface
+        // brightness at sample points.
+        float sunbeams(vec3 ro, vec3 rd, float t) {
+          if (rd.y < 0.05) return 0.0;
+          // Step along ray from the user up toward the surface (y=8).
+          float density = 0.0;
+          float surfaceY = 8.0;
+          for (int i = 1; i <= 12; i++) {
+            float fi = float(i);
+            float along = fi * 0.7;
+            vec3 sample_p = ro + rd * along;
+            // Closer to surface = brighter.
+            float depthFactor = clamp(sample_p.y / surfaceY, 0.0, 1.0);
+            // Caustic-modulated brightness.
+            float c = caustic(sample_p.xz, t);
+            density += c * depthFactor * 0.05;
+          }
+          // Vertical bias: stronger when looking up.
+          density *= pow(max(rd.y, 0.0), 0.6);
+          return density;
+        }
+
+        void main() {
+          vec3 rd = normalize(uViewRotation * vWorldDir);
+          vec3 ro = uCamLocal;
+
+          // ---- Vertical depth gradient ----
+          // Above eye = brighter (toward surface), below = abyss.
+          float t = uTime;
+          vec3 surfaceCol = vec3(0.20, 0.65, 0.85);
+          vec3 midCol = vec3(0.05, 0.30, 0.55);
+          vec3 abyssCol = vec3(0.005, 0.020, 0.075);
+          float depthT = clamp(rd.y * 0.5 + 0.5, 0.0, 1.0);
+          vec3 col = mix(abyssCol, midCol, smoothstep(0.25, 0.55, depthT));
+          col = mix(col, surfaceCol, smoothstep(0.55, 0.95, depthT));
+
+          // ---- Surface caustics when looking up ----
+          if (rd.y > 0.3) {
+            // Project ray to a plane at y = surface.
+            float surfaceY = 8.0;
+            float kt = (surfaceY - ro.y) / rd.y;
+            if (kt > 0.0) {
+              vec3 sp = ro + rd * kt;
+              float c = caustic(sp.xz, t);
+              col = mix(col, vec3(0.95, 1.00, 0.75),
+                        c * smoothstep(0.3, 0.95, rd.y) * 0.55);
+              // Sun disc through surface.
+              vec3 sunDir = normalize(vec3(0.2, 1.0, -0.3));
+              float sa = max(dot(rd, sunDir), 0.0);
+              col += vec3(1.00, 0.95, 0.75)
+                   * smoothstep(0.965, 0.995, sa) * 0.9;
+              col += vec3(1.00, 0.95, 0.75)
+                   * smoothstep(0.85, 1.0, sa) * 0.25;
+            }
+          }
+
+          // ---- Sunbeam shafts (volumetric) ----
+          float beams = sunbeams(ro, rd, t);
+          col += vec3(0.80, 0.95, 1.00) * beams * 1.4;
+
+          // ---- Distant ground (ocean floor) ----
+          if (rd.y < -0.1) {
+            float gt = -ro.y - 6.0;
+            float t2 = gt / rd.y;
+            if (t2 > 0.0 && t2 < 80.0) {
+              vec3 gp = ro + rd * t2;
+              float gn = fbm(gp.xz * 0.15);
+              vec3 ground = mix(vec3(0.05, 0.10, 0.12),
+                                vec3(0.10, 0.18, 0.20), gn);
+              float fog = smoothstep(0.0, 35.0, t2);
+              col = mix(ground, col, fog);
+            }
+          }
+
+          // ---- Drifting jellyfish (animated 3D positions) ----
+          for (int i = 0; i < 5; i++) {
+            float fi = float(i);
+            float seed = fi * 11.3;
+            vec3 jp = vec3(
+              sin(t * 0.2 + seed) * 5.0 + cos(seed * 1.7) * 3.0,
+              0.5 + sin(t * 0.3 + seed * 0.7) * 2.0,
+              cos(t * 0.25 + seed) * 5.0 + sin(seed * 0.9) * 3.0);
+            col += jellyfish(ro, rd, jp, t, seed);
+          }
+
+          // ---- Whale shark passing ----
+          col += whaleShark(ro, rd, t);
+
+          // ---- Rising bubble columns ----
+          col += bubbles(ro, rd, t);
+
+          // ---- Marine snow ----
+          col += vec3(0.95, 0.98, 1.00) * marineSnow(ro, rd, t);
+
+          // ---- Distance haze (blue scattering) ----
+          // Simulate water absorption by mixing toward the depth color
+          // based on view-distance estimate (use ray length to 50m).
+          float haze = 0.55;
+          col = mix(col, midCol, haze * 0.25);
+
+          // Tone-map.
+          col = col / (col + vec3(1.0));
+          col = pow(col, vec3(0.85));
+
+          gl_FragColor = vec4(col, 1.0);
+        }
+      `,
+      side: THREE.BackSide,
+      depthWrite: false,
+    });
+
+    this._sphere = new THREE.Mesh(geom, mat);
+    this._sphere.renderOrder = -100;
+    this._sphere.frustumCulled = false;
+    this._sphere.raycast = () => {};
+    this.add(this._sphere);
+    this.visible = false;
+  }
+}

--- a/demos/portals/index.html
+++ b/demos/portals/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <title>Cosmic Portal</title>
+    <title>Portal Gallery</title>
     <meta charset="utf-8" />
     <meta
       name="viewport"

--- a/demos/portals/scenes/CosmicScene.js
+++ b/demos/portals/scenes/CosmicScene.js
@@ -346,7 +346,18 @@ export const CosmicScene = {
       mc *= 0.15 + density * 2.4;
       col = mix(col, mc, clamp(density * 0.7, 0.0, 1.0));
     }
-    // Far depth layer removed for perf — see CosmicImmersive.js comment.
+    // Far depth layer — distant haze
+    {
+      vec2 nuv = nUv * 1.8;
+      float fn1 = fbm(nuv * 1.2 + vec2(uTime * 0.02, -uTime * 0.015));
+      float fn3 = ridgedFbm(nuv * 3.0 + vec2(-uTime * 0.03, uTime * 0.02));
+      float fDensity = pow(fn1, 1.8);
+      float fWisps = pow(fn3, 2.2);
+      vec3 fc = mix(nebulaA, nebulaB, smoothstep(0.2, 0.75, fn1));
+      fc = mix(fc, nebulaD, fWisps * 0.5);
+      fc *= 0.1 + fDensity * 1.8;
+      col = mix(col, fc, clamp(fDensity * 0.4, 0.0, 1.0));
+    }
     col = mix(vec3(0.005, 0.005, 0.02), col, 0.92);
 
     vec4 sceneRgba = cosmicRaymarch(p, uTime);

--- a/demos/portals/scenes/CosmicScene.js
+++ b/demos/portals/scenes/CosmicScene.js
@@ -78,7 +78,7 @@ export const CosmicScene = {
       vec3 lightDirPlanet = normalize(sunPos - planetPos);
       vec3 lightDirMoon   = normalize(sunPos - moonPos);
       vec3 lightDirGas    = normalize(sunPos - gasPos);
-      vec3 limbCenter = vec3(3.5, -5.5, -3.5);
+      vec3 limbCenter = vec3(-3.5, -5.5, -3.5);
       float limbRadius = 5.5;
       vec3 lightDirLimb = normalize(sunPos - limbCenter);
 

--- a/demos/portals/scenes/CosmicScene.js
+++ b/demos/portals/scenes/CosmicScene.js
@@ -346,18 +346,7 @@ export const CosmicScene = {
       mc *= 0.15 + density * 2.4;
       col = mix(col, mc, clamp(density * 0.7, 0.0, 1.0));
     }
-    // Far depth layer — distant haze
-    {
-      vec2 nuv = nUv * 1.8;
-      float fn1 = fbm(nuv * 1.2 + vec2(uTime * 0.02, -uTime * 0.015));
-      float fn3 = ridgedFbm(nuv * 3.0 + vec2(-uTime * 0.03, uTime * 0.02));
-      float fDensity = pow(fn1, 1.8);
-      float fWisps = pow(fn3, 2.2);
-      vec3 fc = mix(nebulaA, nebulaB, smoothstep(0.2, 0.75, fn1));
-      fc = mix(fc, nebulaD, fWisps * 0.5);
-      fc *= 0.1 + fDensity * 1.8;
-      col = mix(col, fc, clamp(fDensity * 0.4, 0.0, 1.0));
-    }
+    // Far depth layer removed for perf — see CosmicImmersive.js comment.
     col = mix(vec3(0.005, 0.005, 0.02), col, 0.92);
 
     vec4 sceneRgba = cosmicRaymarch(p, uTime);

--- a/demos/portals/scenes/CosmicScene.js
+++ b/demos/portals/scenes/CosmicScene.js
@@ -78,16 +78,21 @@ export const CosmicScene = {
       vec3 lightDirPlanet = normalize(sunPos - planetPos);
       vec3 lightDirMoon   = normalize(sunPos - moonPos);
       vec3 lightDirGas    = normalize(sunPos - gasPos);
+      vec3 limbCenter = vec3(3.5, -5.5, -3.5);
+      float limbRadius = 5.5;
+      vec3 lightDirLimb = normalize(sunPos - limbCenter);
 
       float tBest = 1e9; int hitId = 0;
       float tP = raySphere(ro, rd, planetPos, planetRad);
       float tM = raySphere(ro, rd, moonPos, moonRad);
       float tS = raySphere(ro, rd, sunPos, sunRad);
       float tG = raySphere(ro, rd, gasPos, gasRad);
+      float tLB = raySphere(ro, rd, limbCenter, limbRadius);
       if (tP > 0.0 && tP < tBest) { tBest = tP; hitId = 1; }
       if (tM > 0.0 && tM < tBest) { tBest = tM; hitId = 2; }
       if (tS > 0.0 && tS < tBest) { tBest = tS; hitId = 3; }
       if (tG > 0.0 && tG < tBest) { tBest = tG; hitId = 4; }
+      if (tLB > 0.0 && tLB < tBest) { tBest = tLB; hitId = 5; }
 
       vec3 rgb = vec3(0.0);
       float a = 0.0;
@@ -127,6 +132,47 @@ export const CosmicScene = {
             if (!behind) {
               rgb += ringCol * bands * shade * 1.6;
               a = max(a, bands * 0.95);
+            }
+          }
+        }
+      }
+
+      // Horizon gas-giant limb ring.
+      {
+        vec3 limbRingN = normalize(vec3(-0.25, 0.90, 0.15));
+        float lrd = dot(rd, limbRingN);
+        if (abs(lrd) > 1e-3) {
+          float tLR = dot(limbCenter - ro, limbRingN) / lrd;
+          if (tLR > 0.0) {
+            bool behindLimb = (tLB > 0.0 && tLR > tLB);
+            bool behindObj = (hitId != 5 && hitId > 0 && tLR > tBest);
+            if (!behindLimb && !behindObj) {
+              vec3 rp = ro + rd * tLR - limbCenter;
+              float rr = length(rp);
+              float lInner = limbRadius * 1.15;
+              float lOuter = limbRadius * 1.8;
+              if (rr > lInner && rr < lOuter) {
+                float u = (rr - lInner) / (lOuter - lInner);
+                float ang = atan(rp.z, rp.x) + t * 0.03;
+                float rb = fbm(vec2(u * 50.0, 0.0)) * 0.5
+                         + fbm(vec2(u * 150.0, 5.1)) * 0.3
+                         + fbm(vec2(u * 350.0, 2.2)) * 0.2;
+                rb = smoothstep(0.25, 0.75, rb);
+                float rGap1 = smoothstep(0.40, 0.43, u) - smoothstep(0.43, 0.47, u);
+                float rGap2 = smoothstep(0.65, 0.67, u) - smoothstep(0.67, 0.70, u);
+                rb *= 1.0 - clamp(rGap1 + rGap2, 0.0, 1.0);
+                float rDust = fbm(vec2(ang * 50.0, u * 25.0));
+                rb *= 0.5 + rDust * 0.7;
+                rb *= smoothstep(0.0, 0.05, u) * smoothstep(1.0, 0.95, u);
+                vec3 lrCol = mix(vec3(0.95, 0.80, 0.50),
+                                 vec3(0.85, 0.90, 1.05), u);
+                vec3 lrHit = ro + rd * tLR;
+                vec3 toL = normalize(sunPos - lrHit);
+                float shT = raySphere(lrHit, toL, limbCenter, limbRadius * 1.01);
+                float shade = (shT > 0.0) ? 0.30 : 1.0;
+                rgb += lrCol * rb * shade * 1.4;
+                a = max(a, rb * 0.9);
+              }
             }
           }
         }
@@ -216,6 +262,27 @@ export const CosmicScene = {
         rgb = base * (0.35 + lambert * 0.95)
             + vec3(1.0, 0.75, 0.55) * rim * 0.55;
         a = 1.0;
+      } else if (hitId == 5) {
+        vec3 hp = ro + rd * tBest;
+        vec3 n = normalize(hp - limbCenter);
+        float lon = atan(n.z, n.x) + t * 0.02;
+        float lat = asin(clamp(n.y, -1.0, 1.0));
+        float bandN = fbm(vec2(lat * 8.0, lon * 0.3 + t * 0.03));
+        float bands = sin(lat * 20.0 + bandN * 4.0) * 0.5 + 0.5;
+        vec3 limbA = vec3(0.85, 0.65, 0.40);
+        vec3 limbB = vec3(0.70, 0.45, 0.25);
+        vec3 limbC = vec3(1.00, 0.88, 0.65);
+        vec3 base = mix(limbA, limbB, bands);
+        base = mix(base, limbC, smoothstep(0.6, 0.9,
+                   fbm(vec2(lon * 1.5 + t * 0.06, lat * 1.5))) * 0.5);
+        float grs = smoothstep(0.35, 0.0,
+            length(vec2(lon - 2.0, lat + 0.15) * vec2(1.0, 1.5)));
+        base = mix(base, vec3(0.85, 0.30, 0.15), grs * 0.6);
+        float lambert = max(dot(n, lightDirLimb), 0.0);
+        float rim = pow(1.0 - max(dot(n, -rd), 0.0), 3.0);
+        rgb = base * (0.20 + lambert * 0.80)
+            + vec3(1.0, 0.80, 0.55) * rim * 0.65;
+        a = 1.0;
       }
       return vec4(rgb, a);
     }
@@ -250,19 +317,47 @@ export const CosmicScene = {
 
   body: /* glsl */ `
     vec2 nUv = p * 1.4;
-    float n1 = warpedFbm(nUv * 1.0 + vec2(uTime * 0.03, -uTime * 0.02));
-    float n2 = fbm(nUv * 2.8 - vec2(uTime * 0.05,  uTime * 0.04));
-    float n3 = ridgedFbm(nUv * 4.0 + vec2(-uTime * 0.04, uTime * 0.03));
-    float density = pow(n1 * 0.55 + n2 * 0.45, 1.6);
-    float wisps = pow(n3, 2.2);
     vec3 nebulaA = vec3(0.05, 0.08, 0.30);
     vec3 nebulaB = vec3(0.55, 0.18, 0.70);
     vec3 nebulaC = vec3(0.95, 0.45, 0.25);
     vec3 nebulaD = vec3(0.35, 0.85, 1.00);
-    col = mix(nebulaA, nebulaB, smoothstep(0.15, 0.7, n1));
-    col = mix(col, nebulaC, smoothstep(0.55, 1.0, n2) * 0.9);
-    col = mix(col, nebulaD, wisps * 0.6);
-    col *= 0.15 + density * 2.4;
+    col = vec3(0.005, 0.005, 0.02);
+    // Near depth layer — large soft structures
+    {
+      vec2 nuv = nUv * 0.7;
+      float ln1 = warpedFbm(nuv + vec2(uTime * 0.03, -uTime * 0.02));
+      float ln2 = fbm(nuv * 2.8 - vec2(uTime * 0.05, uTime * 0.04));
+      float ld = pow(ln1 * 0.55 + ln2 * 0.45, 1.6);
+      vec3 lc = mix(nebulaA, nebulaB, smoothstep(0.15, 0.7, ln1));
+      lc = mix(lc, nebulaC, smoothstep(0.55, 1.0, ln2) * 0.9);
+      lc *= 0.15 + ld * 2.4;
+      col = mix(col, lc, ld * 0.35);
+    }
+    // Mid depth layer — primary detail (original scale)
+    {
+      float n1 = warpedFbm(nUv + vec2(uTime * 0.03, -uTime * 0.02));
+      float n2 = fbm(nUv * 2.8 - vec2(uTime * 0.05, uTime * 0.04));
+      float n3 = ridgedFbm(nUv * 4.0 + vec2(-uTime * 0.04, uTime * 0.03));
+      float density = pow(n1 * 0.55 + n2 * 0.45, 1.6);
+      float wisps = pow(n3, 2.2);
+      vec3 mc = mix(nebulaA, nebulaB, smoothstep(0.15, 0.7, n1));
+      mc = mix(mc, nebulaC, smoothstep(0.55, 1.0, n2) * 0.9);
+      mc = mix(mc, nebulaD, wisps * 0.6);
+      mc *= 0.15 + density * 2.4;
+      col = mix(col, mc, clamp(density * 0.7, 0.0, 1.0));
+    }
+    // Far depth layer — distant haze
+    {
+      vec2 nuv = nUv * 1.8;
+      float fn1 = fbm(nuv * 1.2 + vec2(uTime * 0.02, -uTime * 0.015));
+      float fn3 = ridgedFbm(nuv * 3.0 + vec2(-uTime * 0.03, uTime * 0.02));
+      float fDensity = pow(fn1, 1.8);
+      float fWisps = pow(fn3, 2.2);
+      vec3 fc = mix(nebulaA, nebulaB, smoothstep(0.2, 0.75, fn1));
+      fc = mix(fc, nebulaD, fWisps * 0.5);
+      fc *= 0.1 + fDensity * 1.8;
+      col = mix(col, fc, clamp(fDensity * 0.4, 0.0, 1.0));
+    }
     col = mix(vec3(0.005, 0.005, 0.02), col, 0.92);
 
     vec4 sceneRgba = cosmicRaymarch(p, uTime);

--- a/demos/portals/scenes/CosmicScene.js
+++ b/demos/portals/scenes/CosmicScene.js
@@ -4,10 +4,12 @@
 export const CosmicScene = {
   name: 'Cosmic',
 
-  ringCool: 'vec3(0.35, 0.7, 1.0)',
-  ringWarm: 'vec3(1.0, 0.55, 0.9)',
-  haloInner: 'vec3(0.4, 0.7, 1.0)',
-  haloOuter: 'vec3(1.0, 0.6, 0.9)',
+  ringCool: 'vec3(0.55, 0.85, 1.30)',
+  ringWarm: 'vec3(1.30, 0.70, 1.15)',
+  ringColorExpr:
+    'hsv2rgb(vec3(fract(vUv.x * 1.0 + uTime * 0.08), 0.85, 1.0)) * (0.9 + band * 0.6)',
+  haloInner: 'vec3(0.65, 0.90, 1.40)',
+  haloOuter: 'vec3(1.30, 0.75, 1.20)',
 
   helpers: /* glsl */ `
     vec3 shadePlanet(vec3 n, vec3 lightDir, vec3 viewDir,

--- a/demos/portals/scenes/CosmicScene.js
+++ b/demos/portals/scenes/CosmicScene.js
@@ -164,8 +164,8 @@ export const CosmicScene = {
                 float rDust = fbm(vec2(ang * 50.0, u * 25.0));
                 rb *= 0.5 + rDust * 0.7;
                 rb *= smoothstep(0.0, 0.05, u) * smoothstep(1.0, 0.95, u);
-                vec3 lrCol = mix(vec3(0.95, 0.80, 0.50),
-                                 vec3(0.85, 0.90, 1.05), u);
+                vec3 lrCol = mix(vec3(0.65, 0.80, 0.95),
+                                 vec3(0.85, 0.95, 1.05), u);
                 vec3 lrHit = ro + rd * tLR;
                 vec3 toL = normalize(sunPos - lrHit);
                 float shT = raySphere(lrHit, toL, limbCenter, limbRadius * 1.01);
@@ -269,19 +269,19 @@ export const CosmicScene = {
         float lat = asin(clamp(n.y, -1.0, 1.0));
         float bandN = fbm(vec2(lat * 8.0, lon * 0.3 + t * 0.03));
         float bands = sin(lat * 20.0 + bandN * 4.0) * 0.5 + 0.5;
-        vec3 limbA = vec3(0.85, 0.65, 0.40);
-        vec3 limbB = vec3(0.70, 0.45, 0.25);
-        vec3 limbC = vec3(1.00, 0.88, 0.65);
+        vec3 limbA = vec3(0.30, 0.55, 0.85);
+        vec3 limbB = vec3(0.15, 0.30, 0.55);
+        vec3 limbC = vec3(0.65, 0.85, 1.00);
         vec3 base = mix(limbA, limbB, bands);
         base = mix(base, limbC, smoothstep(0.6, 0.9,
                    fbm(vec2(lon * 1.5 + t * 0.06, lat * 1.5))) * 0.5);
-        float grs = smoothstep(0.35, 0.0,
+        float storm = smoothstep(0.35, 0.0,
             length(vec2(lon - 2.0, lat + 0.15) * vec2(1.0, 1.5)));
-        base = mix(base, vec3(0.85, 0.30, 0.15), grs * 0.6);
+        base = mix(base, vec3(0.90, 0.95, 1.00), storm * 0.5);
         float lambert = max(dot(n, lightDirLimb), 0.0);
         float rim = pow(1.0 - max(dot(n, -rd), 0.0), 3.0);
         rgb = base * (0.20 + lambert * 0.80)
-            + vec3(1.0, 0.80, 0.55) * rim * 0.65;
+            + vec3(0.55, 0.80, 1.00) * rim * 0.65;
         a = 1.0;
       }
       return vec4(rgb, a);

--- a/demos/portals/scenes/CyberpunkScene.js
+++ b/demos/portals/scenes/CyberpunkScene.js
@@ -37,9 +37,86 @@ export const CyberpunkScene = {
           flickerOn);
       return lit * win * flicker;
     }
+
+    // Ray-AABB intersection.
+    float rayBoxC(vec3 ro, vec3 rd, vec3 ctr, vec3 hsz, out vec3 nrm) {
+      vec3 m = 1.0 / rd;
+      vec3 oc = ctr - ro;
+      vec3 t1 = (oc - hsz) * m;
+      vec3 t2 = (oc + hsz) * m;
+      vec3 tmin = min(t1, t2);
+      vec3 tmax = max(t1, t2);
+      float tNear = max(max(tmin.x, tmin.y), tmin.z);
+      float tFar = min(min(tmax.x, tmax.y), tmax.z);
+      if (tNear > tFar || tFar < 0.0) return -1.0;
+      if (tNear == tmin.x) nrm = vec3(-sign(rd.x), 0.0, 0.0);
+      else if (tNear == tmin.y) nrm = vec3(0.0, -sign(rd.y), 0.0);
+      else nrm = vec3(0.0, 0.0, -sign(rd.z));
+      return tNear;
+    }
+
+    // 3D ring of skyscraper boxes around the user.
+    vec4 cityRing3D(vec3 ro, vec3 rd, float t) {
+      float bestT = 1e9;
+      vec3 bestCol = vec3(0.0);
+      for (int i = 0; i < 14; i++) {
+        float fi = float(i);
+        float seed = fi + 19.0;
+        float ang = fi * (6.28318 / 14.0)
+                  + (hash(vec2(seed, 0.7)) - 0.5) * 0.15;
+        float dist = 18.0 + hash(vec2(seed, 1.7)) * 14.0;
+        vec3 base = vec3(cos(ang) * dist, -1.6, sin(ang) * dist);
+        float bw = 2.5 + hash(vec2(seed, 2.7)) * 2.5;
+        float bd = 2.5 + hash(vec2(seed, 3.7)) * 2.5;
+        float bh = 8.0 + hash(vec2(seed, 4.7)) * 18.0;
+        vec3 hsz = vec3(bw, bh * 0.5, bd);
+        vec3 ctr = base + vec3(0.0, bh * 0.5, 0.0);
+        vec3 nrm;
+        float th = rayBoxC(ro, rd, ctr, hsz, nrm);
+        if (th > 0.5 && th < bestT) {
+          bestT = th;
+          vec3 hp = ro + rd * th - ctr;
+          vec2 uv = vec2(0.0);
+          float isSide = 1.0 - step(0.5, abs(nrm.y));
+          if (abs(nrm.x) > 0.5) {
+            uv = vec2((hp.z + bd) / (2.0 * bd),
+                       (hp.y + bh * 0.5) / bh);
+          } else if (abs(nrm.z) > 0.5) {
+            uv = vec2((hp.x + bw) / (2.0 * bw),
+                       (hp.y + bh * 0.5) / bh);
+          }
+          vec2 grid = vec2(6.0, 16.0);
+          vec2 cell = uv * grid;
+          vec2 fc = fract(cell);
+          vec2 ic = floor(cell);
+          float lit = step(0.55, hash(ic + seed));
+          float win = step(0.18, fc.x) * step(fc.x, 0.82)
+                    * step(0.20, fc.y) * step(fc.y, 0.85);
+          float flickerOn = step(0.92, hash(ic + seed + 7.7));
+          float flicker = mix(1.0,
+              0.5 + 0.5 * sin(t * 6.0 + ic.x + ic.y),
+              flickerOn);
+          float winMask = lit * win * flicker * isSide;
+          float colorRoll = hash(vec2(seed, 33.7));
+          vec3 wc;
+          if (colorRoll < 0.5) wc = vec3(1.00, 0.85, 0.50);
+          else if (colorRoll < 0.75) wc = vec3(0.20, 0.95, 1.00);
+          else wc = vec3(1.00, 0.30, 0.80);
+          vec3 buildingBase = vec3(0.020, 0.015, 0.035)
+                            + vec3(0.06, 0.02, 0.08);
+          vec3 c = buildingBase + wc * winMask * 1.5;
+          float topMask = step(0.5, nrm.y);
+          c += vec3(1.0, 0.30, 0.55) * topMask
+             * (0.4 + 0.3 * sin(t * 3.0 + seed * 7.0));
+          bestCol = c;
+        }
+      }
+      return vec4(bestCol, bestT);
+    }
   `,
 
   body: /* glsl */ `
+    vec3 ro = uCamLocal;
     // Stereo parallax layers.
     vec2 pFar  = parallaxP(p, rd, 0.35);
     vec2 pBack = parallaxP(p, rd, 0.22);
@@ -57,39 +134,11 @@ export const CyberpunkScene = {
     float smog = fbm(vec2(pFar.x * 2.0 + uTime * 0.05, pFar.y * 2.0));
     col = mix(col, vec3(0.35, 0.10, 0.40), smog * smoothstep(0.0, 0.6, pFar.y) * 0.4);
 
-    // ---- City skyline: layered buildings with windows ----
-    // Back layer (distant, hazy purple).
-    {
-      for (int i = 0; i < 12; i++) {
-        float fi = float(i);
-        float cx = (fi - 5.5) * 0.20 + sin(fi * 2.7) * 0.04;
-        float w  = 0.05 + hash(vec2(fi, 1.7)) * 0.025;
-        float h  = 0.45 + hash(vec2(fi, 4.3)) * 0.20;
-        float baseY = -0.5;
-        float b = buildingMask(pBack, cx, w, h, baseY);
-        col = mix(col, vec3(0.10, 0.05, 0.20), b * 0.7);
-        // Faint window lights.
-        float win = windowsAt(pBack, cx, w, h, baseY, fi);
-        col = mix(col, vec3(0.85, 0.55, 0.95), win * 0.5);
-      }
-    }
-    // Mid layer (taller, dark, brighter windows).
-    {
-      for (int i = 0; i < 7; i++) {
-        float fi = float(i);
-        float cx = (fi - 3.0) * 0.32 + sin(fi * 4.1) * 0.06;
-        float w  = 0.08 + hash(vec2(fi, 11.7)) * 0.03;
-        float h  = 0.65 + hash(vec2(fi, 24.3)) * 0.25;
-        float baseY = -0.7;
-        float b = buildingMask(pMid, cx, w, h, baseY);
-        col = mix(col, vec3(0.02, 0.03, 0.08), b);
-        // Bright neon windows.
-        float win = windowsAt(pMid, cx, w, h, baseY, fi + 100.0);
-        vec3 winCol = mix(vec3(0.20, 0.95, 1.00),
-                          vec3(1.00, 0.30, 0.65),
-                          hash(vec2(fi, 33.7)));
-        col = mix(col, winCol, win);
-      }
+    // ---- 3D raycast city ring (parallaxes correctly) ----
+    vec4 cityHit = cityRing3D(ro, rd, uTime);
+    if (cityHit.w < 1e8) {
+      float fogF = smoothstep(8.0, 50.0, cityHit.w);
+      col = mix(cityHit.rgb, col, fogF * 0.4);
     }
 
     // ---- Neon signs glowing on the buildings ----

--- a/demos/portals/scenes/CyberpunkScene.js
+++ b/demos/portals/scenes/CyberpunkScene.js
@@ -60,6 +60,7 @@ export const CyberpunkScene = {
       float bestT = 1e9;
       vec3 bestCol = vec3(0.0);
       for (int i = 0; i < 14; i++) {
+        if (i == 10 || i == 11) continue; // park wedge — no building here
         float fi = float(i);
         float seed = fi + 19.0;
         float ang = fi * (6.28318 / 14.0)
@@ -108,9 +109,231 @@ export const CyberpunkScene = {
           float topMask = step(0.5, nrm.y);
           c += vec3(1.0, 0.30, 0.55) * topMask
              * (0.4 + 0.3 * sin(t * 3.0 + seed * 7.0));
+          // ---- Shop fronts on lower 2 stories ----
+          float lowZone = step(uv.y, 0.10) * isSide;
+          vec2 sgrid = vec2(3.0, 2.0);
+          vec2 scell = uv * sgrid;
+          vec2 sf = fract(scell);
+          vec2 si = floor(scell);
+          float swin = step(0.08, sf.x) * step(sf.x, 0.92)
+                     * step(0.15, sf.y) * step(sf.y, 0.92);
+          float doorway = step(abs(sf.x - 0.5), 0.12)
+                        * step(sf.y, 0.55);
+          float shopRoll = hash(si + seed + 13.3);
+          vec3 shopCol = (shopRoll < 0.34)
+              ? vec3(1.00, 0.80, 0.30)
+              : (shopRoll < 0.67)
+                  ? vec3(1.00, 0.20, 0.70)
+                  : vec3(0.20, 0.95, 1.00);
+          float interior = 0.65 + 0.35
+              * sin(t * 3.0 + si.x * 11.0 + si.y * 7.0);
+          float shopMask = swin * (1.0 - doorway * 0.85) * interior;
+          vec3 shopFacade = vec3(0.06, 0.04, 0.05)
+                          + shopCol * shopMask * 2.0;
+          c = mix(c, shopFacade, lowZone);
+          float signBand = step(0.105, uv.y) * step(uv.y, 0.135)
+                         * isSide;
+          c += shopCol * signBand * (1.0 + 0.3 * sin(t * 5.0 + seed));
           bestCol = c;
         }
       }
+      return vec4(bestCol, bestT);
+    }
+
+    // ---- Street life: cars, hovercars, pedestrians, traffic lights ----
+    vec4 streetLife(vec3 ro, vec3 rd, float t) {
+      float bestT = 1e9;
+      vec3 bestCol = vec3(0.0);
+      vec3 nrm;
+
+      // Ground cars: 8 across two circular lanes, opposite directions.
+      for (int i = 0; i < 8; i++) {
+        float fi = float(i);
+        float lane = mod(fi, 2.0);
+        float r = mix(15.5, 13.8, lane);
+        float dir = mix(1.0, -1.0, lane);
+        float spd = mix(0.20, 0.26, lane);
+        float baseAng = fi * 0.7854 + lane * 0.39;
+        float ang = baseAng + dir * t * spd;
+        // Skip cars currently inside the park wedge.
+        float pd = mod(ang + 1.5708 + 3.14159, 6.28318) - 3.14159;
+        if (abs(pd) < 0.30) continue;
+        vec3 ctr = vec3(cos(ang) * r, -1.40, sin(ang) * r);
+        vec3 hsz = vec3(0.42, 0.18, 0.42);
+        float th = rayBoxC(ro, rd, ctr, hsz, nrm);
+        if (th > 0.05 && th < bestT) {
+          bestT = th;
+          vec3 fwd = vec3(-sin(ang), 0.0, cos(ang)) * dir;
+          vec3 fwdAxis = (abs(fwd.x) > abs(fwd.z))
+              ? vec3(sign(fwd.x), 0.0, 0.0)
+              : vec3(0.0, 0.0, sign(fwd.z));
+          float head = step(0.9, dot(nrm, fwdAxis));
+          float tail = step(0.9, dot(nrm, -fwdAxis));
+          vec3 body = vec3(0.04, 0.03, 0.07);
+          bestCol = body
+                  + vec3(1.00, 0.95, 0.80) * head * 1.8
+                  + vec3(1.00, 0.15, 0.10) * tail * 1.4;
+        }
+      }
+
+      // Hovercars: 4 above ground, opposite layer flow.
+      for (int i = 0; i < 4; i++) {
+        float fi = float(i);
+        float lane = mod(fi, 2.0);
+        float r = mix(12.0, 13.5, lane);
+        float dir = mix(-1.0, 1.0, lane);
+        float spd = mix(0.32, 0.38, lane);
+        float baseAng = fi * 1.5708 + 0.6;
+        float ang = baseAng + dir * t * spd;
+        float pd = mod(ang + 1.5708 + 3.14159, 6.28318) - 3.14159;
+        if (abs(pd) < 0.30) continue;
+        float yH = mix(2.6, 3.6, lane);
+        vec3 ctr = vec3(cos(ang) * r, yH, sin(ang) * r);
+        vec3 hsz = vec3(0.45, 0.16, 0.45);
+        float th = rayBoxC(ro, rd, ctr, hsz, nrm);
+        if (th > 0.05 && th < bestT) {
+          bestT = th;
+          vec3 fwd = vec3(-sin(ang), 0.0, cos(ang)) * dir;
+          vec3 fwdAxis = (abs(fwd.x) > abs(fwd.z))
+              ? vec3(sign(fwd.x), 0.0, 0.0)
+              : vec3(0.0, 0.0, sign(fwd.z));
+          float head = step(0.9, dot(nrm, fwdAxis));
+          float tail = step(0.9, dot(nrm, -fwdAxis));
+          float bottom = step(0.5, -nrm.y);
+          vec3 body = vec3(0.06, 0.05, 0.10);
+          bestCol = body
+                  + vec3(0.20, 0.95, 1.00) * head * 1.6
+                  + vec3(1.00, 0.25, 0.60) * tail * 1.4
+                  + vec3(0.30, 0.95, 1.00) * bottom * 0.7;
+        }
+      }
+
+      // Pedestrians: 12 silhouettes drifting along the sidewalk.
+      for (int i = 0; i < 12; i++) {
+        float fi = float(i);
+        float r = 16.5 + hash(vec2(fi, 7.3)) * 0.7;
+        float dir = (mod(fi, 2.0) < 0.5) ? 1.0 : -1.0;
+        float spd = 0.04 + hash(vec2(fi, 9.1)) * 0.02;
+        float baseAng = fi * 0.5236 + hash(vec2(fi, 3.3)) * 0.3;
+        float ang = baseAng + dir * t * spd;
+        float pd = mod(ang + 1.5708 + 3.14159, 6.28318) - 3.14159;
+        if (abs(pd) < 0.30) continue;
+        float bob = sin(t * 4.0 + fi * 1.7) * 0.04;
+        vec3 ctr = vec3(cos(ang) * r, -1.10 + bob, sin(ang) * r);
+        vec3 hsz = vec3(0.10, 0.32, 0.10);
+        float th = rayBoxC(ro, rd, ctr, hsz, nrm);
+        if (th > 0.05 && th < bestT) {
+          bestT = th;
+          vec3 hp = ro + rd * th - ctr;
+          float headZ = step(0.22, hp.y);
+          vec3 body = vec3(0.020, 0.018, 0.030);
+          vec3 head = vec3(0.10, 0.08, 0.12);
+          float rim = 1.0 - abs(nrm.y);
+          vec3 neon = vec3(0.45, 0.10, 0.35) * rim * 0.4;
+          bestCol = mix(body, head, headZ) + neon;
+        }
+      }
+
+      // Traffic lights: 4 poles at intersections of the street loop.
+      for (int i = 0; i < 4; i++) {
+        float fi = float(i);
+        float ang = fi * 1.5708 + 0.3927;
+        float r = 14.7;
+        vec3 base = vec3(cos(ang) * r, -1.60, sin(ang) * r);
+        vec3 poleHsz = vec3(0.07, 1.20, 0.07);
+        vec3 poleCtr = base + vec3(0.0, 1.20, 0.0);
+        float th = rayBoxC(ro, rd, poleCtr, poleHsz, nrm);
+        if (th > 0.05 && th < bestT) {
+          bestT = th;
+          bestCol = vec3(0.04, 0.03, 0.05);
+        }
+        vec3 headHsz = vec3(0.18, 0.18, 0.18);
+        vec3 headCtr = base + vec3(0.0, 2.55, 0.0);
+        float th2 = rayBoxC(ro, rd, headCtr, headHsz, nrm);
+        if (th2 > 0.05 && th2 < bestT) {
+          bestT = th2;
+          float ph = mod(t + fi * 2.0, 9.0);
+          vec3 lit;
+          if (ph < 3.0) lit = vec3(1.00, 0.10, 0.10);
+          else if (ph < 5.0) lit = vec3(1.00, 0.85, 0.10);
+          else lit = vec3(0.10, 1.00, 0.30);
+          bestCol = vec3(0.04, 0.03, 0.05) + lit * 1.6;
+        }
+      }
+
+      return vec4(bestCol, bestT);
+    }
+
+    // ---- Neon night park: holographic urban green space ----
+    vec4 nightPark(vec3 ro, vec3 rd, float t) {
+      float bestT = 1e9;
+      vec3 bestCol = vec3(0.0);
+      vec3 nrm;
+      // Park sits inside the street ring (cars at r=13.8-15.5) so it
+      // reads as a clear foreground feature, and at azimuth -π/2 so it
+      // lands directly in front of the user (forward = -z, matching the
+      // hologram/sky azimuth convention atan(rd.x, -rd.z)).
+      float parkAng = -1.5708;
+      float parkR = 10.0;
+      vec3 pc = vec3(cos(parkAng) * parkR, -1.6, sin(parkAng) * parkR);
+
+      // Grass slab (6×6, 0.05 tall, emissive cyan-green).
+      float th = rayBoxC(ro, rd, pc + vec3(0.0, 0.025, 0.0),
+                          vec3(3.0, 0.025, 3.0), nrm);
+      if (th > 0.05 && th < bestT) {
+        bestT = th;
+        bestCol = vec3(0.04, 0.14, 0.10) * 1.3;
+      }
+
+      // Three holographic trees (trunk + canopy).
+      for (int i = 0; i < 3; i++) {
+        float fi = float(i);
+        float ta = -0.7 + fi * 0.7;
+        vec3 tb = pc + vec3(cos(ta) * 2.0, 0.0, sin(ta) * 2.0);
+        th = rayBoxC(ro, rd, tb + vec3(0.0, 0.75, 0.0),
+                      vec3(0.075, 0.75, 0.075), nrm);
+        if (th > 0.05 && th < bestT) {
+          bestT = th; bestCol = vec3(0.04, 0.03, 0.05);
+        }
+        th = rayBoxC(ro, rd, tb + vec3(0.0, 1.80, 0.0),
+                      vec3(0.45, 0.30, 0.45), nrm);
+        if (th > 0.05 && th < bestT) {
+          bestT = th;
+          float hue = sin(t * 0.3 + fi * 2.1) * 0.5 + 0.5;
+          bestCol = mix(vec3(1.00, 0.20, 0.80),
+                        vec3(0.20, 1.00, 0.90), hue) * 1.4;
+        }
+      }
+
+      // Holo-statue: tall emissive prism with colour drift.
+      th = rayBoxC(ro, rd, pc + vec3(0.0, 0.60, 0.0),
+                    vec3(0.15, 0.60, 0.15), nrm);
+      if (th > 0.05 && th < bestT) {
+        bestT = th;
+        vec3 hp = ro + rd * th - (pc + vec3(0.0, 0.60, 0.0));
+        float vGrad = (hp.y + 0.60) / 1.20;
+        float drift = sin(t * 0.5 + vGrad * 4.0) * 0.5 + 0.5;
+        bestCol = mix(vec3(0.20, 0.40, 1.00),
+                      vec3(1.00, 0.20, 0.90), drift) * 1.6;
+      }
+
+      // Two lamp posts (pole + glowing head).
+      for (int i = 0; i < 2; i++) {
+        float fi = float(i);
+        float la = -0.5 + fi * 1.0;
+        vec3 lb = pc + vec3(cos(la) * 2.8, 0.0, sin(la) * 2.8);
+        th = rayBoxC(ro, rd, lb + vec3(0.0, 1.10, 0.0),
+                      vec3(0.05, 1.10, 0.05), nrm);
+        if (th > 0.05 && th < bestT) {
+          bestT = th; bestCol = vec3(0.04, 0.03, 0.05);
+        }
+        th = rayBoxC(ro, rd, lb + vec3(0.0, 2.30, 0.0),
+                      vec3(0.12, 0.08, 0.12), nrm);
+        if (th > 0.05 && th < bestT) {
+          bestT = th; bestCol = vec3(1.00, 0.65, 0.20) * 1.5;
+        }
+      }
+
       return vec4(bestCol, bestT);
     }
   `,
@@ -136,9 +359,21 @@ export const CyberpunkScene = {
 
     // ---- 3D raycast city ring (parallaxes correctly) ----
     vec4 cityHit = cityRing3D(ro, rd, uTime);
-    if (cityHit.w < 1e8) {
-      float fogF = smoothstep(8.0, 50.0, cityHit.w);
-      col = mix(cityHit.rgb, col, fogF * 0.4);
+    float opaqueT = cityHit.w;
+    vec3 opaqueCol = cityHit.rgb;
+    vec4 streetHit = streetLife(ro, rd, uTime);
+    if (streetHit.w < opaqueT) {
+      opaqueT = streetHit.w;
+      opaqueCol = streetHit.rgb;
+    }
+    vec4 parkHit = nightPark(ro, rd, uTime);
+    if (parkHit.w < opaqueT) {
+      opaqueT = parkHit.w;
+      opaqueCol = parkHit.rgb;
+    }
+    if (opaqueT < 1e8) {
+      float fogF = smoothstep(8.0, 50.0, opaqueT);
+      col = mix(opaqueCol, col, fogF * 0.4);
     }
 
     // ---- Neon signs glowing on the buildings ----

--- a/demos/portals/scenes/ForestScene.js
+++ b/demos/portals/scenes/ForestScene.js
@@ -43,6 +43,10 @@ export const ForestScene = {
             : mix(8.0, 13.0, hash(vec2(fi, 5.1)));
         vec2 pos = vec2(cos(ang), sin(ang)) * radius;
         float scale = 1.6 + hash(vec2(fi, 9.7)) * 1.4;
+        float lAng = hash(vec2(fi, 13.1)) * 6.28318;
+        float lAmt = (hash(vec2(fi, 17.3)) - 0.3) * 0.4 * scale;
+        vec2 lean = vec2(cos(lAng), sin(lAng)) * lAmt;
+        float sway = sin(uTime * 0.5 + hash(vec2(fi, 21.7)) * 6.28) * 0.12;
         float trunkTopY = GY + 1.4 * scale;
         float t = rayCylinderY(ro, rd, pos, 0.10 * scale, GY, trunkTopY);
         if (t > 0.0 && t < bestT) {
@@ -51,8 +55,11 @@ export const ForestScene = {
         for (int k = 0; k < 4; k++) {
           float fk = float(k);
           float cy = trunkTopY + (0.4 + fk * 0.55) * scale;
-          float cr = (0.95 - fk * 0.18) * scale;
-          float ts = raySphere(ro, rd, vec3(pos.x, cy, pos.y), cr);
+          float rVar = 0.85 + 0.3 * hash(vec2(pos.x * 7.3 + fk, pos.y * 3.1));
+          float cr = (0.95 - fk * 0.18) * scale * rVar;
+          float hFrac = (fk + 1.0) / 4.0;
+          vec2 off = lean * hFrac + vec2(sway) * hFrac;
+          float ts = raySphere(ro, rd, vec3(pos.x + off.x, cy, pos.y + off.y), cr);
           if (ts > 0.0 && ts < bestT) {
             bestT = ts; bestId = 2; bestPos = pos; bestScale = scale;
           }
@@ -73,7 +80,9 @@ export const ForestScene = {
         float needles = fbm(hp.xz * 6.0 + hp.y * 3.0);
         vec3 base = mix(vec3(0.025, 0.050, 0.028),
                         vec3(0.055, 0.100, 0.050), needles);
-        col = base * (0.45 + topLight * 0.7);
+        float breathe = 0.92 + 0.08 * sin(uTime * 0.6
+          + bestPos.x * 1.3 + bestPos.y * 0.9);
+        col = base * (0.45 + topLight * 0.7) * breathe;
       }
       float fog = smoothstep(3.0, 16.0, bestT);
       col = mix(col, vec3(0.10, 0.08, 0.18), fog * 0.6);
@@ -139,6 +148,20 @@ export const ForestScene = {
           float gn = fbm(gp.xz * 0.4);
           vec3 ground = mix(vec3(0.03, 0.04, 0.02),
                             vec3(0.08, 0.07, 0.04), gn);
+          // Creek — winding stream on the forest floor
+          float creekPath = sin(gp.z * 0.7 + 1.5) * 1.8
+                          + sin(gp.z * 0.3) * 2.5;
+          float creekDist = abs(gp.x - creekPath);
+          float creekW = 0.35 + 0.1 * sin(gp.z * 1.2);
+          float creek = smoothstep(creekW, creekW * 0.4, creekDist);
+          if (creek > 0.01) {
+            vec2 flowUV = gp.xz + vec2(0.0, uTime * 0.2);
+            float ripple = fbm(flowUV * 4.0);
+            vec3 water = mix(vec3(0.03, 0.05, 0.12),
+                             vec3(0.06, 0.10, 0.20), ripple);
+            water += vec3(0.04, 0.03, 0.08) * ripple;
+            ground = mix(ground, water, creek);
+          }
           float fog = smoothstep(0.0, 25.0, t);
           col = mix(ground, col, fog * 0.7);
         }
@@ -150,6 +173,36 @@ export const ForestScene = {
       vec3 ro = uCamLocal;
       vec4 trees = forestTrees3D(ro, rd);
       if (trees.a > 0.0) col = trees.rgb;
+    }
+
+    // Moonbeams — soft volumetric light shafts through canopy gaps
+    {
+      vec3 mRo = uCamLocal;
+      vec3 mLD = normalize(vec3(-0.45, -0.75, 0.55));
+      for (int b = 0; b < 3; b++) {
+        float fb = float(b);
+        vec3 bO = vec3(sin(fb * 2.4 + 0.8) * 3.5,
+                       3.9,
+                       cos(fb * 2.4 + 0.8) * 3.0);
+        vec3 w = mRo - bO;
+        float dd = dot(rd, mLD);
+        float den = 1.0 - dd * dd;
+        if (den > 0.001) {
+          float sC = (dd * dot(w, mLD) - dot(w, rd)) / den;
+          float tC = (dot(w, mLD) - dd * dot(w, rd)) / den;
+          if (sC > 0.5 && tC > 0.0) {
+            vec3 pR = mRo + rd * sC;
+            vec3 pB = bO + mLD * tC;
+            float dist = length(pR - pB);
+            float beam = smoothstep(0.6, 0.0, dist) * 0.12;
+            beam *= smoothstep(0.0, 1.5, tC) * smoothstep(8.0, 5.0, tC);
+            beam *= smoothstep(-1.6, -1.0, pR.y)
+                  * smoothstep(4.0, 1.5, pR.y);
+            beam *= smoothstep(20.0, 2.0, sC);
+            col += vec3(0.50, 0.55, 0.75) * beam;
+          }
+        }
+      }
     }
 
     // Ground mist rolling in (always on, animated).

--- a/demos/portals/scenes/ForestScene.js
+++ b/demos/portals/scenes/ForestScene.js
@@ -10,15 +10,83 @@ export const ForestScene = {
   haloOuter: 'vec3(0.85, 1.00, 0.55)',
 
   helpers: /* glsl */ `
-    // A vertical tree-trunk silhouette.
+    // Vertical-cylinder ray test (axis = Y).
+    float rayCylinderY(vec3 ro, vec3 rd, vec2 c, float r,
+                       float yMin, float yMax) {
+      vec2 d = rd.xz;
+      vec2 oc = ro.xz - c;
+      float a = dot(d, d);
+      if (a < 1e-6) return -1.0;
+      float b = dot(oc, d);
+      float disc = b * b - a * (dot(oc, oc) - r * r);
+      if (disc < 0.0) return -1.0;
+      float t = (-b - sqrt(disc)) / a;
+      if (t < 0.0) return -1.0;
+      float hy = ro.y + rd.y * t;
+      if (hy < yMin || hy > yMax) return -1.0;
+      return t;
+    }
+
+    // Same 18-tree forest as ForestImmersive: 8 inner ring (4-7m),
+    // 10 outer ring (8-13m). Eye at y=0, ground at y=-1.6.
+    // Returns vec4(rgb, hitT) or vec4(0,0,0,-1) on miss.
+    vec4 forestTrees3D(vec3 ro, vec3 rd) {
+      const float GY = -1.6;
+      float bestT = 1e9; int bestId = 0; vec2 bestPos = vec2(0.0);
+      float bestScale = 1.0;
+      for (int i = 0; i < 18; i++) {
+        float fi = float(i);
+        float ringT = (fi < 8.0) ? fi / 8.0 : (fi - 8.0) / 10.0;
+        float ang = ringT * 6.28318 + hash(vec2(fi, 1.7)) * 0.6;
+        float radius = (fi < 8.0)
+            ? mix(4.0, 7.0, hash(vec2(fi, 3.3)))
+            : mix(8.0, 13.0, hash(vec2(fi, 5.1)));
+        vec2 pos = vec2(cos(ang), sin(ang)) * radius;
+        float scale = 1.6 + hash(vec2(fi, 9.7)) * 1.4;
+        float trunkTopY = GY + 1.4 * scale;
+        float t = rayCylinderY(ro, rd, pos, 0.10 * scale, GY, trunkTopY);
+        if (t > 0.0 && t < bestT) {
+          bestT = t; bestId = 1; bestPos = pos; bestScale = scale;
+        }
+        for (int k = 0; k < 4; k++) {
+          float fk = float(k);
+          float cy = trunkTopY + (0.4 + fk * 0.55) * scale;
+          float cr = (0.95 - fk * 0.18) * scale;
+          float ts = raySphere(ro, rd, vec3(pos.x, cy, pos.y), cr);
+          if (ts > 0.0 && ts < bestT) {
+            bestT = ts; bestId = 2; bestPos = pos; bestScale = scale;
+          }
+        }
+      }
+      if (bestId == 0) return vec4(0.0, 0.0, 0.0, -1.0);
+      vec3 hp = ro + rd * bestT;
+      vec3 col;
+      if (bestId == 1) {
+        float bark = fbm(vec2(hp.y * 6.0,
+                        atan(hp.z - bestPos.y, hp.x - bestPos.x) * 4.0));
+        col = mix(vec3(0.030, 0.022, 0.015),
+                  vec3(0.075, 0.055, 0.035), bark);
+      } else {
+        vec3 trunkTop = vec3(bestPos.x, GY + 1.4 * bestScale, bestPos.y);
+        vec3 n = normalize(hp - trunkTop);
+        float topLight = max(n.y, 0.0);
+        float needles = fbm(hp.xz * 6.0 + hp.y * 3.0);
+        vec3 base = mix(vec3(0.025, 0.050, 0.028),
+                        vec3(0.055, 0.100, 0.050), needles);
+        col = base * (0.45 + topLight * 0.7);
+      }
+      float fog = smoothstep(3.0, 16.0, bestT);
+      col = mix(col, vec3(0.10, 0.08, 0.18), fog * 0.6);
+      return vec4(col, bestT);
+    }
+
+    // A vertical tree-trunk silhouette (kept for legacy; unused).
     float treeMask(vec2 p, float cx, float w, float h, float baseY) {
       float taper = w * (1.0 - smoothstep(baseY, baseY + h, p.y) * 0.6);
       float trunk = smoothstep(taper, taper * 0.85, abs(p.x - cx))
                   * step(baseY, p.y) * step(p.y, baseY + h);
-      // Triangular pine canopy on top.
       float dx = abs(p.x - cx);
       float canopyTop = baseY + h + 0.25;
-      float canopySlope = (canopyTop - (baseY + h * 0.4)) / (w * 4.0);
       float canopy = step(p.y, canopyTop - dx / (w * 4.0))
                    * step(baseY + h * 0.4, p.y);
       return clamp(trunk + canopy, 0.0, 1.0);
@@ -60,38 +128,28 @@ export const ForestScene = {
       col += vec3(0.95, 0.95, 1.0) * (s1 + s2 * 0.6) * upper * 0.9;
     }
 
-    // ---- Distant tree silhouettes (back row, hazy) ----
+    // ---- 3D ground (matches immersive: y=-1.6 plane) ----
     {
-      for (int i = 0; i < 9; i++) {
-        float fi = float(i);
-        float cx = (fi - 4.0) * 0.25 + sin(fi * 1.7) * 0.05;
-        float w = 0.020 + hash(vec2(fi, 1.1)) * 0.010;
-        float h = 0.30 + hash(vec2(fi, 7.7)) * 0.10;
-        float baseY = -0.4;
-        float t = treeMask(pBack, cx, w, h, baseY);
-        col = mix(col, vec3(0.05, 0.07, 0.12), t * 0.85);
+      vec3 ro = uCamLocal;
+      float gy = -1.6;
+      if (rd.y < -0.001 && ro.y > gy) {
+        float t = (gy - ro.y) / rd.y;
+        if (t > 0.0 && t < 200.0) {
+          vec3 gp = ro + rd * t;
+          float gn = fbm(gp.xz * 0.4);
+          vec3 ground = mix(vec3(0.03, 0.04, 0.02),
+                            vec3(0.08, 0.07, 0.04), gn);
+          float fog = smoothstep(0.0, 25.0, t);
+          col = mix(ground, col, fog * 0.7);
+        }
       }
     }
 
-    // ---- Mid-ground trees (denser, darker) ----
+    // ---- 3D raycast trees (same 18-tree layout as the immersive) ----
     {
-      for (int i = 0; i < 7; i++) {
-        float fi = float(i);
-        float cx = (fi - 3.0) * 0.32 + sin(fi * 2.3) * 0.08;
-        float w = 0.030 + hash(vec2(fi, 3.1)) * 0.015;
-        float h = 0.45 + hash(vec2(fi, 9.7)) * 0.15;
-        float baseY = -0.6;
-        float t = treeMask(pMid, cx, w, h, baseY);
-        col = mix(col, vec3(0.02, 0.04, 0.06), t);
-      }
-    }
-
-    // Forest floor.
-    if (pMid.y < -0.55) {
-      float floorN = fbm(vec2(pMid.x * 4.0, pMid.y * 4.0));
-      vec3 floorCol = mix(vec3(0.04, 0.06, 0.04),
-                          vec3(0.10, 0.12, 0.06), floorN);
-      col = mix(col, floorCol, smoothstep(-0.55, -1.0, pMid.y));
+      vec3 ro = uCamLocal;
+      vec4 trees = forestTrees3D(ro, rd);
+      if (trees.a > 0.0) col = trees.rgb;
     }
 
     // Ground mist rolling in (always on, animated).

--- a/demos/portals/scenes/LavaScene.js
+++ b/demos/portals/scenes/LavaScene.js
@@ -19,9 +19,114 @@ export const LavaScene = {
       float surf = top + jagged;
       return step(p.y, surf) * step(c.y - 0.05, p.y);
     }
+
+    // Ray vs axis-aligned ellipsoid.
+    float rayEllipL(vec3 oc, vec3 rd, vec3 ax) {
+      vec3 ocS = oc / ax;
+      vec3 rdS = rd / ax;
+      float a = dot(rdS, rdS);
+      float b = dot(ocS, rdS);
+      float c = dot(ocS, ocS) - 1.0;
+      float d = b * b - a * c;
+      if (d < 0.0) return -1.0;
+      return (-b - sqrt(d)) / a;
+    }
+
+    float fbm3L(vec3 p) {
+      float v = 0.0;
+      float a = 0.5;
+      for (int i = 0; i < 4; i++) {
+        v += a * fbm(p.xy + p.z * 1.3);
+        p *= 2.07;
+        a *= 0.5;
+      }
+      return v;
+    }
+
+    // 3D volcano: stacked ellipsoid mounds; returns vec4(rgb, t).
+    vec4 volcano3D_d(vec3 ro, vec3 rd, vec3 base, float t,
+                    float scaleR, float scaleH) {
+      vec3 sunDir = normalize(vec3(0.3, 0.6, -0.7));
+      float bestT = 1e9;
+      int bestLayer = -1;
+      vec3 bestN = vec3(0.0);
+      vec3 bestHp = vec3(0.0);
+      for (int i = 0; i < 4; i++) {
+        float fi = float(i);
+        float r = (3.4 - fi * 0.75) * scaleR;
+        float ry = 0.9 * scaleH;
+        vec3 ax = vec3(r, ry, r);
+        vec3 ctr = base + vec3(0.0, 0.5 * scaleH + fi * 1.4 * scaleH, 0.0);
+        float th = rayEllipL(ro - ctr, rd, ax);
+        if (th > 0.5 && th < bestT) {
+          bestT = th;
+          bestHp = ro + rd * th - ctr;
+          bestN = normalize(bestHp / (ax * ax));
+          bestLayer = i;
+        }
+      }
+      if (bestT >= 1e9) return vec4(0.0, 0.0, 0.0, 1e9);
+      float noiseTex = fbm3L(bestHp * 1.6);
+      vec3 rock = mix(vec3(0.10, 0.05, 0.04),
+                      vec3(0.22, 0.11, 0.08), noiseTex);
+      float streakNoise = fbm(vec2(atan(bestHp.x, bestHp.z) * 8.0,
+                                    bestHp.y * 0.8 - t * 0.15));
+      float layerFrac = float(bestLayer) / 3.0;
+      float streakMask = smoothstep(0.62, 0.78, streakNoise)
+                       * (1.0 - layerFrac * 0.6);
+      vec3 lava = vec3(1.00, 0.45, 0.10);
+      vec3 col = mix(rock, lava, streakMask * 0.85);
+      if (bestLayer == 3) {
+        float craterUp = max(bestN.y, 0.0);
+        col = mix(col, vec3(1.0, 0.65, 0.15), craterUp * craterUp);
+      }
+      float lamb = max(dot(bestN, sunDir), 0.0);
+      float rim = pow(1.0 - max(dot(bestN, -rd), 0.0), 2.5);
+      col = col * (0.30 + lamb * 0.85)
+          + vec3(0.6, 0.3, 0.2) * rim * 0.20;
+      return vec4(col, bestT);
+    }
+
+    // Foreground lava rocks scattered around the user.
+    vec4 lavaRocks3D(vec3 ro, vec3 rd, float t) {
+      vec3 sunDir = normalize(vec3(0.3, 0.6, -0.7));
+      float bestT = 1e9;
+      vec3 bestCol = vec3(0.0);
+      vec3 bestN = vec3(0.0);
+      for (int i = 0; i < 8; i++) {
+        float fi = float(i);
+        float ang = fi * 0.91;
+        float dist = 4.5 + mod(fi * 1.7, 4.0);
+        vec3 base = vec3(cos(ang) * dist, -1.6, sin(ang) * dist);
+        float ry = 0.35 + 0.18 * sin(fi * 2.3);
+        vec3 ax = vec3(0.7 + 0.2 * cos(fi * 1.7), ry,
+                        0.6 + 0.2 * sin(fi * 1.7));
+        vec3 ctr = base + vec3(0.0, ry, 0.0);
+        float th = rayEllipL(ro - ctr, rd, ax);
+        if (th > 0.3 && th < bestT) {
+          bestT = th;
+          vec3 hp = ro + rd * th - ctr;
+          bestN = normalize(hp / (ax * ax));
+          float n = fbm3L(hp * 4.0 + fi);
+          vec3 rock = mix(vec3(0.06, 0.03, 0.02),
+                          vec3(0.18, 0.09, 0.07), n);
+          float crack = smoothstep(0.55, 0.7,
+                                    fbm(hp.xz * 9.0 + t * 0.2));
+          crack *= max(-bestN.y, 0.0);
+          bestCol = mix(rock, vec3(1.0, 0.42, 0.08), crack * 0.6);
+        }
+      }
+      if (bestT >= 1e9) return vec4(0.0, 0.0, 0.0, 1e9);
+      float lamb = max(dot(bestN, sunDir), 0.0);
+      float rim = pow(1.0 - max(dot(bestN, -rd), 0.0), 2.5);
+      vec3 col = bestCol * (0.30 + lamb * 0.85)
+               + vec3(1.0, 0.5, 0.2) * rim * 0.18;
+      return vec4(col, bestT);
+    }
   `,
 
   body: /* glsl */ `
+    vec3 ro = uCamLocal;
     // Stereo parallax layers.
     vec2 pFar  = parallaxP(p, rd, 0.35);
     vec2 pBack = parallaxP(p, rd, 0.22);
@@ -48,19 +153,33 @@ export const LavaScene = {
       col += vec3(1.0, 0.8, 0.5) * spark * 0.6;
     }
 
-    // ---- Distant volcano on the horizon (centered) ----
+    // ---- 3D raycast volcanoes (parallax correctly with head movement) ----
+    float opaqueT = 1e9;
+    vec3 opaqueCol = vec3(0.0);
+    vec4 v1Hit = volcano3D_d(ro, rd, vec3(14.0, -1.6, -8.0), uTime, 1.0, 1.0);
+    if (v1Hit.w < opaqueT) {
+      opaqueT = v1Hit.w;
+      opaqueCol = v1Hit.rgb;
+    }
+    vec4 v2Hit = volcano3D_d(ro, rd, vec3(-18.0, -1.6, 9.0), uTime, 0.85, 0.9);
+    if (v2Hit.w < opaqueT) {
+      opaqueT = v2Hit.w;
+      opaqueCol = v2Hit.rgb;
+    }
+    vec4 rocksHit = lavaRocks3D(ro, rd, uTime);
+    if (rocksHit.w < opaqueT) {
+      opaqueT = rocksHit.w;
+      opaqueCol = rocksHit.rgb;
+    }
+    if (opaqueT < 1e8) {
+      float fogF = smoothstep(4.0, 60.0, opaqueT);
+      col = mix(opaqueCol, col, fogF * 0.55);
+    }
+
+    // Lava river still rendered as 2D parallax band on the foreground.
     vec2 volcCenter = vec2(0.0, -0.4);
     float volcW = 0.8;
     float volcH = 0.55;
-    float volc = volcanoMask(pBack, volcCenter, volcW, volcH);
-    if (volc > 0.0) {
-      // Dark rocky body with occasional glowing cracks.
-      vec3 rock = vec3(0.10, 0.05, 0.04);
-      float cracks = ridgedFbm(vec2(pBack.x * 18.0, pBack.y * 22.0));
-      cracks = smoothstep(0.55, 0.85, cracks);
-      vec3 lavaCrack = vec3(1.00, 0.45, 0.10);
-      col = mix(rock, lavaCrack, cracks * 0.6);
-    }
 
     // ---- Lava river running across the foreground ----
     {

--- a/demos/portals/scenes/LavaScene.js
+++ b/demos/portals/scenes/LavaScene.js
@@ -234,9 +234,10 @@ export const LavaScene = {
     // ---- Animated ash plume + lava spurts above main volcano apex ----
     {
       vec3 apexW = vec3(2.0, 4.4, -16.0);
-      // Sample 14 horizontal slices from the crater upward; each slice tests
-      // distance from the vertical column through the apex.
-      for (int i = 0; i < 14; i++) {
+      // Sample kNumSlices horizontal slices from the crater upward; each
+      // slice tests distance from the vertical column through the apex.
+      const int kNumSlices = 14;
+      for (int i = 0; i < kNumSlices; i++) {
         float h = float(i) * 0.65;
         float ty = apexW.y + h;
         if (abs(rd.y) < 0.001) continue;

--- a/demos/portals/scenes/LavaScene.js
+++ b/demos/portals/scenes/LavaScene.js
@@ -365,44 +365,6 @@ export const LavaScene = {
       col += vec3(1.0, 0.95, 0.55) * flash * 1.2;
     }
 
-    // ---- Lava bombs every 5s arcing across sky ----
-    {
-      float cycle = 5.0;
-      float k = floor(uTime / cycle);
-      float local = uTime - k * cycle;
-      for (int i = 0; i < 4; i++) {
-        float fi = float(i);
-        float dly = fi * 0.8;
-        float life = local - dly;
-        if (life > 0.0 && life < cycle - dly) {
-          // Parabolic arc from crater to a random landing point.
-          float landX = (hash(vec2(k, fi + 11.7)) - 0.5) * 1.8;
-          vec2 c0 = vec2(0.0, volcCenter.y + volcH);
-          vec2 c1 = vec2(landX, -0.55);
-          float u = life / 1.8;
-          if (u <= 1.0) {
-            vec2 pos = mix(c0, c1, u);
-            pos.y += sin(u * 3.14159) * (0.35 + fi * 0.05);
-            float dr = length(pMid - pos);
-            float bomb = smoothstep(0.02, 0.0, dr);
-            col += vec3(1.0, 0.85, 0.30) * bomb * 2.5;
-            // Trailing smoke.
-            for (int j = 0; j < 6; j++) {
-              float fj = float(j);
-              float u2 = u - fj * 0.04;
-              if (u2 > 0.0) {
-                vec2 pos2 = mix(c0, c1, u2);
-                pos2.y += sin(u2 * 3.14159) * (0.35 + fi * 0.05);
-                float td = length(pMid - pos2);
-                float trail = smoothstep(0.012 + fj * 0.003, 0.0, td);
-                col += vec3(0.85, 0.45, 0.20) * trail * (1.0 - fj * 0.15);
-              }
-            }
-          }
-        }
-      }
-    }
-
     // ---- Volcanic lightning in ash plume every 7s ----
     {
       float cycle = 7.0;

--- a/demos/portals/scenes/LavaScene.js
+++ b/demos/portals/scenes/LavaScene.js
@@ -214,7 +214,7 @@ export const LavaScene = {
       opaqueT = v1Hit.w;
       opaqueCol = v1Hit.rgb;
     }
-    vec4 v2Hit = volcanoCone(ro, rd, vec3(-12.0, -1.6, -10.0), 4.2,
+    vec4 v2Hit = volcanoCone(ro, rd, vec3(-15.0, -1.6, 8.0), 4.2,
                               6.0, 1.8, uTime);
     if (v2Hit.w < opaqueT) {
       opaqueT = v2Hit.w;

--- a/demos/portals/scenes/LavaScene.js
+++ b/demos/portals/scenes/LavaScene.js
@@ -43,48 +43,100 @@ export const LavaScene = {
       return v;
     }
 
-    // 3D volcano: stacked ellipsoid mounds; returns vec4(rgb, t).
-    vec4 volcano3D_d(vec3 ro, vec3 rd, vec3 base, float t,
-                    float scaleR, float scaleH) {
+    // Ray vs truncated cone (volcano with flat-top crater).
+    // base: world position of base; topY: height to crater plateau;
+    // bottomR: base radius; topR: crater radius.
+    vec4 volcanoCone(vec3 ro, vec3 rd, vec3 base, float topY,
+                      float bottomR, float topR, float t) {
       vec3 sunDir = normalize(vec3(0.3, 0.6, -0.7));
-      float bestT = 1e9;
-      int bestLayer = -1;
-      vec3 bestN = vec3(0.0);
-      vec3 bestHp = vec3(0.0);
-      for (int i = 0; i < 4; i++) {
-        float fi = float(i);
-        float r = (3.4 - fi * 0.75) * scaleR;
-        float ry = 0.9 * scaleH;
-        vec3 ax = vec3(r, ry, r);
-        vec3 ctr = base + vec3(0.0, 0.5 * scaleH + fi * 1.4 * scaleH, 0.0);
-        float th = rayEllipL(ro - ctr, rd, ax);
-        if (th > 0.5 && th < bestT) {
-          bestT = th;
-          bestHp = ro + rd * th - ctr;
-          bestN = normalize(bestHp / (ax * ax));
-          bestLayer = i;
+      float craterOffset = topR * topY / max(bottomR - topR, 0.001);
+      vec3 apex = base + vec3(0.0, topY + craterOffset, 0.0);
+      float tanT = bottomR / (topY + craterOffset);
+      float tan2 = tanT * tanT;
+      vec3 oc = ro - apex;
+      float a = rd.x * rd.x + rd.z * rd.z - tan2 * rd.y * rd.y;
+      float b = oc.x * rd.x + oc.z * rd.z - tan2 * oc.y * rd.y;
+      float c = oc.x * oc.x + oc.z * oc.z - tan2 * oc.y * oc.y;
+      float tCone = 1e9;
+      if (abs(a) > 1e-5) {
+        float disc = b * b - a * c;
+        if (disc > 0.0) {
+          float sq = sqrt(disc);
+          float t0 = (-b - sq) / a;
+          float t1 = (-b + sq) / a;
+          for (int k = 0; k < 2; k++) {
+            float ti = (k == 0) ? t0 : t1;
+            if (ti > 0.5 && ti < tCone) {
+              float py = ro.y + rd.y * ti;
+              if (py >= base.y && py <= base.y + topY) tCone = ti;
+            }
+          }
         }
       }
-      if (bestT >= 1e9) return vec4(0.0, 0.0, 0.0, 1e9);
-      float noiseTex = fbm3L(bestHp * 1.6);
-      vec3 rock = mix(vec3(0.10, 0.05, 0.04),
-                      vec3(0.22, 0.11, 0.08), noiseTex);
-      float streakNoise = fbm(vec2(atan(bestHp.x, bestHp.z) * 8.0,
-                                    bestHp.y * 0.8 - t * 0.15));
-      float layerFrac = float(bestLayer) / 3.0;
-      float streakMask = smoothstep(0.62, 0.78, streakNoise)
-                       * (1.0 - layerFrac * 0.6);
-      vec3 lava = vec3(1.00, 0.45, 0.10);
-      vec3 col = mix(rock, lava, streakMask * 0.85);
-      if (bestLayer == 3) {
-        float craterUp = max(bestN.y, 0.0);
-        col = mix(col, vec3(1.0, 0.65, 0.15), craterUp * craterUp);
+      float tPlat = 1e9;
+      if (abs(rd.y) > 1e-5) {
+        float plateauY = base.y + topY;
+        float tp = (plateauY - ro.y) / rd.y;
+        if (tp > 0.5) {
+          vec3 hp = ro + rd * tp;
+          float r = length(hp.xz - apex.xz);
+          if (r <= topR) tPlat = tp;
+        }
       }
-      float lamb = max(dot(bestN, sunDir), 0.0);
-      float rim = pow(1.0 - max(dot(bestN, -rd), 0.0), 2.5);
-      col = col * (0.30 + lamb * 0.85)
-          + vec3(0.6, 0.3, 0.2) * rim * 0.20;
-      return vec4(col, bestT);
+      float tBest = min(tCone, tPlat);
+      if (tBest >= 1e9) return vec4(0.0, 0.0, 0.0, 1e9);
+      bool hitPlat = (tPlat <= tCone);
+      vec3 hp = ro + rd * tBest;
+      vec3 nrm;
+      if (hitPlat) {
+        nrm = vec3(0.0, 1.0, 0.0);
+      } else {
+        vec3 op = hp - apex;
+        nrm = normalize(vec3(op.x, -tan2 * op.y, op.z));
+      }
+      vec3 col;
+      if (hitPlat) {
+        float r = length(hp.xz - apex.xz) / topR;
+        float crustNoise = fbm3L(hp * 1.8 + vec3(0.0, t * 0.15, 0.0));
+        float fissure = fbm3L(hp * 3.5 + vec3(t * 0.25, 0.0, t * 0.2));
+        float crackMask = smoothstep(0.48, 0.60, fissure);
+        vec3 crust = mix(vec3(0.06, 0.03, 0.02),
+                         vec3(0.16, 0.08, 0.05), crustNoise);
+        vec3 hotLava = mix(vec3(1.00, 0.55, 0.10),
+                           vec3(1.00, 0.95, 0.55),
+                           smoothstep(0.55, 0.75, fissure));
+        col = mix(crust, hotLava, crackMask);
+        col *= mix(1.4, 0.85, r);
+      } else {
+        float h = clamp((hp.y - base.y) / topY, 0.0, 1.0);
+        float ang = atan(hp.x - apex.x, hp.z - apex.z);
+        float strata = fbm3L(vec3(ang * 1.5, h * 6.0, 0.0));
+        float pebble = fbm3L(hp * 3.5);
+        vec3 darkRock = vec3(0.07, 0.04, 0.03);
+        vec3 midRock = vec3(0.20, 0.11, 0.07);
+        vec3 ashRock = vec3(0.32, 0.26, 0.22);
+        vec3 rock = mix(darkRock, midRock, strata);
+        rock = mix(rock, ashRock, smoothstep(0.55, 0.95, h) * 0.55);
+        rock = mix(rock * 0.85, rock * 1.15, pebble);
+        float chan = abs(fract(ang * 1.9 + fbm3L(hp * 0.6) * 0.4) - 0.5);
+        float channelMask = smoothstep(0.04, 0.0, chan)
+                          * smoothstep(0.15, 0.65, h);
+        float trickle = fbm(vec2(ang * 8.0, h * 4.5 - t * 0.18));
+        channelMask *= smoothstep(0.35, 0.75, trickle);
+        vec3 lavaHot = mix(vec3(0.85, 0.18, 0.04),
+                           vec3(1.00, 0.70, 0.20),
+                           smoothstep(0.6, 1.0, h));
+        col = mix(rock, lavaHot, channelMask);
+        float rimGlow = smoothstep(0.88, 1.0, h);
+        col += vec3(1.00, 0.50, 0.10) * rimGlow * 0.55;
+        float lamb = max(dot(nrm, sunDir), 0.0);
+        float ao = mix(0.6, 1.0, h);
+        col = col * (0.22 + lamb * 0.95) * ao;
+        float rimL = pow(1.0 - max(dot(nrm, -rd), 0.0), 2.5);
+        col += vec3(0.55, 0.28, 0.18) * rimL * 0.20;
+        col += lavaHot * channelMask * 0.55;
+      }
+      return vec4(col, tBest);
     }
 
     // Foreground lava rocks scattered around the user.
@@ -156,12 +208,14 @@ export const LavaScene = {
     // ---- 3D raycast volcanoes (parallax correctly with head movement) ----
     float opaqueT = 1e9;
     vec3 opaqueCol = vec3(0.0);
-    vec4 v1Hit = volcano3D_d(ro, rd, vec3(14.0, -1.6, -8.0), uTime, 1.0, 1.0);
+    vec4 v1Hit = volcanoCone(ro, rd, vec3(2.0, -1.6, -16.0), 6.0,
+                              8.5, 2.6, uTime);
     if (v1Hit.w < opaqueT) {
       opaqueT = v1Hit.w;
       opaqueCol = v1Hit.rgb;
     }
-    vec4 v2Hit = volcano3D_d(ro, rd, vec3(-18.0, -1.6, 9.0), uTime, 0.85, 0.9);
+    vec4 v2Hit = volcanoCone(ro, rd, vec3(-12.0, -1.6, -10.0), 4.2,
+                              6.0, 1.8, uTime);
     if (v2Hit.w < opaqueT) {
       opaqueT = v2Hit.w;
       opaqueCol = v2Hit.rgb;
@@ -172,12 +226,80 @@ export const LavaScene = {
       opaqueCol = rocksHit.rgb;
     }
     if (opaqueT < 1e8) {
-      float fogF = smoothstep(4.0, 60.0, opaqueT);
-      col = mix(opaqueCol, col, fogF * 0.55);
+      // Light atmospheric fog only; keep the volcano shape readable.
+      float fogF = smoothstep(8.0, 80.0, opaqueT);
+      col = mix(opaqueCol, col, fogF * 0.25);
     }
 
-    // Lava river still rendered as 2D parallax band on the foreground.
-    vec2 volcCenter = vec2(0.0, -0.4);
+    // ---- Animated ash plume + lava spurts above main volcano apex ----
+    {
+      vec3 apexW = vec3(2.0, 4.4, -16.0);
+      // Sample 14 horizontal slices from the crater upward; each slice tests
+      // distance from the vertical column through the apex.
+      for (int i = 0; i < 14; i++) {
+        float h = float(i) * 0.65;
+        float ty = apexW.y + h;
+        if (abs(rd.y) < 0.001) continue;
+        float ti = (ty - ro.y) / rd.y;
+        if (ti < 0.5 || ti > opaqueT) continue;
+        vec3 p = ro + rd * ti;
+        vec2 d = p.xz - apexW.xz;
+        float r = length(d);
+        float radius = 1.6 + h * 0.55;
+        float mask = smoothstep(radius, radius * 0.35, r);
+        float n = fbm3L(vec3(d.x * 0.45, h * 0.6 - uTime * 0.5,
+                              d.y * 0.45));
+        // Cooler grey/brown ash higher up; warmer near the base.
+        vec3 ashHot = vec3(0.55, 0.30, 0.18);
+        vec3 ashCold = vec3(0.20, 0.16, 0.18);
+        vec3 ashCol = mix(ashHot, ashCold, smoothstep(0.0, 6.0, h));
+        ashCol = mix(ashCol * 0.4, ashCol, n);
+        col += ashCol * mask * (0.06 + n * 0.10);
+        // Hot orange glow at the base of the plume.
+        if (h < 1.5) {
+          col += vec3(1.0, 0.55, 0.20) * mask * (1.5 - h) * 0.07;
+        }
+      }
+      // Lava spurts: 5 glowing bombs arc up out of the crater on staggered
+      // timers, then fall back. Each is a small bright sphere.
+      for (int b = 0; b < 5; b++) {
+        float fb = float(b);
+        float cycle = 2.6 + fb * 0.31;
+        float phase = mod(uTime + fb * 0.7, cycle) / cycle;
+        // Random launch direction, stable per cycle index.
+        float ck = floor((uTime + fb * 0.7) / cycle);
+        float ang = hash(vec2(fb, ck)) * 6.28318;
+        float spread = 0.5 + hash(vec2(fb + 3.1, ck)) * 0.8;
+        float peakH = 2.5 + hash(vec2(fb + 7.7, ck)) * 2.0;
+        // Parabolic trajectory.
+        vec3 dir = vec3(cos(ang) * spread, 0.0, sin(ang) * spread);
+        vec3 pos = apexW + dir * phase
+                 + vec3(0.0, peakH * 4.0 * phase * (1.0 - phase), 0.0);
+        // Ray-sphere test.
+        vec3 oc2 = ro - pos;
+        float rad = 0.18;
+        float bSp = dot(oc2, rd);
+        float cSp = dot(oc2, oc2) - rad * rad;
+        float disc = bSp * bSp - cSp;
+        if (disc > 0.0) {
+          float ts = -bSp - sqrt(disc);
+          if (ts > 0.5 && ts < opaqueT) {
+            // Hot at launch, cools as it arcs.
+            vec3 lavaC = mix(vec3(1.0, 0.95, 0.55),
+                             vec3(0.95, 0.30, 0.05), phase);
+            col = mix(col, lavaC * 1.6, 0.95);
+          }
+        }
+        // Glowing trail behind the bomb.
+        vec3 tp = ro + rd * max(dot(pos - ro, rd), 0.5);
+        float trail = exp(-length(tp - pos) * 4.0)
+                    * smoothstep(0.0, 0.6, phase);
+        col += vec3(1.0, 0.55, 0.20) * trail * 0.4;
+      }
+    }
+
+    // 2D effects anchored above the main 3D volcano's projected apex.
+    vec2 volcCenter = vec2(0.10, -0.20);
     float volcW = 0.8;
     float volcH = 0.55;
 
@@ -197,17 +319,6 @@ export const LavaScene = {
       // Heat haze glow around it.
       float glow = smoothstep(0.30, 0.0, abs(pNear.y - riverY)) * step(pNear.y, -0.30);
       col += vec3(1.0, 0.45, 0.10) * glow * 0.35;
-    }
-
-    // ---- Glowing crater pulse (volcano top) ----
-    {
-      float craterY = volcCenter.y + volcH;
-      float craterDist = length(vec2(pBack.x * 1.2, pBack.y - craterY));
-      float pulse = 0.7 + 0.3 * sin(uTime * 2.0);
-      float craterGlow = smoothstep(0.20, 0.0, craterDist) * pulse;
-      col += vec3(1.0, 0.55, 0.10) * craterGlow * 1.2;
-      float craterCore = smoothstep(0.05, 0.0, craterDist);
-      col += vec3(1.0, 0.95, 0.65) * craterCore * 1.8;
     }
 
     // ---- Always-on rising embers ----
@@ -232,22 +343,9 @@ export const LavaScene = {
     }
 
     // ---- Volcanic ash plume rising from crater (always on) ----
-    {
-      vec2 plumeCenter = vec2(0.0, volcCenter.y + volcH);
-      vec2 dp = pBack - plumeCenter;
-      // Plume fans out as it rises.
-      float widen = max(dp.y, 0.0) * 0.6 + 0.05;
-      float plumeMask = smoothstep(widen, widen * 0.6, abs(dp.x))
-                      * smoothstep(1.5, 0.0, dp.y)
-                      * step(0.0, dp.y);
-      float plumeNoise = warpedFbm(vec2(dp.x * 3.0, dp.y * 2.5 - uTime * 0.4));
-      vec3 plumeCol = mix(vec3(0.10, 0.05, 0.10),
-                          vec3(0.55, 0.30, 0.20), plumeNoise);
-      col = mix(col, plumeCol, plumeMask * (0.4 + plumeNoise * 0.6));
-      // Hot base of plume glows.
-      float baseGlow = smoothstep(0.4, 0.0, dp.y) * step(0.0, dp.y) * plumeMask;
-      col += vec3(1.0, 0.55, 0.20) * baseGlow * 0.6;
-    }
+    // Removed: 2D screen-space plume no longer aligns with the 3D volcano apex.
+    // The 3D cone reads on its own; immersive view has its own properly-anchored
+    // sky-projected plume.
 
     // ---- Eruption every 9s (mega blast) ----
     {

--- a/demos/portals/scenes/LavaScene.js
+++ b/demos/portals/scenes/LavaScene.js
@@ -347,23 +347,8 @@ export const LavaScene = {
     // The 3D cone reads on its own; immersive view has its own properly-anchored
     // sky-projected plume.
 
-    // ---- Eruption every 9s (mega blast) ----
-    {
-      float cycle = 9.0;
-      float k = floor(uTime / cycle);
-      float local = uTime - k * cycle;
-      float blast = smoothstep(0.0, 0.2, local) * smoothstep(2.5, 0.3, local);
-      vec2 cr = vec2(0.0, volcCenter.y + volcH);
-      float dr = length(pBack - cr);
-      // Bright dome expanding out of crater.
-      float dome = smoothstep(0.0, 1.5, local) * 0.5;
-      float front = smoothstep(0.04, 0.0, abs(dr - dome))
-                  * step(0.0, pBack.y - cr.y);
-      col += vec3(1.0, 0.75, 0.30) * front * blast * 2.0;
-      // Bright flash on whole crater.
-      float flash = smoothstep(0.4, 0.0, dr) * blast;
-      col += vec3(1.0, 0.95, 0.55) * flash * 1.2;
-    }
+    // Removed: 2D screen-space mega-blast dome — the 3D bombs already convey
+    // eruption energy and the flat semicircle didn't sit naturally on the cone.
 
     // ---- Volcanic lightning in ash plume every 7s ----
     {

--- a/demos/portals/scenes/UnderwaterScene.js
+++ b/demos/portals/scenes/UnderwaterScene.js
@@ -1,6 +1,6 @@
-// Underwater scene: deep ocean with sunbeams, drifting jellyfish bloom,
-// schools of fish, passing whale shark, glowing bioluminescent burst,
-// rising bubble columns, falling marine snow.
+// Underwater scene: raycast jellyfish bloom, whale shark passing,
+// rising bubble columns, sunbeam shafts, sandy floor — same 3D content
+// as UnderwaterImmersive so the disc preview matches what's inside.
 export const UnderwaterScene = {
   name: 'Underwater',
 
@@ -10,9 +10,8 @@ export const UnderwaterScene = {
   haloOuter: 'vec3(0.30, 1.00, 0.85)',
 
   helpers: /* glsl */ `
-    // Voronoi-style caustic pattern.
-    float caustic(vec2 uv, float t) {
-      vec2 p = uv * 4.0;
+    float caustic2(vec2 uv, float t) {
+      vec2 p = uv * 0.6;
       float v = 0.0;
       for (int i = 0; i < 3; i++) {
         float fi = float(i);
@@ -22,228 +21,157 @@ export const UnderwaterScene = {
       return pow(max(v * 0.33 + 0.5, 0.0), 2.5);
     }
 
-    // A simple "fish" silhouette: streamlined body + tail wedge.
-    float fishShape(vec2 d, float facing) {
-      // d.x = along body (positive forward), d.y = vertical.
-      d.x *= facing;
-      float body = smoothstep(0.018, 0.014, abs(d.y))
-                 * smoothstep(0.030, 0.025, abs(d.x));
-      float tail = smoothstep(0.008, 0.0, d.x + 0.030)
-                 * smoothstep(0.020, 0.0, abs(d.y) - max(d.x + 0.030, 0.0)*1.5);
-      return clamp(body + tail, 0.0, 1.0);
+    // Glowing jellyfish bell + halo, projected on the ray at world pos.
+    vec3 jellyfish3D(vec3 ro, vec3 rd, vec3 pos, float t, float seed) {
+      vec3 oc = pos - ro;
+      float along = dot(oc, rd);
+      if (along < 0.5 || along > 25.0) return vec3(0.0);
+      vec3 proj = ro + rd * along;
+      float d = length(pos - proj);
+      float bellR = 0.5 + 0.1 * sin(t * 1.2 + seed * 7.0);
+      float bell = smoothstep(bellR, 0.0, d) * 0.55;
+      float halo = smoothstep(bellR * 3.0, bellR, d) * 0.18;
+      float fade = 1.0 / (1.0 + along * 0.08);
+      vec3 color = mix(vec3(0.4, 0.85, 1.0), vec3(0.85, 0.55, 1.0),
+                       sin(t + seed) * 0.5 + 0.5);
+      return color * (bell + halo) * fade;
     }
 
-    // Whale shark silhouette (much bigger, slow tail wave).
-    float whaleShape(vec2 d, float wave) {
-      // body: long ellipse
-      float body = smoothstep(0.045, 0.040, abs(d.y))
-                 * smoothstep(0.18, 0.16, abs(d.x));
-      // tail (swept)
-      float tailY = d.y + sin(d.x * 6.0 + wave) * 0.02;
-      float tail = smoothstep(0.020, 0.0, abs(tailY))
-                 * smoothstep(0.06, 0.0, max(d.x - 0.16, 0.0));
-      // dorsal fin nub
-      float fin = smoothstep(0.010, 0.0,
-          length(vec2(d.x + 0.04, max(d.y - 0.03, 0.0))));
-      return clamp(body + tail + fin, 0.0, 1.0);
+    // Whale shark drifting in a slow horizontal arc.
+    vec3 whaleShark3D(vec3 ro, vec3 rd, float t) {
+      float phase = t * 0.04;
+      vec3 pos = vec3(sin(phase) * 18.0,
+                      -3.0 + sin(t * 0.1) * 0.5,
+                      cos(phase) * 18.0 - 4.0);
+      vec3 oc = pos - ro;
+      float along = dot(oc, rd);
+      if (along < 1.0 || along > 40.0) return vec3(0.0);
+      vec3 proj = ro + rd * along;
+      vec3 d = pos - proj;
+      vec3 fwd = vec3(cos(phase), 0.0, -sin(phase));
+      float along2 = dot(d, fwd);
+      vec3 perp = d - fwd * along2;
+      float body = smoothstep(0.6, 0.0,
+                              length(vec2(along2 / 4.0, length(perp))));
+      float tail = smoothstep(0.6, 0.0,
+                              length(vec2((along2 - 4.0) / 1.5,
+                                          length(perp) * 2.0)));
+      float silhouette = max(body, tail * 0.7);
+      float fade = 1.0 / (1.0 + along * 0.05);
+      float spot = hash(floor(perp.xy * 30.0 + along2));
+      vec3 bodyCol = mix(vec3(0.06, 0.10, 0.14),
+                         vec3(0.18, 0.25, 0.30), spot);
+      return bodyCol * silhouette * fade;
+    }
+
+    // Rising bubble columns at fixed (hashed) xz positions.
+    vec3 bubbles3D(vec3 ro, vec3 rd, float t) {
+      vec3 col = vec3(0.0);
+      for (int i = 0; i < 8; i++) {
+        float fi = float(i);
+        float seed = fi * 13.7;
+        vec2 base = vec2(sin(seed) * 8.0 + cos(seed * 1.3) * 4.0,
+                         cos(seed * 0.7) * 8.0 + sin(seed * 1.1) * 4.0);
+        float bh = mod(t * 1.5 + seed * 3.0, 6.0) - 1.0;
+        vec3 pos = vec3(base.x + sin(bh + seed) * 0.15,
+                        -2.5 + bh,
+                        base.y + cos(bh + seed) * 0.15);
+        vec3 oc = pos - ro;
+        float along = dot(oc, rd);
+        if (along < 0.3 || along > 20.0) continue;
+        vec3 proj = ro + rd * along;
+        float d = length(pos - proj);
+        float r = 0.05 + 0.02 * sin(bh * 4.0 + seed);
+        float bubble = smoothstep(r, 0.0, d) * 0.4;
+        float fade = 1.0 / (1.0 + along * 0.15);
+        col += vec3(0.85, 0.95, 1.00) * bubble * fade;
+      }
+      return col;
+    }
+
+    // Volumetric sunbeam shafts when looking up.
+    float sunbeams3D(vec3 ro, vec3 rd, float t) {
+      if (rd.y < 0.05) return 0.0;
+      float density = 0.0;
+      float surfaceY = 8.0;
+      for (int i = 1; i <= 12; i++) {
+        float fi = float(i);
+        float along = fi * 0.7;
+        vec3 sp = ro + rd * along;
+        float depthFactor = clamp(sp.y / surfaceY, 0.0, 1.0);
+        float c = caustic2(sp.xz, t);
+        density += c * depthFactor * 0.05;
+      }
+      density *= pow(max(rd.y, 0.0), 0.6);
+      return density;
     }
   `,
 
   body: /* glsl */ `
-    // Stereo parallax layers.
-    vec2 pFar  = parallaxP(p, rd, 0.35);
-    vec2 pBack = parallaxP(p, rd, 0.22);
-    vec2 pMid  = parallaxP(p, rd, 0.12);
-    vec2 pNear = parallaxP(p, rd, 0.04);
+    vec3 ro = uCamLocal;
+    float t = uTime;
 
-    // Vertical depth gradient: bright surface up top, abyss below.
-    float depth = 0.5 - pFar.y * 0.5;
-    vec3 surface = vec3(0.20, 0.65, 0.85);
-    vec3 mid     = vec3(0.05, 0.30, 0.55);
-    vec3 abyss   = vec3(0.00, 0.05, 0.18);
-    col = mix(surface, mid,  smoothstep(0.0, 0.6, depth));
-    col = mix(col,     abyss, smoothstep(0.55, 1.0, depth));
+    // Vertical depth gradient (above eye = brighter, below = abyss).
+    vec3 surfaceCol = vec3(0.20, 0.65, 0.85);
+    vec3 midCol     = vec3(0.05, 0.30, 0.55);
+    vec3 abyssCol   = vec3(0.005, 0.020, 0.075);
+    float depthT = clamp(rd.y * 0.5 + 0.5, 0.0, 1.0);
+    col = mix(abyssCol, midCol, smoothstep(0.25, 0.55, depthT));
+    col = mix(col, surfaceCol, smoothstep(0.55, 0.95, depthT));
 
-    // Slow swaying water — sample-domain warp.
-    vec2 warp = vec2(sin(uTime * 0.4 + pFar.y * 3.0) * 0.02,
-                     cos(uTime * 0.3 + pFar.x * 2.0) * 0.02);
-    vec2 wp = pFar + warp;
-
-    // God-ray sunbeams streaming down from upper-left.
-    {
-      vec2 r = wp;
-      // Project rays from angle slightly off vertical.
-      float ang = -0.35;
-      float u = r.x * cos(ang) - r.y * sin(ang);
-      float v = r.x * sin(ang) + r.y * cos(ang);
-      float ray = 0.0;
-      for (int i = 0; i < 4; i++) {
-        float fi = float(i);
-        float w = 0.18 + fi * 0.07;
-        float off = sin(uTime * 0.3 + fi * 1.7) * 0.2 + fi * 0.35 - 0.5;
-        float band = exp(-pow((u - off) / w, 2.0));
-        ray += band * (0.4 + 0.6 * sin(uTime * 0.6 + fi));
-      }
-      // Falloff with depth & jitter.
-      ray *= smoothstep(1.0, -0.4, pFar.y);
-      ray *= 0.7 + 0.3 * fbm(vec2(u * 6.0, v * 3.0 + uTime * 0.4));
-      col += vec3(0.60, 0.90, 1.00) * ray * 0.55;
-    }
-
-    // Caustic shimmer near the surface.
-    float caus = caustic(wp + vec2(0.0, uTime * 0.05), uTime);
-    caus *= smoothstep(0.6, -0.6, pFar.y);
-    col += vec3(0.50, 0.95, 1.00) * caus * 0.35;
-
-    // Marine snow / drifting particles (always-on).
-    {
-      vec2 uvNear = pNear * 0.5 + 0.5;
-      float s = starsLayer(uvNear * 3.0 + vec2(0.0, uTime * 0.05), 60.0, 0.985);
-      col += vec3(0.85, 0.95, 1.0) * s * 0.7;
-      float s2 = starsLayer(uvNear * 3.0 + vec2(7.0, uTime * 0.10), 110.0, 0.992);
-      col += vec3(0.7, 0.85, 1.0) * s2 * 0.5;
-    }
-
-    // ---- Always-on fish school weaving across mid-depth ----
-    {
-      float t = uTime * 0.5;
-      for (int i = 0; i < 14; i++) {
-        float fi = float(i);
-        float row = floor(fi / 7.0);
-        float col_i = mod(fi, 7.0);
-        float baseY = -0.15 + row * 0.10
-                    + sin(t * 0.6 + col_i * 0.5) * 0.04;
-        float baseX = mod(col_i * 0.18 + t * 0.18 + row * 0.4, 2.4) - 1.4;
-        vec2 d = pMid - vec2(baseX, baseY);
-        float wig = sin(t * 4.0 + col_i + row * 1.7) * 0.005;
-        d.y += wig;
-        float f = fishShape(d, 1.0);
-        vec3 fc = mix(vec3(0.95, 0.75, 0.30),
-                      vec3(1.00, 0.95, 0.75), 0.5 + 0.5 * sin(fi));
-        col = mix(col, fc * 1.4, f * 0.85);
+    // Surface caustics + sun disc when looking up.
+    if (rd.y > 0.3) {
+      float surfaceY = 8.0;
+      float kt = (surfaceY - ro.y) / rd.y;
+      if (kt > 0.0) {
+        vec3 sp = ro + rd * kt;
+        float c = caustic2(sp.xz, t);
+        col = mix(col, vec3(0.95, 1.00, 0.75),
+                  c * smoothstep(0.3, 0.95, rd.y) * 0.55);
+        vec3 sunDir = normalize(vec3(0.2, 1.0, -0.3));
+        float sa = max(dot(rd, sunDir), 0.0);
+        col += vec3(1.00, 0.95, 0.75)
+             * smoothstep(0.965, 0.995, sa) * 0.9;
+        col += vec3(1.00, 0.95, 0.75)
+             * smoothstep(0.85, 1.0, sa) * 0.25;
       }
     }
 
-    // ---- Bubble column rising every 4s from random spot ----
-    {
-      float cycle = 4.0;
-      float k = floor(uTime / cycle);
-      float local = uTime - k * cycle;
-      float baseX = hash(vec2(k, 3.1)) * 1.6 - 0.8;
-      for (int i = 0; i < 6; i++) {
-        float fi = float(i);
-        float dly = fi * 0.4;
-        float life = local - dly;
-        if (life > 0.0 && life < cycle - dly) {
-          float by = -1.0 + life * 0.45;
-          float bx = baseX + sin(life * 3.0 + fi) * 0.04;
-          float br = 0.012 + fi * 0.003;
-          float d = length(pNear - vec2(bx, by));
-          float bub = smoothstep(br, br * 0.5, d);
-          // Highlight rim
-          float rim = smoothstep(br, br * 0.85, d) - smoothstep(br * 0.85, br * 0.7, d);
-          col = mix(col, vec3(0.85, 0.98, 1.05), bub * 0.6);
-          col += vec3(1.0, 1.0, 1.0) * max(rim, 0.0) * 0.6;
-        }
+    // Volumetric sunbeams.
+    col += vec3(0.80, 0.95, 1.00) * sunbeams3D(ro, rd, t) * 1.4;
+
+    // Sandy ocean floor.
+    if (rd.y < -0.1) {
+      float gt = -ro.y - 6.0;
+      float t2 = gt / rd.y;
+      if (t2 > 0.0 && t2 < 80.0) {
+        vec3 gp = ro + rd * t2;
+        float gn = fbm(gp.xz * 0.15);
+        vec3 ground = mix(vec3(0.05, 0.10, 0.12),
+                          vec3(0.10, 0.18, 0.20), gn);
+        float fog = smoothstep(0.0, 35.0, t2);
+        col = mix(ground, col, fog);
       }
     }
 
-    // ---- Jellyfish bloom drifting through every 14s ----
-    {
-      float cycle = 14.0;
-      float k = floor(uTime / cycle);
-      float local = uTime - k * cycle;
-      float life = smoothstep(0.0, 1.0, local) * smoothstep(cycle, cycle - 2.0, local);
-      for (int i = 0; i < 5; i++) {
-        float fi = float(i);
-        float baseX = -1.5 + local * 0.18 + fi * 0.35
-                    + sin(uTime * 0.6 + fi) * 0.05;
-        float baseY = -0.2 + sin(uTime * 0.4 + fi * 1.3) * 0.3 + fi * 0.06;
-        vec2 c = vec2(baseX, baseY);
-        vec2 d = pMid - c;
-        // Bell (top hemisphere)
-        float bellR = 0.06 + fi * 0.005;
-        float bell = smoothstep(bellR, bellR * 0.85, length(d))
-                   * step(d.y, 0.0);
-        // Tendrils trailing below
-        float tendril = 0.0;
-        for (int j = 0; j < 5; j++) {
-          float fj = float(j);
-          float tx = (fj - 2.0) * 0.012
-                   + sin(uTime * 1.2 + fj + fi) * 0.01;
-          float td = abs(d.x - tx);
-          float ty = max(-d.y, 0.0);
-          tendril += smoothstep(0.005, 0.0, td)
-                   * smoothstep(0.20, 0.0, ty);
-        }
-        // Bioluminescent pulse on the bell rim.
-        float pulse = 0.5 + 0.5 * sin(uTime * 2.5 + fi * 1.7);
-        vec3 jellyCol = mix(vec3(0.55, 0.30, 0.95),
-                            vec3(0.30, 0.95, 0.85), pulse);
-        col += jellyCol * (bell * 1.3 + tendril * 0.6) * life;
-      }
+    // Drifting jellyfish bloom.
+    for (int i = 0; i < 5; i++) {
+      float fi = float(i);
+      float seed = fi * 11.3;
+      vec3 jp = vec3(
+        sin(t * 0.2 + seed) * 5.0 + cos(seed * 1.7) * 3.0,
+        0.5 + sin(t * 0.3 + seed * 0.7) * 2.0,
+        cos(t * 0.25 + seed) * 5.0 + sin(seed * 0.9) * 3.0);
+      col += jellyfish3D(ro, rd, jp, t, seed);
     }
 
-    // ---- Whale shark passing through every 19s ----
-    {
-      float cycle = 19.0;
-      float k = floor(uTime / cycle);
-      float local = uTime - k * cycle;
-      float life = smoothstep(0.0, 1.5, local) * smoothstep(cycle, cycle - 2.0, local);
-      // Slow horizontal drift.
-      float baseY = (hash(vec2(k, 41.7)) - 0.5) * 0.4;
-      vec2 c = vec2(-1.8 + local * 0.18, baseY);
-      vec2 d = pBack - c;
-      float wave = uTime * 1.5 + k;
-      float w = whaleShape(d, wave);
-      // Body color: deep blue-gray with white spots.
-      vec3 body = vec3(0.20, 0.30, 0.40);
-      float spots = step(0.7, hash(floor((pBack - c) * vec2(40.0, 60.0))));
-      body = mix(body, vec3(0.80, 0.90, 1.0), spots * 0.6);
-      // Belly highlight (lower side lighter).
-      body = mix(body, vec3(0.50, 0.65, 0.75),
-                 smoothstep(-0.02, 0.04, d.y));
-      col = mix(col, body, w * life * 0.95);
-    }
+    // Whale shark passing.
+    col += whaleShark3D(ro, rd, t);
 
-    // ---- Bioluminescent burst every 11s ----
-    {
-      float cycle = 11.0;
-      float k = floor(uTime / cycle);
-      float local = uTime - k * cycle;
-      vec2 bp = vec2(hash(vec2(k, 51.3)) * 1.4 - 0.7,
-                     hash(vec2(k, 67.7)) * 1.4 - 0.7);
-      float dr = length(pMid - bp);
-      float flash = smoothstep(0.0, 0.1, local) * smoothstep(2.5, 0.2, local);
-      float core = smoothstep(0.04, 0.0, dr) * 3.5;
-      float halo = smoothstep(0.4, 0.0, dr) * 1.0;
-      // Sparks radiating outward
-      float ang = atan(pMid.y - bp.y, pMid.x - bp.x);
-      float spark = pow(0.5 + 0.5 * cos(ang * 18.0 + local * 8.0), 6.0)
-                  * smoothstep(0.30, 0.04, dr);
-      vec3 bioCol = mix(vec3(0.30, 1.00, 0.85),
-                        vec3(0.55, 0.45, 1.20),
-                        sin(uTime * 0.7) * 0.5 + 0.5);
-      col += bioCol * (core + halo + spark * 1.2) * flash;
-    }
+    // Rising bubble columns.
+    col += bubbles3D(ro, rd, t);
 
-    // ---- Lightning flash through water every 26s ----
-    {
-      float cycle = 26.0;
-      float k = floor(uTime / cycle);
-      float local = uTime - k * cycle;
-      float flash = smoothstep(0.0, 0.05, local) * smoothstep(0.8, 0.1, local);
-      // Quick double-flash
-      flash *= 0.5 + 0.5 * sin(local * 50.0);
-      // Whole upper region brightens through caustics.
-      float upper = smoothstep(1.0, -0.2, pFar.y);
-      col += vec3(0.70, 0.85, 1.00) * flash * upper * 0.9;
-      // Bright fork from upper edge.
-      float fx = hash(vec2(k, 91.7)) * 1.6 - 0.8;
-      float fork = smoothstep(0.012, 0.0,
-          abs(pFar.x - (fx + sin(pFar.y * 14.0 + k) * 0.04)))
-        * smoothstep(-0.8, 1.0, pFar.y);
-      col += vec3(0.95, 0.95, 1.10) * fork * flash * 2.5;
-    }
+    // Mild blue haze.
+    col = mix(col, midCol, 0.14);
   `,
 };

--- a/demos/portals/scenes/UnderwaterScene.js
+++ b/demos/portals/scenes/UnderwaterScene.js
@@ -21,20 +21,45 @@ export const UnderwaterScene = {
       return pow(max(v * 0.33 + 0.5, 0.0), 2.5);
     }
 
-    // Glowing jellyfish bell + halo, projected on the ray at world pos.
+    // Glowing jellyfish: dome bell + trailing tendrils below.
     vec3 jellyfish3D(vec3 ro, vec3 rd, vec3 pos, float t, float seed) {
       vec3 oc = pos - ro;
       float along = dot(oc, rd);
       if (along < 0.5 || along > 25.0) return vec3(0.0);
-      vec3 proj = ro + rd * along;
-      float d = length(pos - proj);
-      float bellR = 0.5 + 0.1 * sin(t * 1.2 + seed * 7.0);
-      float bell = smoothstep(bellR, 0.0, d) * 0.55;
-      float halo = smoothstep(bellR * 3.0, bellR, d) * 0.18;
       float fade = 1.0 / (1.0 + along * 0.08);
+      float pulse = 0.5 + 0.5 * sin(t * 1.2 + seed * 7.0);
       vec3 color = mix(vec3(0.4, 0.85, 1.0), vec3(0.85, 0.55, 1.0),
                        sin(t + seed) * 0.5 + 0.5);
-      return color * (bell + halo) * fade;
+      float bellR = 0.28 + 0.04 * pulse;
+      float th = raySphere(ro, rd, pos, bellR);
+      float bellHit = 0.0;
+      if (th > 0.0) {
+        vec3 hp = ro + rd * th;
+        vec3 n = normalize(hp - pos);
+        if (n.y > -0.05) {
+          float rim = pow(1.0 - max(-dot(rd, n), 0.0), 2.5);
+          float fill = smoothstep(-0.1, 1.0, n.y) * 0.6;
+          bellHit = (fill + rim * 0.9) * (0.7 + pulse * 0.4);
+        }
+      }
+      float tendril = 0.0;
+      vec3 proj = ro + rd * along;
+      vec3 d = proj - pos;
+      float horizD = length(d.xz);
+      if (horizD < bellR * 1.4 && d.y < 0.0 && d.y > -1.0) {
+        for (int k = 0; k < 6; k++) {
+          float fk = float(k);
+          float ang = fk / 6.0 * 6.28318;
+          vec2 base = vec2(cos(ang), sin(ang)) * bellR * 0.6;
+          base += vec2(sin(t * 1.5 + fk + seed) * 0.02,
+                       cos(t * 1.3 + fk * 1.7) * 0.02);
+          float dx = length(d.xz - base);
+          tendril += smoothstep(0.025, 0.0, dx)
+                   * smoothstep(0.0, -0.8, d.y);
+        }
+      }
+      float halo = smoothstep(bellR * 3.0, bellR, length(d)) * 0.18;
+      return color * (bellHit + tendril * 0.5 + halo) * fade;
     }
 
     // Whale shark drifting in a slow horizontal arc.
@@ -85,6 +110,354 @@ export const UnderwaterScene = {
         float bubble = smoothstep(r, 0.0, d) * 0.4;
         float fade = 1.0 / (1.0 + along * 0.15);
         col += vec3(0.85, 0.95, 1.00) * bubble * fade;
+      }
+      return col;
+    }
+
+    // Schools of clownfish: ray-ellipsoid body with shading, bands, eye, fin.
+    float rayEllip3(vec3 ro, vec3 rd, vec3 axes) {
+      vec3 roS = ro / axes;
+      vec3 rdS = rd / axes;
+      float A = dot(rdS, rdS);
+      float B = dot(roS, rdS);
+      float C = dot(roS, roS) - 1.0;
+      float d = B * B - A * C;
+      if (d < 0.0) return -1.0;
+      return (-B - sqrt(d)) / A;
+    }
+
+    vec3 clownfishSchool3D(vec3 ro, vec3 rd, float t) {
+      vec3 col = vec3(0.0);
+      vec3 sunDir = normalize(vec3(0.2, 1.0, -0.3));
+      vec3 bodyAxes = vec3(0.28, 0.16, 0.105);
+      vec3 tailAxes = vec3(0.10, 0.07, 0.028);
+      vec3 dorsalAxes = vec3(0.13, 0.11, 0.013);
+      vec3 pectAxes = vec3(0.08, 0.018, 0.06);
+      for (int s = 0; s < 2; s++) {
+        float fs = float(s);
+        vec3 schoolC = vec3(
+            sin(t * 0.04 + fs * 2.1) * 2.5 + cos(fs * 3.7) * 1.5,
+            -0.3 + sin(t * 0.05 + fs) * 0.4,
+            cos(t * 0.045 + fs * 1.7) * 2.5 + sin(fs * 2.3) * 1.2);
+        vec3 fwd = normalize(vec3(
+            cos(t * 0.04 + fs * 2.1) * 2.5,
+            0.0,
+            -sin(t * 0.045 + fs * 1.7) * 2.5) + vec3(0.001));
+        vec3 sideAx = normalize(cross(fwd, vec3(0.0, 1.0, 0.0)));
+        for (int i = 0; i < 3; i++) {
+          float fi = float(i);
+          float seed = fs * 7.0 + fi * 1.3;
+          vec3 off = vec3(
+              cos(seed) * 0.9 + sin(seed * 3.7) * 0.3,
+              sin(seed * 1.7) * 0.20,
+              sin(seed) * 0.9 + cos(seed * 2.1) * 0.3);
+          vec3 pos = schoolC + off;
+          float wig = sin(t * 3.5 + seed * 4.0) * 0.05;
+          vec3 fwdW = normalize(fwd + sideAx * wig);
+          vec3 sideW = normalize(cross(fwdW, vec3(0.0, 1.0, 0.0)));
+          vec3 upW = normalize(cross(sideW, fwdW));
+          vec3 oc = ro - pos;
+          vec3 roL = vec3(dot(oc, fwdW), dot(oc, upW), dot(oc, sideW));
+          vec3 rdL = vec3(dot(rd, fwdW), dot(rd, upW), dot(rd, sideW));
+
+          vec3 bodyOff = vec3(0.05, 0.0, 0.0);
+          float tBody = rayEllip3(roL - bodyOff, rdL, bodyAxes);
+          vec3 tailOff = vec3(-0.18, 0.0, 0.0);
+          float tTail = rayEllip3(roL - tailOff, rdL, tailAxes);
+          vec3 dorsalOff = vec3(0.02, 0.20, 0.0);
+          float tDor = rayEllip3(roL - dorsalOff, rdL, dorsalAxes);
+          vec3 pectOffL = vec3(0.06, -0.05, 0.10);
+          vec3 pectOffR = vec3(0.06, -0.05, -0.10);
+          float tPL = rayEllip3(roL - pectOffL, rdL, pectAxes);
+          float tPR = rayEllip3(roL - pectOffR, rdL, pectAxes);
+
+          float tH = -1.0;
+          int which = 0;
+          if (tBody > 0.3 && tBody < 18.0) { tH = tBody; which = 1; }
+          if (tTail > 0.3 && tTail < 18.0 &&
+              (tH < 0.0 || tTail < tH)) { tH = tTail; which = 2; }
+          if (tDor > 0.3 && tDor < 18.0 &&
+              (tH < 0.0 || tDor < tH)) { tH = tDor; which = 3; }
+          if (tPL > 0.3 && tPL < 18.0 &&
+              (tH < 0.0 || tPL < tH)) { tH = tPL; which = 4; }
+          if (tPR > 0.3 && tPR < 18.0 &&
+              (tH < 0.0 || tPR < tH)) { tH = tPR; which = 5; }
+
+          if (which > 0) {
+            vec3 hpL = roL + rdL * tH;
+            vec3 nL;
+            if (which == 1) {
+              nL = normalize((hpL - bodyOff) / (bodyAxes * bodyAxes));
+            } else if (which == 2) {
+              nL = normalize((hpL - tailOff) / (tailAxes * tailAxes));
+            } else if (which == 3) {
+              nL = normalize((hpL - dorsalOff) / (dorsalAxes * dorsalAxes));
+            } else if (which == 4) {
+              nL = normalize((hpL - pectOffL) / (pectAxes * pectAxes));
+            } else {
+              nL = normalize((hpL - pectOffR) / (pectAxes * pectAxes));
+            }
+            vec3 nW = sideW * nL.z + upW * nL.y + fwdW * nL.x;
+            float u = hpL.x / 0.30;
+            float v = hpL.y / 0.16;
+            vec3 base = vec3(1.00, 0.45, 0.05);
+            if (which == 1) {
+              float bandD = min(min(abs(u - 0.55), abs(u - 0.05)),
+                                abs(u + 0.4));
+              float white = smoothstep(0.16, 0.10, bandD);
+              float black = smoothstep(0.22, 0.16, bandD)
+                          - smoothstep(0.16, 0.10, bandD);
+              base = mix(base, vec3(0.04, 0.04, 0.04), black);
+              base = mix(base, vec3(1.00, 1.00, 1.00), white);
+              float eyeD = length(vec2(u - 0.72, v - 0.20));
+              base = mix(base, vec3(0.02, 0.02, 0.02),
+                         smoothstep(0.08, 0.05, eyeD));
+              base = mix(base, vec3(1.0, 1.0, 1.0),
+                         smoothstep(0.035, 0.018, eyeD));
+              float mouthD = abs(u - 0.95) + abs(v + 0.05) * 0.5;
+              base = mix(base, vec3(0.05, 0.02, 0.0),
+                         smoothstep(0.10, 0.05, mouthD));
+              base = mix(base, base * 1.5,
+                         smoothstep(0.0, -0.7, v));
+            } else if (which == 3 || which == 4 || which == 5) {
+              float edge;
+              if (which == 3) edge = abs(hpL.y - dorsalOff.y) / dorsalAxes.y;
+              else edge = abs(hpL.x - bodyOff.x) / 0.10;
+              base = mix(base, vec3(0.04, 0.04, 0.04),
+                         smoothstep(0.78, 0.95, edge));
+            }
+            float lamb = max(dot(nW, sunDir), 0.0);
+            float rim = pow(1.0 - max(dot(nW, -rd), 0.0), 2.5);
+            vec3 fishCol = base * (0.35 + lamb * 0.85)
+                         + vec3(0.4, 0.6, 0.8) * rim * 0.25;
+            col += fishCol * 1.6 / (1.0 + tH * 0.1);
+          }
+
+          // Forked caudal fin.
+          float denom = dot(rd, sideW);
+          if (abs(denom) > 1e-4) {
+            for (int k = 0; k < 2; k++) {
+              float kk = float(k);
+              float yC = (kk == 0.0) ? 0.06 : -0.06;
+              vec3 finC = pos + fwdW * (-0.32) + upW * yC;
+              float tFin = dot(finC - ro, sideW) / denom;
+              if (tFin > 0.3 && tFin < 18.0 &&
+                  (tH < 0.0 || tFin < tH)) {
+                vec3 fp = ro + rd * tFin - finC;
+                float fu = dot(fp, fwdW);
+                float fv = dot(fp, upW);
+                float yLo = (kk == 0.0) ? 0.0 : -0.10 - fu * 0.5;
+                float yHi = (kk == 0.0) ? 0.10 + fu * 0.5 + 0.06 : 0.0;
+                float finMask = step(fu, 0.0) * step(-0.16, fu)
+                              * step(yLo, fv) * step(fv, yHi);
+                if (finMask > 0.0) {
+                  vec3 finBase = vec3(1.00, 0.45, 0.05);
+                  float trail = step(fu, -0.13);
+                  finBase = mix(finBase, vec3(0.04, 0.04, 0.04), trail);
+                  col += finBase * 1.4 / (1.0 + tFin * 0.1);
+                }
+              }
+            }
+          }
+        }
+      }
+      return col;
+    }
+
+    // Coral reef: 5 colorful clusters with trunk + tilted branches + bumpy surface.
+    vec3 coralReef3D(vec3 ro, vec3 rd) {
+      vec3 sunDir = normalize(vec3(0.2, 1.0, -0.3));
+      float bestT = 100.0;
+      vec3 bestCol = vec3(0.0);
+      vec3 bestN = vec3(0.0);
+      vec3 bestHp = vec3(0.0);
+      for (int c = 0; c < 5; c++) {
+        float fc = float(c);
+        vec3 base = vec3(
+            cos(fc * 1.7 + 0.5) * 5.5,
+            -6.0,
+            sin(fc * 1.7 + 0.5) * 5.5);
+        vec3 palette;
+        if (c == 0) palette = vec3(1.00, 0.30, 0.55);
+        else if (c == 1) palette = vec3(1.00, 0.55, 0.10);
+        else if (c == 2) palette = vec3(0.60, 0.25, 0.90);
+        else if (c == 3) palette = vec3(1.00, 0.85, 0.20);
+        else palette = vec3(0.20, 0.85, 0.70);
+        vec3 trunkAx = vec3(0.10, 0.55, 0.10);
+        vec3 trunkCtr = base + vec3(0.0, 0.55, 0.0);
+        float tT = rayEllip3(ro - trunkCtr, rd, trunkAx);
+        if (tT > 0.3 && tT < bestT) {
+          bestT = tT;
+          bestHp = ro + rd * tT - trunkCtr;
+          bestN = normalize(bestHp / (trunkAx * trunkAx));
+          bestCol = palette;
+        }
+        for (int b = 0; b < 6; b++) {
+          float fb = float(b);
+          float ang = fb * 1.04 + fc * 0.7;
+          float tilt = 0.7 + sin(fb + fc) * 0.2;
+          vec3 dir = normalize(vec3(cos(ang), tilt, sin(ang)));
+          vec3 side = normalize(
+              cross(dir, vec3(0.0, 1.0, 0.0)) + vec3(0.001));
+          vec3 up = normalize(cross(side, dir));
+          vec3 ctr = base + vec3(0.0, 0.55, 0.0) + dir * 0.35;
+          vec3 oc = ro - ctr;
+          vec3 roL = vec3(dot(oc, dir), dot(oc, up), dot(oc, side));
+          vec3 rdL = vec3(dot(rd, dir), dot(rd, up), dot(rd, side));
+          vec3 ax = vec3(0.32, 0.07, 0.07);
+          float tB = rayEllip3(roL, rdL, ax);
+          if (tB > 0.3 && tB < bestT) {
+            bestT = tB;
+            vec3 hpL = roL + rdL * tB;
+            vec3 nL = normalize(hpL / (ax * ax));
+            bestN = side * nL.z + up * nL.y + dir * nL.x;
+            bestHp = ro + rd * tB - ctr;
+            bestCol = palette;
+          }
+        }
+      }
+      if (bestT >= 100.0) return vec3(0.0);
+      float bumpy = fbm(bestHp.xz * 8.0 + bestHp.y * 3.0);
+      vec3 baseC = bestCol * mix(0.75, 1.10, bumpy);
+      float lamb = max(dot(bestN, sunDir), 0.0);
+      float rim = pow(1.0 - max(dot(bestN, -rd), 0.0), 2.5);
+      vec3 col = baseC * (0.35 + lamb * 0.85)
+               + vec3(0.5, 0.7, 0.9) * rim * 0.25;
+      return col / (1.0 + bestT * 0.06);
+    }
+
+    // Blue tang school: Dory-style. Tall blue body, yellow tail, palette mark.
+    vec3 blueTangSchool3D(vec3 ro, vec3 rd, float t) {
+      vec3 col = vec3(0.0);
+      vec3 sunDir = normalize(vec3(0.2, 1.0, -0.3));
+      vec3 bodyAxes = vec3(0.26, 0.22, 0.085);
+      vec3 tailAxes = vec3(0.10, 0.09, 0.025);
+      vec3 dorsalAxes = vec3(0.13, 0.13, 0.012);
+      vec3 pectAxes = vec3(0.07, 0.018, 0.05);
+      vec3 schoolC = vec3(
+          sin(t * 0.06) * 3.0 + 1.5,
+          0.5 + sin(t * 0.07) * 0.3,
+          cos(t * 0.07) * 3.0 - 1.5);
+      vec3 fwd = normalize(vec3(
+          cos(t * 0.06) * 3.0, 0.0,
+          -sin(t * 0.07) * 3.0) + vec3(0.001));
+      vec3 sideAx = normalize(cross(fwd, vec3(0.0, 1.0, 0.0)));
+      for (int i = 0; i < 4; i++) {
+        float seed = float(i) * 1.7 + 3.3;
+        vec3 off = vec3(
+            cos(seed) * 0.7 + sin(seed * 2.1) * 0.25,
+            sin(seed * 1.7) * 0.20,
+            sin(seed) * 0.7);
+        vec3 pos = schoolC + off;
+        float wig = sin(t * 3.5 + seed * 4.0) * 0.05;
+        vec3 fwdW = normalize(fwd + sideAx * wig);
+        vec3 sideW = normalize(cross(fwdW, vec3(0.0, 1.0, 0.0)));
+        vec3 upW = normalize(cross(sideW, fwdW));
+        vec3 oc = ro - pos;
+        vec3 roL = vec3(dot(oc, fwdW), dot(oc, upW), dot(oc, sideW));
+        vec3 rdL = vec3(dot(rd, fwdW), dot(rd, upW), dot(rd, sideW));
+
+        vec3 bodyOff = vec3(0.04, 0.0, 0.0);
+        float tBody = rayEllip3(roL - bodyOff, rdL, bodyAxes);
+        vec3 tailOff = vec3(-0.18, 0.0, 0.0);
+        float tTail = rayEllip3(roL - tailOff, rdL, tailAxes);
+        vec3 dorsalOff = vec3(0.02, 0.24, 0.0);
+        float tDor = rayEllip3(roL - dorsalOff, rdL, dorsalAxes);
+        vec3 pectOffL = vec3(0.06, -0.04, 0.10);
+        vec3 pectOffR = vec3(0.06, -0.04, -0.10);
+        float tPL = rayEllip3(roL - pectOffL, rdL, pectAxes);
+        float tPR = rayEllip3(roL - pectOffR, rdL, pectAxes);
+
+        float tH = -1.0;
+        int which = 0;
+        if (tBody > 0.3 && tBody < 18.0) { tH = tBody; which = 1; }
+        if (tTail > 0.3 && tTail < 18.0 &&
+            (tH < 0.0 || tTail < tH)) { tH = tTail; which = 2; }
+        if (tDor > 0.3 && tDor < 18.0 &&
+            (tH < 0.0 || tDor < tH)) { tH = tDor; which = 3; }
+        if (tPL > 0.3 && tPL < 18.0 &&
+            (tH < 0.0 || tPL < tH)) { tH = tPL; which = 4; }
+        if (tPR > 0.3 && tPR < 18.0 &&
+            (tH < 0.0 || tPR < tH)) { tH = tPR; which = 5; }
+
+        if (which > 0) {
+          vec3 hpL = roL + rdL * tH;
+          vec3 nL;
+          if (which == 1) {
+            nL = normalize((hpL - bodyOff) / (bodyAxes * bodyAxes));
+          } else if (which == 2) {
+            nL = normalize((hpL - tailOff) / (tailAxes * tailAxes));
+          } else if (which == 3) {
+            nL = normalize((hpL - dorsalOff) / (dorsalAxes * dorsalAxes));
+          } else if (which == 4) {
+            nL = normalize((hpL - pectOffL) / (pectAxes * pectAxes));
+          } else {
+            nL = normalize((hpL - pectOffR) / (pectAxes * pectAxes));
+          }
+          vec3 nW = sideW * nL.z + upW * nL.y + fwdW * nL.x;
+          float u = hpL.x / 0.30;
+          float v = hpL.y / 0.22;
+          vec3 base = vec3(0.10, 0.40, 0.95);
+          if (which == 1) {
+            float bd = length(vec2((u + 0.05) * 1.2, (v - 0.20) * 0.9));
+            base = mix(base, vec3(0.03, 0.03, 0.10),
+                       smoothstep(0.55, 0.30, bd));
+            base = mix(base, vec3(1.0, 0.85, 0.10),
+                       smoothstep(-0.30, -0.65, u));
+            float eyeD = length(vec2(u - 0.65, v - 0.10));
+            base = mix(base, vec3(0.02, 0.02, 0.05),
+                       smoothstep(0.08, 0.05, eyeD));
+            base = mix(base, vec3(1.0, 1.0, 1.0),
+                       smoothstep(0.035, 0.018, eyeD));
+            float mouthD = abs(u - 0.95) + abs(v + 0.05) * 0.5;
+            base = mix(base, vec3(0.05, 0.02, 0.0),
+                       smoothstep(0.10, 0.05, mouthD));
+          } else if (which == 2) {
+            base = vec3(1.0, 0.85, 0.10);
+          } else if (which == 3) {
+            float topness = (hpL.y - dorsalOff.y) / dorsalAxes.y;
+            base = mix(vec3(0.10, 0.40, 0.95),
+                       vec3(1.0, 0.85, 0.10),
+                       smoothstep(0.4, 0.95, topness));
+          } else {
+            float edge = abs(hpL.x - bodyOff.x) / 0.10;
+            base = mix(vec3(0.10, 0.40, 0.95),
+                       vec3(0.04, 0.04, 0.10),
+                       smoothstep(0.78, 0.95, edge));
+          }
+          float lamb = max(dot(nW, sunDir), 0.0);
+          float rim = pow(1.0 - max(dot(nW, -rd), 0.0), 2.5);
+          vec3 fishCol = base * (0.35 + lamb * 0.85)
+                       + vec3(0.4, 0.6, 0.9) * rim * 0.25;
+          col += fishCol * 1.6 / (1.0 + tH * 0.1);
+        }
+
+        // Forked yellow caudal fin.
+        float denom = dot(rd, sideW);
+        if (abs(denom) > 1e-4) {
+          for (int k = 0; k < 2; k++) {
+            float kk = float(k);
+            float yC = (kk == 0.0) ? 0.06 : -0.06;
+            vec3 finC = pos + fwdW * (-0.32) + upW * yC;
+            float tFin = dot(finC - ro, sideW) / denom;
+            if (tFin > 0.3 && tFin < 18.0 &&
+                (tH < 0.0 || tFin < tH)) {
+              vec3 fp = ro + rd * tFin - finC;
+              float fu = dot(fp, fwdW);
+              float fv = dot(fp, upW);
+              float yLo = (kk == 0.0) ? 0.0 : -0.10 - fu * 0.5;
+              float yHi = (kk == 0.0) ? 0.10 + fu * 0.5 + 0.06 : 0.0;
+              float finMask = step(fu, 0.0) * step(-0.16, fu)
+                            * step(yLo, fv) * step(fv, yHi);
+              if (finMask > 0.0) {
+                vec3 finBase = vec3(1.0, 0.85, 0.10);
+                float trail = step(fu, -0.13);
+                finBase = mix(finBase, vec3(0.04, 0.04, 0.10), trail);
+                col += finBase * 1.4 / (1.0 + tFin * 0.1);
+              }
+            }
+          }
+        }
       }
       return col;
     }
@@ -170,6 +543,15 @@ export const UnderwaterScene = {
 
     // Rising bubble columns.
     col += bubbles3D(ro, rd, t);
+
+    // Coral reef on the floor.
+    col += coralReef3D(ro, rd);
+
+    // Clownfish schools.
+    col += clownfishSchool3D(ro, rd, t);
+
+    // Blue tang school.
+    col += blueTangSchool3D(ro, rd, t);
 
     // Mild blue haze.
     col = mix(col, midCol, 0.14);

--- a/demos/portals/scenes/UnderwaterScene.js
+++ b/demos/portals/scenes/UnderwaterScene.js
@@ -498,6 +498,9 @@ export const UnderwaterScene = {
       float kt = (surfaceY - ro.y) / rd.y;
       if (kt > 0.0) {
         vec3 sp = ro + rd * kt;
+        // Gentle refractive wobble on the surface plane.
+        sp.xz += vec2(sin(t * 0.3 + sp.x * 0.5) * 0.4,
+                      cos(t * 0.25 + sp.z * 0.5) * 0.4);
         float c = caustic2(sp.xz, t);
         col = mix(col, vec3(0.95, 1.00, 0.75),
                   c * smoothstep(0.3, 0.95, rd.y) * 0.55);
@@ -520,8 +523,8 @@ export const UnderwaterScene = {
       if (t2 > 0.0 && t2 < 80.0) {
         vec3 gp = ro + rd * t2;
         float gn = fbm(gp.xz * 0.15);
-        vec3 ground = mix(vec3(0.05, 0.10, 0.12),
-                          vec3(0.10, 0.18, 0.20), gn);
+        vec3 ground = mix(vec3(0.18, 0.14, 0.08),
+                          vec3(0.30, 0.25, 0.15), gn);
         float fog = smoothstep(0.0, 35.0, t2);
         col = mix(ground, col, fog);
       }
@@ -553,7 +556,9 @@ export const UnderwaterScene = {
     // Blue tang school.
     col += blueTangSchool3D(ro, rd, t);
 
-    // Mild blue haze.
-    col = mix(col, midCol, 0.14);
+    // Depth-distance haze — horizontal rays fade toward deep teal.
+    vec3 deepFog = vec3(0.02, 0.12, 0.22);
+    float viewDist = clamp(1.0 - abs(rd.y), 0.0, 1.0);
+    col = mix(col, deepFog, viewDist * viewDist * 0.35);
   `,
 };


### PR DESCRIPTION
Follow-up to #261. Same portal demo, but you can now walk *into* a portal and end up inside the world.

Each scene has a matching immersive sphere with true 3D raymarching, not the 2D parallax disc. Walk through the disc and the world swaps to the immersive shader; walk back out the other side and you're back in the lobby. Bidirectional, so the entry isn't blocked behind you.

A few other things picked up along the way:

- per-eye stereo parallax on the disc (was flat before)
- the lobby pauses non-active portals while you're inside one
- forest immersive mirrors the cinematics from the disc (owl, comet, lightning, aurora) so going in doesn't feel like a different scene
- cosmic ring is now a drifting rainbow, the rest still use their 2-color bands
- lava: cone-shaped volcanoes with proper 3D bombs, dropped a 2D explosion artifact from the preview
- cyberpunk: night park with neon billboards
- underwater: warmer sand + a school of Dory tang & clownfish

Most of the perf cost is the immersive shader. The exit-snapshot RT is now 256² and runs every other frame, and the hot per-frame allocations in the gallery are gone. Still GPU-bound on M1 Chrome but should be fine on the Galaxy XR target.

`npm run serve` → `http://localhost:8080/demos/portals/`

Demo: https://youtu.be/TMl-VkBOv50
