### PR TITLE
Update @sparkjsdev/spark to v2.0.0 and optimize XR rendering

### DIFF
--- a/demos/3dgs_walkthrough/index.html
+++ b/demos/3dgs_walkthrough/index.html
@@ -16,7 +16,7 @@
         "imports": {
           "three": "https://cdn.jsdelivr.net/npm/three@0.182.0/build/three.module.js",
           "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.182.0/examples/jsm/",
-          "@sparkjsdev/spark": "https://sparkjs.dev/releases/spark/0.1.10/spark.module.js",
+          "@sparkjsdev/spark": "https://sparkjs.dev/releases/spark/2.0.0/spark.module.js",
           "xrblocks": "../../build/xrblocks.js",
           "xrblocks/addons/": "../../build/addons/"
         }

--- a/demos/3dgs_walkthrough/main.js
+++ b/demos/3dgs_walkthrough/main.js
@@ -57,7 +57,7 @@ class WalkthroughManager extends xb.Script {
     // the simulator can toggle encodeLinear for correct color space.
     const sparkRenderer = new SparkRenderer({
       renderer: xb.core.renderer,
-      maxStdDev: Math.sqrt(5),
+      maxStdDev: Math.sqrt(4),
     });
     xb.core.registry.register(new xb.SparkRendererHolder(sparkRenderer));
     xb.add(sparkRenderer);

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@rollup/plugin-replace": "^6.0.2",
         "@rollup/plugin-terser": "^1.0.0",
         "@rollup/plugin-typescript": "^12.1.4",
-        "@sparkjsdev/spark": "^0.1.10",
+        "@sparkjsdev/spark": "^2.0.0",
         "@types/dom-speech-recognition": "^0.0.7",
         "@types/node": "^25.0.8",
         "@types/three": "^0.182.0",
@@ -1653,13 +1653,16 @@
       ]
     },
     "node_modules/@sparkjsdev/spark": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@sparkjsdev/spark/-/spark-0.1.10.tgz",
-      "integrity": "sha512-CiijdZQuj7KPDUqIZPiEqyUkJCYo1JqR05vq/V+ElxMwqR7L70ZuZDyIKcasjZHSiPB8pGRMH8HZGqUKO9aRPQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sparkjsdev/spark/-/spark-2.0.0.tgz",
+      "integrity": "sha512-W1p7NM4xXcUAVVcVus2mIFwcAC3VckyE0l4wXJuSmhcOgb6hHpqhQ/Ks9MK9ts7j23K+UwbCBwe+aTc/zgGygw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
+      },
+      "peerDependencies": {
+        "three": "^0.180.0"
       }
     },
     "node_modules/@tweenjs/tween.js": {

--- a/package.json
+++ b/package.json
@@ -74,5 +74,10 @@
   },
   "peerDependencies": {
     "three": "^0.182.0"
+  },
+  "overrides": {
+    "@sparkjsdev/spark": {
+      "three": ">=0.180.0"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@rollup/plugin-replace": "^6.0.2",
     "@rollup/plugin-terser": "^1.0.0",
     "@rollup/plugin-typescript": "^12.1.4",
-    "@sparkjsdev/spark": "^0.1.10",
+    "@sparkjsdev/spark": "^2.0.0",
     "@types/dom-speech-recognition": "^0.0.7",
     "@types/node": "^25.0.8",
     "@types/three": "^0.182.0",

--- a/samples/modelviewer/index.html
+++ b/samples/modelviewer/index.html
@@ -31,7 +31,7 @@
           "lit/": "https://esm.run/lit@3/",
           "xrblocks": "../../build/xrblocks.js",
           "xrblocks/addons/": "../../build/addons/",
-          "@sparkjsdev/spark": "https://sparkjs.dev/releases/spark/0.1.10/spark.module.js"
+          "@sparkjsdev/spark": "https://sparkjs.dev/releases/spark/2.0.0/spark.module.js"
         }
       }
     </script>

--- a/src/simulator/Simulator.ts
+++ b/src/simulator/Simulator.ts
@@ -75,7 +75,7 @@ export class Simulator extends Script {
   private initialized = false;
   private renderSimulatorSceneToCanvasBound =
     this.renderSimulatorSceneToCanvas.bind(this);
-  private sparkRenderer?: SparkRenderer & {encodeLinear?: boolean};
+  private sparkRenderer?: SparkRenderer;
   private registry?: Registry;
 
   constructor(

--- a/src/simulator/Simulator.ts
+++ b/src/simulator/Simulator.ts
@@ -75,7 +75,7 @@ export class Simulator extends Script {
   private initialized = false;
   private renderSimulatorSceneToCanvasBound =
     this.renderSimulatorSceneToCanvas.bind(this);
-  private sparkRenderer?: SparkRenderer;
+  private sparkRenderer?: SparkRenderer & {encodeLinear?: boolean};
   private registry?: Registry;
 
   constructor(
@@ -272,7 +272,7 @@ export class Simulator extends Script {
     this.sparkRenderer =
       this.sparkRenderer || this.registry!.get(SparkRendererHolder)?.renderer;
     if (this.sparkRenderer) {
-      this.sparkRenderer.defaultView.encodeLinear = true;
+      this.sparkRenderer.encodeLinear = true;
     }
     this.renderer.setRenderTarget(this.virtualSceneRenderTarget!);
     this.renderer.clear();
@@ -297,7 +297,7 @@ export class Simulator extends Script {
 
   private renderSimulatorSceneToCanvas(camera: THREE.Camera) {
     if (this.sparkRenderer) {
-      this.sparkRenderer.defaultView.encodeLinear = false;
+      this.sparkRenderer.encodeLinear = false;
     }
     this.renderer.setRenderTarget(null);
     if (this.backgroundVideoQuad) {

--- a/src/ui/interaction/ModelViewer.ts
+++ b/src/ui/interaction/ModelViewer.ts
@@ -586,7 +586,7 @@ export class ModelViewer extends Script implements Draggable {
 
   async createSparkRendererIfNeeded() {
     // We insert our own SparkRenderer configured to show Gaussians up to
-    // Math.sqrt(5) standard deviations from the center, recommended for XR.
+    // Math.sqrt(4) standard deviations from the center, recommended for XR.
     const {SparkRenderer} = await import('@sparkjsdev/spark');
     let sparkRendererExists = false;
     this.scene!.traverse((child) => {
@@ -595,7 +595,7 @@ export class ModelViewer extends Script implements Draggable {
     if (!sparkRendererExists) {
       const sparkRenderer = new SparkRenderer({
         renderer: this.renderer!,
-        maxStdDev: Math.sqrt(5),
+        maxStdDev: Math.sqrt(4),
       });
       this.registry!.register(new SparkRendererHolder(sparkRenderer));
       this.scene!.add(sparkRenderer);


### PR DESCRIPTION
- Upgrade @sparkjsdev/spark dependency and CDN import maps to v2.0.0.
- Reduce SparkRenderer maxStdDev from Math.sqrt(5) to Math.sqrt(4) to optimize WebXR performance.
- Update Simulator to toggle encodeLinear directly on SparkRenderer for v2.0 API compatibility.

Tested in simulator and Galaxy XR.