### PR TITLE
Remove duplicate rollup build from serve script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "concurrently \"npm:build:watch\" \"npm:serve\"",
     "start": "npm run dev",
     "build:watch": "rollup -c -w",
-    "serve": "concurrently \"rollup -c -w\" \"http-server --cors -a 127.0.0.1 -p 8080\"",
+    "serve": "http-server --cors -a 127.0.0.1 -p 8080",
     "build": "echo \"Building xrblocks.js...\" && rollup -c --failAfterWarnings",
     "prepare": "npm run build",
     "lint": "eslint src",


### PR DESCRIPTION
Resolves a compilation race condition introduced in 4d3b8fc7 where running npm start spawned two concurrent rollup instances attempting to write to build/xrblocks.js simultaneously.