### PR TITLE
Update default Gemini flash and live model versions

### DIFF
--- a/demos/aisimulator/GeminiLivePanel.js
+++ b/demos/aisimulator/GeminiLivePanel.js
@@ -7,6 +7,7 @@ import {
   ApiKeyEnteredEvent,
   MicButtonPressedEvent,
 } from 'xrblocks/addons/simulator/ui/GeminiLiveEvents.js';
+import * as xb from 'xrblocks';
 
 import {GeminiLiveWebInterface} from './GeminiLiveWebInterface.js';
 
@@ -137,7 +138,10 @@ export class GeminiLivePanel extends LitElement {
 
     try {
       console.log('Connecting to Gemini Live...');
-      this.geminiLive = new GeminiLiveWebInterface(apiKey);
+      this.geminiLive = new GeminiLiveWebInterface(
+        apiKey,
+        xb.GEMINI_DEFAULT_LIVE_MODEL
+      );
       this.geminiLive.setCallbacks({
         onTranscription: (data) => this.handleTranscription(data),
       });

--- a/demos/aisimulator/GeminiLiveWebInterface.js
+++ b/demos/aisimulator/GeminiLiveWebInterface.js
@@ -1,9 +1,9 @@
 import {GoogleGenAI, Modality} from '@google/genai';
 
 export class GeminiLiveWebInterface {
-  constructor(apiKey) {
+  constructor(apiKey, model) {
     this.ai = new GoogleGenAI({apiKey: apiKey});
-    this.model = 'gemini-3.1-flash-live-preview';
+    this.model = model;
     this.config = {
       responseModalities: [Modality.AUDIO],
       speechConfig: {voiceConfig: {prebuiltVoiceConfig: {voiceName: 'Aoede'}}},
@@ -839,7 +839,7 @@ export class GeminiLiveWebInterface {
 
   async generateSpeech(text) {
     const response = await this.ai.models.generateContent({
-      model: 'gemini-2.5-flash-preview-tts',
+      model: this.model,
       contents: [{parts: [{text: `Say cheerfully: ${text}`}]}],
       config: {
         responseModalities: ['AUDIO'],

--- a/demos/gemini_xrobject/main.js
+++ b/demos/gemini_xrobject/main.js
@@ -34,7 +34,6 @@ options.sound.speechRecognizer.playSimulatorActivationSounds = true;
 // or provided with `keys.json` in the same directory.
 options.ai.enabled = true;
 options.ai.gemini.enabled = true;
-options.ai.gemini.model = 'gemini-2.5-flash';
 options.world.objects.backendConfig.activeBackend = 'gemini';
 options.world.objects.showDebugVisualizations = false;
 options.setAppTitle('Gemini XR-Objects');
@@ -42,6 +41,7 @@ options.setAppDescription(
   'Recognize objects with Gemini and ask questions about them. Perform a long pinch / press to start!'
 );
 options.xrButton.showEnterSimulatorButton = true;
+options.simulator.defaultMode = xb.SimulatorMode.CONTROLLER;
 
 function start() {
   const xrObjectManager = new XRObjectManager();

--- a/src/ai/AIOptions.ts
+++ b/src/ai/AIOptions.ts
@@ -1,8 +1,7 @@
 import * as GoogleGenAITypes from '@google/genai';
 
-export const GEMINI_DEFAULT_FLASH_MODEL = 'gemini-2.5-flash';
-export const GEMINI_DEFAULT_LIVE_MODEL =
-  'gemini-2.5-flash-native-audio-preview-12-2025';
+export const GEMINI_DEFAULT_FLASH_MODEL = 'gemini-3-flash-preview';
+export const GEMINI_DEFAULT_LIVE_MODEL = 'gemini-3.1-flash-live-preview';
 
 export class GeminiOptions {
   apiKey = '';


### PR DESCRIPTION
Set the following models as defaults in XR Blocks: gemini-3-flash-preview
gemini-3.1-flash-live-preview

Modifies aisimulator and gemini-xrobjects to use the default models in XR Blocks.
Also changes gemini-xrobjects to use hands mode by default.