### PR TITLE
fix(simulator): ignore gamepad input when tab isn't focused, also switching LT/RT default to match Q/E movement controls for controller and desktop parity

### DIFF
--- a/src/addons/simulator/ui/GamepadSettingsPanel.ts
+++ b/src/addons/simulator/ui/GamepadSettingsPanel.ts
@@ -13,8 +13,8 @@ const ACTION_LABELS: Record<xb.GamepadAction, string> = {
   cycleSimulatorMode: 'Cycle Simulator Mode',
   toggleUI: 'Toggle UI',
   toggleHand: 'Swap Active Hand',
-  moveDown: 'Move Down',
   moveUp: 'Move Up',
+  moveDown: 'Move Down',
   openSettings: 'Open Settings',
 };
 

--- a/src/input/GamepadBindings.ts
+++ b/src/input/GamepadBindings.ts
@@ -18,8 +18,8 @@ const DEFAULT_BINDINGS: Record<GamepadAction, number> = {
   cycleSimulatorMode: 3, // Y
   toggleUI: 5, // RB / R1
   toggleHand: 4, // LB / L1
-  moveDown: 6, // LT (analog)
-  moveUp: 7, // RT (analog)
+  moveUp: 6, // LT (analog) — matches keyboard Q
+  moveDown: 7, // RT (analog) — matches keyboard E
   openSettings: 9, // Start / Menu
 };
 

--- a/src/simulator/SimulatorInterface.ts
+++ b/src/simulator/SimulatorInterface.ts
@@ -213,9 +213,9 @@ export class SimulatorInterface {
     toast.show({
       'Left Stick': 'Move (or Hand in Controller mode)',
       'Right Stick': 'Look',
-      [btnName(b.getBinding('moveDown')) +
+      [btnName(b.getBinding('moveUp')) +
       ' / ' +
-      btnName(b.getBinding('moveUp'))]: 'Down / Up',
+      btnName(b.getBinding('moveDown'))]: 'Up / Down',
       [btnName(b.getBinding('select'))]: 'Select / Interact',
       [btnName(b.getBinding('cycleHandPoseLeft')) +
       ' / ' +

--- a/src/simulator/controlModes/SimulatorControlMode.ts
+++ b/src/simulator/controlModes/SimulatorControlMode.ts
@@ -99,8 +99,11 @@ export class SimulatorControlMode {
       .applyQuaternion(cameraRotation);
     cameraPosition.add(vector3);
 
-    // Gamepad stick input (if connected).
-    if (gp.userData.connected) {
+    // Gamepad stick input (if connected). Skip while the tab isn't
+    // focused — the Gamepad API delivers state to every tab, so without
+    // this guard the camera moves in background tabs whenever the user
+    // touches the stick in the foreground tab.
+    if (gp.userData.connected && document.hasFocus()) {
       const [lx, ly, rx, ry] = gp.getAxes();
 
       // Left stick → move camera.

--- a/src/simulator/controlModes/SimulatorControllerMode.ts
+++ b/src/simulator/controlModes/SimulatorControllerMode.ts
@@ -45,8 +45,10 @@ export class SimulatorControllerMode extends SimulatorControlMode {
     localPos.add(vector3);
 
     // Gamepad: left stick moves hand on XZ; configurable buttons on Y.
+    // Skip when the tab isn't focused so background tabs don't react to
+    // stick input meant for the foreground tab.
     const gp = this.input.gamepadController;
-    if (gp.userData.connected && !gp.menuActive) {
+    if (gp.userData.connected && !gp.menuActive && document.hasFocus()) {
       const [lx, ly] = gp.getAxes();
       const downVal = gp.getButtonValue(gp.bindings.getBinding('moveDown'));
       const upVal = gp.getButtonValue(gp.bindings.getBinding('moveUp'));


### PR DESCRIPTION
Open the simulator in two tabs side by side and grab a gamepad, moving the stick in one tab also moves the camera (and the simulated hand) in the other. The Gamepad API hands state to every tab regardless of focus, so both polls see the same axes.

Found while testing a multi-tab netblocks sample where a remote avatar appeared to mirror the local user's gamepad input, turned out the other tab's camera was actually moving on its own. This wasn't really an issue before, it was I guess when on a different window 😄 but when building out netblocks https://github.com/google/xrblocks/pull/284 and having controller support, having them both input is a problem