### PR TITLE
Add a UI Blocks sample to the Spatial UI section of the XR Blocks samples doc.

### DIFF
--- a/docs/docs/samples/24-UIBlocks.mdx
+++ b/docs/docs/samples/24-UIBlocks.mdx
@@ -1,0 +1,14 @@
+---
+title: UI Blocks
+hide_title: true
+breadcrumbs: false
+pagination_next: null
+pagination_prev: null
+---
+
+import {SamplesIFrame} from './SamplesIFrame';
+
+<SamplesIFrame
+  sample="uiblocks"
+  link="https://github.com/google/xrblocks/tree/main/samples/uiblocks/"
+></SamplesIFrame>

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -35,7 +35,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Spatial UI',
       collapsed: false,
-      items: ['samples/ModelViewer', 'samples/UI'],
+      items: ['samples/ModelViewer', 'samples/UI', 'samples/UIBlocks'],
     },
     {
       type: 'category',


### PR DESCRIPTION
Add a basic UI Blocks sample with a textual description to guide users to refer to UI Blocks for spatial UI.