### PR TITLE
Depth support for mobile.

### DIFF
--- a/samples/depthmap/DepthVisualizationPass.js
+++ b/samples/depthmap/DepthVisualizationPass.js
@@ -21,6 +21,10 @@ export class DepthVisualizationPass extends xb.XRPass {
       uIsTextureArray: {value: 0},
       // Used to interpret Quest 3 depth.
       uDepthNear: {value: 0},
+      uUsingFloatDepth: {
+        value: xb.core.options.depth.dataFormatPreference[0] === 'float32',
+      },
+      uNormDepthBufferFromNormView: {value: new THREE.Matrix4()},
     };
     this.depthMapQuad = new FullScreenQuad(
       new THREE.ShaderMaterial({
@@ -45,6 +49,8 @@ export class DepthVisualizationPass extends xb.XRPass {
         .isExternalTexture
         ? 1.0
         : 0;
+      this.uniforms.uUsingFloatDepth.value =
+        this.depthTextures[0].type === THREE.FloatType;
     }
   }
 
@@ -57,6 +63,11 @@ export class DepthVisualizationPass extends xb.XRPass {
       this.uniforms.uDepthNear.value = depthNear;
     } else {
       this.uniforms.uDepthTexture.value = texture;
+    }
+    if (xb.core.depth.normDepthBufferFromNormViewMatrices.length > viewId) {
+      this.uniforms.uNormDepthBufferFromNormView.value.copy(
+        xb.core.depth.normDepthBufferFromNormViewMatrices[viewId]
+      );
     }
     this.uniforms.tDiffuse.value = readBuffer.texture;
     this.uniforms.uView.value = viewId;

--- a/samples/depthmap/depthmap.glsl.js
+++ b/samples/depthmap/depthmap.glsl.js
@@ -23,6 +23,8 @@ export const DepthMapShader = {
   uniform float uIsTextureArray;
   uniform int uView;
   uniform float uDepthNear;
+  uniform bool uUsingFloatDepth;
+  uniform mat4 uNormDepthBufferFromNormView;
 
   uniform sampler2D tDiffuse;
   uniform float cameraNear;
@@ -31,8 +33,11 @@ export const DepthMapShader = {
   varying vec2 vTexCoord;
 
   float DepthGetMeters(in sampler2D depth_texture, in vec2 depth_uv) {
-    // Assume we're using floating point depth.
-    return uRawValueToMeters * texture2D(depth_texture, depth_uv).r;
+    if (uUsingFloatDepth) {
+      return uRawValueToMeters * texture2D(depth_texture, depth_uv).r;
+    }
+    vec2 packedDepthAndVisibility = texture2D(depth_texture, depth_uv).rg;
+    return dot(packedDepthAndVisibility, vec2(255.0, 256.0 * 255.0)) * uRawValueToMeters;
   }
 
   float DepthArrayGetMeters(in sampler2DArray depth_texture, in vec2 depth_uv) {
@@ -66,10 +71,12 @@ export const DepthMapShader = {
     vec4 diffuse = texture2D( tDiffuse, texCoord.xy );
     highp float real_depth;
     if (uIsTextureArray < 0.5) {
-      uv.y = 1.0 - uv.y;
-      real_depth = DepthGetMeters(uDepthTexture, uv);
-    } else
+      vec2 view_uv = vec2(vTexCoord.x, 1.0 - vTexCoord.y);
+      vec2 depth_uv = (uNormDepthBufferFromNormView * vec4(view_uv, 0.0, 1.0)).xy;
+      real_depth = DepthGetMeters(uDepthTexture, depth_uv);
+    } else {
       real_depth = DepthArrayGetMeters(uDepthTextureArray, uv);
+    }
     vec4 depth_visualization = vec4(
       TurboColormap(clamp(real_depth / 8.0, 0.0, 1.0)), 1.0);
     gl_FragColor = mix(diffuse, depth_visualization, uAlpha);

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -275,10 +275,8 @@ export class Core {
       webXRRequiredFeatures.push('depth-sensing');
       webXRRequiredFeatures.push('local-floor');
       this.webXRSettings.depthSensing = {
-        usagePreference: [],
-        dataFormatPreference: [
-          this.options.depth.useFloat32 ? 'float32' : 'luminance-alpha',
-        ],
+        usagePreference: options.depth.usagePreference,
+        dataFormatPreference: options.depth.dataFormatPreference,
         depthTypeRequest: options.depth.depthTypeRequest,
         matchDepthView: options.depth.matchDepthView,
       };

--- a/src/core/components/WebXRSessionManager.ts
+++ b/src/core/components/WebXRSessionManager.ts
@@ -108,7 +108,17 @@ export class WebXRSessionManager extends THREE.EventDispatcher<WebXRSessionManag
       .finally(() => {
         this.waitingForXRSession = false;
       })
-      .then(this.onSessionStartedInternal.bind(this));
+      .then(this.onSessionStartedInternal.bind(this))
+      .catch((err) => {
+        console.error(
+          'Error requesting session',
+          err,
+          'mode:',
+          this.mode,
+          'sesionOptions:',
+          this.sessionOptions
+        );
+      });
   }
 
   /**

--- a/src/core/components/XREffects.ts
+++ b/src/core/components/XREffects.ts
@@ -96,8 +96,9 @@ export class XREffects {
     renderer.xr.cameraAutoUpdate = false;
     renderer.xr.enabled = false;
     const deltaTime = this.timer.getDelta();
-    if (renderer.xr.getCamera().cameras.length == 2) {
-      for (let camIndex = 0; camIndex < 2; ++camIndex) {
+    const numCameras = renderer.xr.getCamera().cameras.length;
+    if (numCameras > 0) {
+      for (let camIndex = 0; camIndex < numCameras; ++camIndex) {
         const cam = renderer.xr.getCamera().cameras[camIndex];
         renderer.setViewport(cam.viewport);
         renderer.setRenderTarget(renderTargets[camIndex]);
@@ -109,14 +110,14 @@ export class XREffects {
       renderer.clear();
       renderer.xr.isPresenting = false;
       renderer.autoClearColor = false;
-      for (let eye = 0; eye < 2; eye++) {
+      for (let eye = 0; eye < numCameras; eye++) {
         for (let i = 0; i < this.passes.length - 1; ++i) {
           const lastRenderTargetIndex = i % 2;
           const nextRenderTargetIndex = (i + 1) % 2;
           defaultTarget.viewport.set(
-            (eye * this.dimensions.x) / 2,
+            (eye * this.dimensions.x) / numCameras,
             0,
-            this.dimensions.x / 2,
+            this.dimensions.x / numCameras,
             this.dimensions.y
           );
           this.passes[i].render(
@@ -131,9 +132,9 @@ export class XREffects {
         if (this.passes.length > 0) {
           const lastRenderTargetIndex = (this.passes.length - 1) % 2;
           defaultTarget.viewport.set(
-            (eye * this.dimensions.x) / 2,
+            (eye * this.dimensions.x) / numCameras,
             0,
-            this.dimensions.x / 2,
+            this.dimensions.x / numCameras,
             this.dimensions.y
           );
           this.passes[this.passes.length - 1].render(

--- a/src/depth/Depth.ts
+++ b/src/depth/Depth.ts
@@ -262,27 +262,33 @@ export class Depth {
     );
   }
 
-  updateCPUDepthData(depthData: XRCPUDepthInformation, viewId = 0) {
+  updateCPUDepthData(
+    depthData: XRCPUDepthInformation,
+    viewId: number,
+    depthDataFormat: XRDepthDataFormat
+  ) {
     this.cpuDepthData[viewId] = depthData;
     this.updateDepthMatrices(depthData, viewId);
 
     // Updates Depth Array.
-    this.depthArray[viewId] = this.options.useFloat32
-      ? new Float32Array(depthData.data)
-      : new Uint16Array(depthData.data);
+    this.depthArray[viewId] =
+      depthDataFormat === 'float32'
+        ? new Float32Array(depthData.data)
+        : new Uint16Array(depthData.data);
     this.width = depthData.width;
     this.height = depthData.height;
 
     // Updates Depth Texture.
     if (this.options.depthTexture.enabled && this.depthTextures) {
-      this.depthTextures.updateData(depthData, viewId);
+      this.depthTextures.updateData(depthData, viewId, depthDataFormat);
     }
 
     if (this.options.depthMesh.enabled && this.depthMesh && viewId == 0) {
       if (this.shouldUpdateDepthMesh()) {
         this.depthMesh.updateDepth(
           depthData,
-          this.depthProjectionInverseMatrices[0]
+          this.depthProjectionInverseMatrices[0],
+          depthDataFormat
         );
       }
       this.depthMesh.updatePose(
@@ -292,7 +298,11 @@ export class Depth {
     }
   }
 
-  updateGPUDepthData(depthData: XRWebGLDepthInformation, viewId = 0) {
+  updateGPUDepthData(
+    depthData: XRWebGLDepthInformation,
+    viewId: number,
+    depthDataFormat: XRDepthDataFormat
+  ) {
     this.gpuDepthData[viewId] = depthData;
     this.updateDepthMatrices(depthData, viewId);
 
@@ -305,15 +315,16 @@ export class Depth {
         : null;
     if (cpuDepth) {
       if (this.depthArray[viewId] == null) {
-        this.depthArray[viewId] = this.options.useFloat32
-          ? new Float32Array(cpuDepth.data)
-          : new Uint16Array(cpuDepth.data);
+        this.depthArray[viewId] =
+          depthDataFormat === 'float32'
+            ? new Float32Array(cpuDepth.data)
+            : new Uint16Array(cpuDepth.data);
         this.width = cpuDepth.width;
         this.height = cpuDepth.height;
       } else {
         // Copies the data from an ArrayBuffer to the existing TypedArray.
         this.depthArray[viewId].set(
-          this.options.useFloat32
+          depthDataFormat === 'float32'
             ? new Float32Array(cpuDepth.data)
             : new Uint16Array(cpuDepth.data)
         );
@@ -330,12 +341,14 @@ export class Depth {
         if (cpuDepth) {
           this.depthMesh.updateDepth(
             cpuDepth,
-            this.depthProjectionInverseMatrices[0]
+            this.depthProjectionInverseMatrices[0],
+            depthDataFormat
           );
         } else {
           this.depthMesh.updateGPUDepth(
             depthData,
-            this.depthProjectionInverseMatrices[0]
+            this.depthProjectionInverseMatrices[0],
+            depthDataFormat
           );
         }
       }
@@ -409,13 +422,21 @@ export class Depth {
             if (!depthData) {
               return;
             }
-            this.updateGPUDepthData(depthData, viewId);
+            this.updateGPUDepthData(
+              depthData,
+              viewId,
+              session.depthDataFormat ?? 'luminance-alpha'
+            );
           } else {
             const depthData = frame.getDepthInformation(view);
             if (!depthData) {
               return;
             }
-            this.updateCPUDepthData(depthData, viewId);
+            this.updateCPUDepthData(
+              depthData,
+              viewId,
+              session.depthDataFormat ?? 'luminance-alpha'
+            );
           }
         }
       } else {

--- a/src/depth/DepthMesh.ts
+++ b/src/depth/DepthMesh.ts
@@ -93,13 +93,16 @@ export class DepthMesh extends MeshScript {
         uOpacity: {value: options.opacity},
         uDebug: {value: options.showDebugTexture ? 1.0 : 0.0},
         uLightDirection: {value: new THREE.Vector3(1.0, 1.0, 1.0).normalize()},
-        uUsingFloatDepth: {value: depthOptions.useFloat32},
+        uUsingFloatDepth: {
+          value: depthOptions.dataFormatPreference[0] === 'float32',
+        },
+        uNormDepthBufferFromNormView: {value: new THREE.Matrix4()},
       };
       material = new THREE.ShaderMaterial({
         uniforms: uniforms,
         vertexShader: DepthMeshTexturedShader.vertexShader,
         fragmentShader: DepthMeshTexturedShader.fragmentShader,
-        side: THREE.FrontSide,
+        side: THREE.DoubleSide,
         transparent: true,
       });
     } else {
@@ -146,7 +149,8 @@ export class DepthMesh extends MeshScript {
    */
   updateDepth(
     depthData: Readonly<XRCPUDepthInformation>,
-    projectionMatrixInverse: Readonly<THREE.Matrix4>
+    projectionMatrixInverse: Readonly<THREE.Matrix4>,
+    depthDataFormat: XRDepthDataFormat
   ) {
     this.projectionMatrixInverse = projectionMatrixInverse;
 
@@ -154,10 +158,10 @@ export class DepthMesh extends MeshScript {
     this.maxDepth = 0;
 
     if (this.options.updateFullResolutionGeometry) {
-      this.updateFullResolutionGeometry(depthData);
+      this.updateFullResolutionGeometry(depthData, depthDataFormat);
     }
     if (this.downsampledGeometry) {
-      this.updateGeometry(depthData, this.downsampledGeometry);
+      this.updateGeometry(depthData, this.downsampledGeometry, depthDataFormat);
     }
 
     this.minDepthPrev = this.minDepth;
@@ -166,6 +170,15 @@ export class DepthMesh extends MeshScript {
 
     const depthTextureLeft = this.depthTextures?.get(0);
     if (depthTextureLeft && this.depthTextureMaterialUniforms) {
+      this.depthTextureMaterialUniforms.uUsingFloatDepth.value =
+        depthDataFormat === 'float32';
+      if (depthData.normDepthBufferFromNormView) {
+        this.depthTextureMaterialUniforms.uNormDepthBufferFromNormView.value.fromArray(
+          depthData.normDepthBufferFromNormView.matrix
+        );
+      } else {
+        this.depthTextureMaterialUniforms.uNormDepthBufferFromNormView.value.identity();
+      }
       const isTextureArray = depthTextureLeft instanceof THREE.ExternalTexture;
       this.depthTextureMaterialUniforms.uIsTextureArray.value = isTextureArray
         ? 1.0
@@ -203,9 +216,14 @@ export class DepthMesh extends MeshScript {
 
   updateGPUDepth(
     depthData: Readonly<XRWebGLDepthInformation>,
-    projectionMatrixInverse: Readonly<THREE.Matrix4>
+    projectionMatrixInverse: Readonly<THREE.Matrix4>,
+    depthDataFormat: XRDepthDataFormat
   ) {
-    this.updateDepth(this.convertGPUToGPU(depthData), projectionMatrixInverse);
+    this.updateDepth(
+      this.convertGPUToGPU(depthData),
+      projectionMatrixInverse,
+      depthDataFormat
+    );
   }
 
   convertGPUToGPU(depthData: Readonly<XRWebGLDepthInformation>) {
@@ -304,8 +322,11 @@ export class DepthMesh extends MeshScript {
    * Method to manually update the full resolution geometry.
    * Only needed if options.updateFullResolutionGeometry is false.
    */
-  updateFullResolutionGeometry(depthData: XRCPUDepthInformation) {
-    this.updateGeometry(depthData, this.geometry);
+  updateFullResolutionGeometry(
+    depthData: XRCPUDepthInformation,
+    depthDataFormat: XRDepthDataFormat
+  ) {
+    this.updateGeometry(depthData, this.geometry, depthDataFormat);
   }
 
   /**
@@ -313,21 +334,42 @@ export class DepthMesh extends MeshScript {
    */
   private updateGeometry(
     depthData: XRCPUDepthInformation,
-    geometry: THREE.BufferGeometry
+    geometry: THREE.BufferGeometry,
+    depthDataFormat: XRDepthDataFormat
   ) {
     const width = depthData.width;
     const height = depthData.height;
-    const depthArray = this.depthOptions.useFloat32
-      ? new Float32Array(depthData.data)
-      : new Uint16Array(depthData.data);
+    const depthArray =
+      depthDataFormat === 'float32'
+        ? new Float32Array(depthData.data)
+        : new Uint16Array(depthData.data);
     const vertexPosition = new THREE.Vector3();
+    const normViewCoord = new THREE.Vector3();
+    const normDepthBufferFromNormView = depthData.normDepthBufferFromNormView
+      ? new THREE.Matrix4().fromArray(
+          depthData.normDepthBufferFromNormView.matrix
+        )
+      : new THREE.Matrix4().identity();
+
     for (let i = 0; i < geometry.attributes.position.count; ++i) {
       const u = geometry.attributes.uv.array[2 * i];
       const v = geometry.attributes.uv.array[2 * i + 1];
 
+      let sampleU = u;
+      let sampleV = v;
+
+      if (depthData.normDepthBufferFromNormView) {
+        normViewCoord.set(u, 1.0 - v, 0);
+        normViewCoord.applyMatrix4(normDepthBufferFromNormView);
+        sampleU = normViewCoord.x;
+        sampleV = normViewCoord.y;
+      } else {
+        sampleV = 1.0 - v;
+      }
+
       // Grabs the nearest for now.
-      const depthX = Math.round(clamp(u * (width - 1), 0, width - 1));
-      const depthY = Math.round(clamp((1.0 - v) * (height - 1), 0, height - 1));
+      const depthX = Math.round(clamp(sampleU * (width - 1), 0, width - 1));
+      const depthY = Math.round(clamp(sampleV * (height - 1), 0, height - 1));
       const rawDepth = depthArray[depthY * width + depthX];
       let depth = depthData.rawValueToMeters * rawDepth;
 

--- a/src/depth/DepthMeshTexturedShader.ts
+++ b/src/depth/DepthMeshTexturedShader.ts
@@ -38,6 +38,7 @@ uniform float uDebug;
 uniform float uOpacity;
 uniform bool uUsingFloatDepth;
 uniform bool uIsTextureArray;
+uniform mat4 uNormDepthBufferFromNormView;
 
 float saturate(in float x) {
   return clamp(x, 0.0, 1.0);
@@ -108,13 +109,13 @@ void main() {
     return;
   }
 
-  vec2 depth_uv = uv;
-  depth_uv.y = 1.0 - depth_uv.y;
+  vec2 view_uv = vec2(uv.x, 1.0 - uv.y);
+  vec2 depth_uv = (uNormDepthBufferFromNormView * vec4(view_uv, 0.0, 1.0)).xy;
 
   float depth = (uIsTextureArray ? DepthArrayGetMeters(uDepthTextureArray, depth_uv) : DepthGetMeters(uDepthTexture, depth_uv)) * 8.0;
   float normalized_depth =
     saturate((depth - uMinDepth) / (uMaxDepth - uMinDepth));
-  gl_FragColor = uOpacity * vec4(TurboColormap(normalized_depth), 1.0);
+  gl_FragColor =  vec4(TurboColormap(normalized_depth), 1.0);
 }
 `,
 };

--- a/src/depth/DepthOptions.ts
+++ b/src/depth/DepthOptions.ts
@@ -36,7 +36,8 @@ export class DepthOptions {
   };
   // Occlusion pass.
   occlusion = {enabled: false};
-  useFloat32 = true;
+  usagePreference: XRDepthUsage[] = [];
+  dataFormatPreference: XRDepthDataFormat[] = ['float32', 'luminance-alpha'];
   depthTypeRequest: XRDepthType[] = ['raw'];
   matchDepthView = true;
 

--- a/src/depth/DepthTextures.ts
+++ b/src/depth/DepthTextures.ts
@@ -13,12 +13,13 @@ export class DepthTextures {
 
   private createDataDepthTextures(
     depthData: XRCPUDepthInformation,
-    viewId: number
+    viewId: number,
+    depthDataFormat: XRDepthDataFormat
   ) {
     if (this.dataTextures[viewId]) {
       this.dataTextures[viewId].dispose();
     }
-    if (this.options.useFloat32) {
+    if (depthDataFormat === 'float32') {
       const typedArray = new Float32Array(depthData.width * depthData.height);
       const format = THREE.RedFormat;
       const type = THREE.FloatType;
@@ -45,15 +46,19 @@ export class DepthTextures {
     }
   }
 
-  updateData(depthData: XRCPUDepthInformation, viewId: number) {
+  updateData(
+    depthData: XRCPUDepthInformation,
+    viewId: number,
+    depthDataFormat: XRDepthDataFormat
+  ) {
     if (
       this.dataTextures.length < viewId + 1 ||
       this.dataTextures[viewId].image.width !== depthData.width ||
       this.dataTextures[viewId].image.height !== depthData.height
     ) {
-      this.createDataDepthTextures(depthData, viewId);
+      this.createDataDepthTextures(depthData, viewId, depthDataFormat);
     }
-    if (this.options.useFloat32) {
+    if (depthDataFormat === 'float32') {
       this.float32Arrays[viewId].set(new Float32Array(depthData.data));
     } else {
       this.uint8Arrays[viewId].set(new Uint8Array(depthData.data));

--- a/src/simulator/SimulatorDepth.ts
+++ b/src/simulator/SimulatorDepth.ts
@@ -151,6 +151,10 @@ export class SimulatorDepth {
       transform: transform,
     };
 
-    this.depth.updateCPUDepthData(depthData as XRCPUDepthInformation, 0);
+    this.depth.updateCPUDepthData(
+      depthData as XRCPUDepthInformation,
+      0,
+      'float32'
+    );
   }
 }


### PR DESCRIPTION
1. Updated DepthOptions and Core to configure WebXR depth sensing using standard dataFormatPreference and usagePreference arrays.
2. Modified Depth, DepthTextures, and SimulatorDepth to dynamically read and pass depthDataFormat from the active XRSession instead of relying on static configuration.
3. Enhanced XREffects with dynamic camera viewport scaling to enable postprocessing pipelines on single-camera mobile AR devices.
4. Fixed missing luminance-alpha decoding across the depthmap sample and core shaders to properly unpack 16-bit integer depth on mobile devices.
5. Corrected mobile depth texture rotation and X/Y flipping in depthmap and DepthMesh by properly mapping WebGL UVs before applying WebXR's normDepthBufferFromNormView transform.

depthmesh, depthmap, and ballpit samples are now working on mobile.
<img width="1080" height="2340" alt="vlcsnap-2026-05-14-10h49m17s569" src="https://github.com/user-attachments/assets/4605d33f-4262-43e1-b701-8dc313d9f899" />

