### PR TITLE
Move microphone permission request from `enableCamera()` to gemini_icebreakers

### DIFF
--- a/demos/gemini_icebreakers/main.js
+++ b/demos/gemini_icebreakers/main.js
@@ -11,6 +11,8 @@ const options = new xb.Options({
 });
 options.enableAI();
 options.enableCamera();
+// Request microphone permission before entering XR.
+options.permissions.microphone = true;
 
 async function start() {
   xb.add(new GeminiIcebreakers());

--- a/src/core/Options.ts
+++ b/src/core/Options.ts
@@ -266,7 +266,6 @@ export class Options {
    */
   enableCamera(facingMode: 'environment' | 'user' = 'environment') {
     this.permissions.camera = true;
-    this.permissions.microphone = true;
     this.deviceCamera = new DeviceCameraOptions(
       facingMode === 'environment'
         ? xrDeviceCameraEnvironmentOptions


### PR DESCRIPTION
This way the mic isn't requested if the app only needs the camera.

Reverts #275