### PR TITLE
Add Portal Gallery to docs samples

### DIFF
--- a/docs/docs/samples/23-Portals.mdx
+++ b/docs/docs/samples/23-Portals.mdx
@@ -1,0 +1,14 @@
+---
+title: Portal Gallery
+hide_title: true
+breadcrumbs: false
+pagination_next: null
+pagination_prev: null
+---
+
+import {SamplesIFrame} from './SamplesIFrame';
+
+<SamplesIFrame
+  demo="portals"
+  link="https://github.com/google/xrblocks/tree/main/demos/portals/"
+></SamplesIFrame>

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -74,6 +74,7 @@ const sidebars: SidebarsConfig = {
       label: 'Advanced Demos',
       collapsed: false,
       items: [
+        'samples/Portals',
         'samples/Ballpit',
         'samples/BalloonPop',
         'samples/Paint',


### PR DESCRIPTION
Promoting the portals demo to Advanced Demos (#265), comment [here](https://github.com/google/xrblocks/pull/265#issuecomment-4411247784).

Same pattern as BalloonPop and 3DGS Walkthrough mdx page wrapping it in SamplesIFrame, plus a sidebars.ts entry.

Looks like this:
<img width="1920" height="1107" alt="Docs for portals" src="https://github.com/user-attachments/assets/355805c0-a18e-40f2-8f06-68f3fd4db3c1" />
