### PR TITLE
docs: add Language Detector sample page

### DIFF
--- a/docs/docs/samples/24-Language-Detector.mdx
+++ b/docs/docs/samples/24-Language-Detector.mdx
@@ -1,0 +1,15 @@
+---
+title: Language Detector
+hide_title: true
+breadcrumbs: false
+pagination_next: null
+pagination_prev: null
+---
+
+import {SamplesIFrame} from './SamplesIFrame';
+
+<SamplesIFrame
+  requiresApiKey={true}
+  demo="language_detector"
+  link="https://github.com/google/xrblocks/tree/main/demos/language_detector/"
+></SamplesIFrame>

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -66,6 +66,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'samples/XR-Poet',
         'samples/Gemini-XRObject',
+        'samples/Language-Detector',
         'samples/Gemini-Icebreakers',
       ],
     },


### PR DESCRIPTION
follow-up to #274 — adds the Language Detector demo to the docs site so it shows up under AI + XR (right under XR Object since it's the closest neighbour).

just the .mdx + a sidebar entry, mirrors the existing Gemini-XRObject page.