### PR TITLE
Catch exceptions in script lifecycle methods.

### DIFF
--- a/src/core/Core.test.ts
+++ b/src/core/Core.test.ts
@@ -1,0 +1,372 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  MockInstance,
+} from 'vitest';
+
+// Stub AudioContext globally before importing any modules that rely on THREE.AudioListener.
+// Use plain JS functions rather than vi.fn() to prevent vi.restoreAllMocks() from clearing the mock implementation.
+vi.hoisted(() => {
+  vi.stubGlobal('AudioContext', function () {
+    return {
+      createGain: function () {
+        return {
+          connect: function () {},
+        };
+      },
+      destination: {},
+    };
+  });
+});
+
+import * as THREE from 'three';
+import {Core} from './Core';
+import {Options} from './Options';
+import {Script, SelectEvent} from './Script';
+import {Controller} from '../input/Controller';
+import {Physics} from '../physics/Physics';
+import {
+  ScriptsManagerEventType,
+  ScriptsManagerEventMap,
+} from './components/ScriptsManager';
+
+type ExceptionEvent =
+  ScriptsManagerEventMap[ScriptsManagerEventType.EXCEPTION] & {type: string};
+
+describe('Core and ScriptsManager exception handling via EventDispatcher', () => {
+  let core: Core;
+  let consoleErrorSpy: MockInstance;
+
+  beforeEach(() => {
+    // Reset Core singleton to ensure fresh state for each test
+    Core.instance = undefined;
+    core = new Core();
+    core.options = new Options();
+
+    // Mock core dependencies/methods to isolate update and physics loops
+    core.renderer = {
+      render: vi.fn(),
+      xr: {
+        enabled: false,
+        getDepthSensingMesh: vi.fn(),
+        setReferenceSpaceType: vi.fn(),
+      },
+    } as unknown as THREE.WebGLRenderer;
+    core.depth.update = vi.fn();
+    core.input.update = vi.fn();
+    core.scriptsManager.syncScriptsWithScene = vi.fn();
+    core.waitFrame.onFrame = vi.fn();
+    core.screenshotSynthesizer.onAfterRender = vi.fn();
+
+    // Spy on console.error
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('catchScriptExceptions defaults to true', () => {
+    it('should have catchScriptExceptions enabled by default', () => {
+      expect(core.options.catchScriptExceptions).toBe(true);
+    });
+  });
+
+  describe('update loop via ScriptsManager', () => {
+    it('should catch script exceptions, emit exception event, and continue updating other scripts when enabled', () => {
+      const script1 = {
+        name: 'Script1',
+        ux: {reset: vi.fn()},
+        update: vi.fn().mockImplementation(() => {
+          throw new Error('Script1 crashed');
+        }),
+      } as unknown as Script;
+
+      const script2 = {
+        name: 'Script2',
+        ux: {reset: vi.fn()},
+        update: vi.fn(),
+      } as unknown as Script;
+
+      core.scriptsManager.scripts = new Set([script1, script2]);
+
+      const events: ExceptionEvent[] = [];
+      core.scriptsManager.addEventListener(
+        ScriptsManagerEventType.EXCEPTION,
+        (event) => {
+          events.push(event);
+        }
+      );
+
+      expect(() => {
+        (
+          core as unknown as {update: (time: number, frame: XRFrame) => void}
+        ).update(1000, {} as XRFrame);
+      }).not.toThrow();
+
+      // Both scripts had their UX reset
+      expect(script1.ux.reset).toHaveBeenCalled();
+      expect(script2.ux.reset).toHaveBeenCalled();
+
+      // Both updates were attempted
+      expect(script1.update).toHaveBeenCalled();
+      expect(script2.update).toHaveBeenCalled();
+
+      // console.error was called with the error details
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('An error occurred in script Script1 [update]'),
+        expect.any(Error)
+      );
+
+      // EXCEPTION event is dispatched with correct payload
+      expect(events.length).toBe(1);
+      expect(events[0]).toEqual(
+        expect.objectContaining({
+          type: ScriptsManagerEventType.EXCEPTION,
+          scriptName: 'Script1',
+          context: 'update',
+          error: expect.any(Error),
+          timestamp: expect.any(Number),
+        })
+      );
+    });
+
+    it('should propagate script exceptions immediately and NOT emit exception event when disabled', () => {
+      core.scriptsManager.catchExceptions = false;
+
+      const script1 = {
+        name: 'Script1',
+        ux: {reset: vi.fn()},
+        update: vi.fn().mockImplementation(() => {
+          throw new Error('Script1 crashed');
+        }),
+      } as unknown as Script;
+
+      const script2 = {
+        name: 'Script2',
+        ux: {reset: vi.fn()},
+        update: vi.fn(),
+      } as unknown as Script;
+
+      core.scriptsManager.scripts = new Set([script1, script2]);
+
+      const events: ExceptionEvent[] = [];
+      core.scriptsManager.addEventListener(
+        ScriptsManagerEventType.EXCEPTION,
+        (event) => {
+          events.push(event);
+        }
+      );
+
+      expect(() => {
+        (
+          core as unknown as {update: (time: number, frame: XRFrame) => void}
+        ).update(1000, {} as XRFrame);
+      }).toThrow('Script1 crashed');
+
+      // script2.update should not be called since script1.update threw and stopped the loop
+      expect(script1.update).toHaveBeenCalled();
+      expect(script2.update).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+      // EXCEPTION event is not emitted
+      expect(events.length).toBe(0);
+    });
+
+    it('should catch and emit individual events for exceptions in UX reset, onSelecting, and onSqueezing', () => {
+      const script1 = {
+        name: 'Script1',
+        ux: {
+          reset: vi.fn().mockImplementation(() => {
+            throw new Error('UX reset crashed');
+          }),
+        },
+        onSelecting: vi.fn().mockImplementation(() => {
+          throw new Error('onSelecting crashed');
+        }),
+        onSqueezing: vi.fn().mockImplementation(() => {
+          throw new Error('onSqueezing crashed');
+        }),
+        update: vi.fn(),
+      } as unknown as Script;
+
+      const script2 = {
+        name: 'Script2',
+        ux: {reset: vi.fn()},
+        onSelecting: vi.fn(),
+        onSqueezing: vi.fn(),
+        update: vi.fn(),
+      } as unknown as Script;
+
+      core.scriptsManager.scripts = new Set([script1, script2]);
+
+      // Set up mock controllers to trigger selection and squeezing callbacks
+      core.input.controllers = [
+        {
+          userData: {
+            selected: true,
+            squeezing: true,
+          },
+        },
+      ] as unknown as Controller[];
+
+      const events: ExceptionEvent[] = [];
+      core.scriptsManager.addEventListener(
+        ScriptsManagerEventType.EXCEPTION,
+        (event) => {
+          events.push(event);
+        }
+      );
+
+      expect(() => {
+        (
+          core as unknown as {update: (time: number, frame: XRFrame) => void}
+        ).update(1000, {} as XRFrame);
+      }).not.toThrow();
+
+      // script2 calls should still execute successfully
+      expect(script2.ux.reset).toHaveBeenCalled();
+      expect(script2.onSelecting).toHaveBeenCalled();
+      expect(script2.onSqueezing).toHaveBeenCalled();
+      expect(script2.update).toHaveBeenCalled();
+
+      // console.error is called three times
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(3);
+
+      // Three events are dispatched
+      expect(events.length).toBe(3);
+      expect(events.map((e) => e.context)).toEqual([
+        'ux.reset',
+        'onSelecting',
+        'onSqueezing',
+      ]);
+    });
+  });
+
+  describe('event callbacks robustness', () => {
+    it('should catch and emit exceptions inside callSelectStart without crashing other scripts', () => {
+      const script1 = {
+        name: 'Script1',
+        onSelectStart: vi.fn().mockImplementation(() => {
+          throw new Error('SelectStart error');
+        }),
+      } as unknown as Script;
+
+      const script2 = {
+        name: 'Script2',
+        onSelectStart: vi.fn(),
+      } as unknown as Script;
+
+      core.scriptsManager.scripts = new Set([script1, script2]);
+
+      const events: ExceptionEvent[] = [];
+      core.scriptsManager.addEventListener(
+        ScriptsManagerEventType.EXCEPTION,
+        (event) => {
+          events.push(event);
+        }
+      );
+
+      expect(() => {
+        core.scriptsManager.callSelectStart({} as unknown as SelectEvent);
+      }).not.toThrow();
+
+      expect(script1.onSelectStart).toHaveBeenCalled();
+      expect(script2.onSelectStart).toHaveBeenCalled();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[onSelectStart]'),
+        expect.any(Error)
+      );
+      expect(events.length).toBe(1);
+      expect(events[0].context).toBe('onSelectStart');
+    });
+  });
+
+  describe('physics step', () => {
+    it('should catch and emit physicsStep exceptions without crashing physics simulation', () => {
+      core.physics = {
+        physicsStep: vi.fn(),
+      } as unknown as Physics;
+
+      const script1 = {
+        name: 'Script1',
+        physicsStep: vi.fn().mockImplementation(() => {
+          throw new Error('physicsStep crashed');
+        }),
+      } as unknown as Script;
+
+      const script2 = {
+        name: 'Script2',
+        physicsStep: vi.fn(),
+      } as unknown as Script;
+
+      core.scriptsManager.scripts = new Set([script1, script2]);
+
+      const events: ExceptionEvent[] = [];
+      core.scriptsManager.addEventListener(
+        ScriptsManagerEventType.EXCEPTION,
+        (event) => {
+          events.push(event);
+        }
+      );
+
+      expect(() => {
+        (core as unknown as {physicsStep: () => void}).physicsStep();
+      }).not.toThrow();
+
+      expect(script1.physicsStep).toHaveBeenCalled();
+      expect(script2.physicsStep).toHaveBeenCalled();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'An error occurred in script Script1 [physicsStep]'
+        ),
+        expect.any(Error)
+      );
+      expect(events.length).toBe(1);
+      expect(events[0].context).toBe('physicsStep');
+    });
+
+    it('should propagate physicsStep exceptions immediately when disabled', () => {
+      core.scriptsManager.catchExceptions = false;
+      core.physics = {
+        physicsStep: vi.fn(),
+      } as unknown as Physics;
+
+      const script1 = {
+        name: 'Script1',
+        physicsStep: vi.fn().mockImplementation(() => {
+          throw new Error('physicsStep crashed');
+        }),
+      } as unknown as Script;
+
+      const script2 = {
+        name: 'Script2',
+        physicsStep: vi.fn(),
+      } as unknown as Script;
+
+      core.scriptsManager.scripts = new Set([script1, script2]);
+
+      const events: ExceptionEvent[] = [];
+      core.scriptsManager.addEventListener(
+        ScriptsManagerEventType.EXCEPTION,
+        (event) => {
+          events.push(event);
+        }
+      );
+
+      expect(() => {
+        (core as unknown as {physicsStep: () => void}).physicsStep();
+      }).toThrow('physicsStep crashed');
+
+      expect(script1.physicsStep).toHaveBeenCalled();
+      expect(script2.physicsStep).not.toHaveBeenCalled();
+      expect(events.length).toBe(0);
+    });
+  });
+});

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -235,6 +235,7 @@ export class Core {
     }
 
     this.options = options;
+    this.scriptsManager.catchExceptions = options.catchScriptExceptions;
 
     // Sets up controllers.
     if (options.controllers.enabled) {
@@ -244,14 +245,14 @@ export class Core {
         options: options,
         renderer: this.renderer,
       });
-      this.input.bindSelectStart(this.scriptsManager.callSelectStartBound);
-      this.input.bindSelectEnd(this.scriptsManager.callSelectEndBound);
-      this.input.bindSelect(this.scriptsManager.callSelectBound);
-      this.input.bindSqueezeStart(this.scriptsManager.callSqueezeStartBound);
-      this.input.bindSqueezeEnd(this.scriptsManager.callSqueezeEndBound);
-      this.input.bindSqueeze(this.scriptsManager.callSqueezeBound);
-      this.input.bindKeyDown(this.scriptsManager.callKeyDownBound);
-      this.input.bindKeyUp(this.scriptsManager.callKeyUpBound);
+      this.input.bindSelectStart(this.scriptsManager.callSelectStart);
+      this.input.bindSelectEnd(this.scriptsManager.callSelectEnd);
+      this.input.bindSelect(this.scriptsManager.callSelect);
+      this.input.bindSqueezeStart(this.scriptsManager.callSqueezeStart);
+      this.input.bindSqueezeEnd(this.scriptsManager.callSqueezeEnd);
+      this.input.bindSqueeze(this.scriptsManager.callSqueeze);
+      this.input.bindKeyDown(this.scriptsManager.callKeyDown);
+      this.input.bindKeyUp(this.scriptsManager.callKeyUp);
     }
 
     // Sets up device camera.
@@ -444,25 +445,19 @@ export class Core {
     this.scriptsManager.syncScriptsWithScene(this.scene);
 
     // Updates reticles and UIs.
-    for (const script of this.scriptsManager.scripts) {
-      script.ux.reset();
-    }
+    this.scriptsManager.resetUX();
     this.input.update();
 
     // Updates scripts with user interactions.
     for (const controller of this.input.controllers) {
       if (controller.userData.selected) {
-        for (const script of this.scriptsManager.scripts) {
-          script.onSelecting({target: controller});
-        }
+        this.scriptsManager.callSelecting(controller);
       }
     }
 
     for (const controller of this.input.controllers) {
       if (controller.userData.squeezing) {
-        for (const script of this.scriptsManager.scripts) {
-          script.onSqueezing({target: controller});
-        }
+        this.scriptsManager.callSqueezing(controller);
       }
     }
 
@@ -470,9 +465,7 @@ export class Core {
     this.waitFrame.onFrame();
 
     // Updates renderings.
-    for (const script of this.scriptsManager.scripts) {
-      script.update(time, frame);
-    }
+    this.scriptsManager.update(time, frame);
 
     this.renderSimulatorAndScene();
     this.screenshotSynthesizer.onAfterRender(
@@ -491,9 +484,7 @@ export class Core {
    */
   private physicsStep() {
     this.physics!.physicsStep();
-    for (const script of this.scriptsManager.scripts) {
-      script.physicsStep();
-    }
+    this.scriptsManager.physicsStep();
   }
 
   /**

--- a/src/core/Options.ts
+++ b/src/core/Options.ts
@@ -126,6 +126,13 @@ export class Options {
   enableSimulator = true;
 
   /**
+   * Whether to catch all exceptions thrown by developer scripts in the main update loop
+   * and physics step, and log them using console.error instead of crashing the application.
+   * When enabled, exceptions in one script will not prevent other scripts or subsystems from updating.
+   */
+  catchScriptExceptions = true;
+
+  /**
    * Configuration for the XR session button.
    */
   xrButton = {

--- a/src/core/components/ScriptsManager.ts
+++ b/src/core/components/ScriptsManager.ts
@@ -1,30 +1,56 @@
 import * as THREE from 'three';
 
+import type {Controller} from '../../input/Controller';
 import {KeyEvent, Script, SelectEvent} from '../Script';
 
 type MaybeScript = THREE.Object3D & {isXRScript?: boolean};
 
-export class ScriptsManager {
+export enum ScriptsManagerEventType {
+  EXCEPTION = 'exception',
+}
+
+export type ScriptsManagerEventMap = THREE.Object3DEventMap & {
+  [ScriptsManagerEventType.EXCEPTION]: {
+    scriptName: string;
+    context: string;
+    error: Error;
+    timestamp: number;
+  };
+};
+
+export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap> {
   /** The set of all currently initialized scripts. */
   scripts = new Set<Script>();
-
-  callSelectStartBound = this.callSelectStart.bind(this);
-  callSelectEndBound = this.callSelectEnd.bind(this);
-  callSelectBound = this.callSelect.bind(this);
-  callSqueezeStartBound = this.callSqueezeStart.bind(this);
-  callSqueezeEndBound = this.callSqueezeEnd.bind(this);
-  callSqueezeBound = this.callSqueeze.bind(this);
-  callKeyDownBound = this.callKeyDown.bind(this);
-  callKeyUpBound = this.callKeyUp.bind(this);
 
   /** The set of scripts currently being initialized. */
   private initializingScripts = new Set<Script>();
 
   private seenScripts = new Set<Script>();
   private syncPromises: Promise<void>[] = [];
-  private checkScriptBound = this.checkScript.bind(this);
 
-  constructor(private initScriptFunction: (script: Script) => Promise<void>) {}
+  /** Whether to catch all exceptions thrown by developer scripts. */
+  catchExceptions = true;
+
+  constructor(private initScriptFunction: (script: Script) => Promise<void>) {
+    super();
+  }
+
+  private handleException(error: Error, script: Script, context: string) {
+    console.error(
+      `An error occurred in script ${
+        script.name || script.constructor.name
+      } [${context}]:`,
+      error
+    );
+
+    this.dispatchEvent({
+      type: ScriptsManagerEventType.EXCEPTION,
+      scriptName: script.name || script.constructor.name,
+      context,
+      error,
+      timestamp: performance.now(),
+    });
+  }
 
   /**
    * Initializes a script and adds it to the set of scripts which will receive
@@ -60,13 +86,13 @@ export class ScriptsManager {
   /**
    * Helper for scene traversal to avoid closure allocation.
    */
-  private checkScript(obj: THREE.Object3D) {
+  private checkScript = (obj: THREE.Object3D) => {
     if ((obj as MaybeScript).isXRScript) {
       const script = obj as Script;
       this.syncPromises.push(this.initScript(script));
       this.seenScripts.add(script);
     }
-  }
+  };
 
   /**
    * Finds all scripts in the scene and initializes them or uninitailizes them.
@@ -80,7 +106,7 @@ export class ScriptsManager {
     this.seenScripts.clear();
     this.syncPromises.length = 0;
 
-    scene.traverse(this.checkScriptBound);
+    scene.traverse(this.checkScript);
 
     // Delete missing scripts.
     for (const script of this.scripts) {
@@ -92,69 +118,307 @@ export class ScriptsManager {
     return Promise.allSettled(this.syncPromises);
   }
 
-  callSelectStart(event: SelectEvent) {
+  resetUX = () => {
+    const catchExceptions = this.catchExceptions;
     for (const script of this.scripts) {
-      script.onSelectStart(event);
+      if (catchExceptions) {
+        try {
+          script.ux.reset();
+        } catch (error: unknown) {
+          this.handleException(
+            error instanceof Error ? error : new Error(String(error)),
+            script,
+            'ux.reset'
+          );
+        }
+      } else {
+        script.ux.reset();
+      }
     }
-  }
+  };
 
-  callSelectEnd(event: SelectEvent) {
+  callSelecting = (controller: Controller) => {
+    const catchExceptions = this.catchExceptions;
     for (const script of this.scripts) {
-      script.onSelectEnd(event);
+      if (catchExceptions) {
+        try {
+          script.onSelecting({target: controller});
+        } catch (error: unknown) {
+          this.handleException(
+            error instanceof Error ? error : new Error(String(error)),
+            script,
+            'onSelecting'
+          );
+        }
+      } else {
+        script.onSelecting({target: controller});
+      }
     }
-  }
+  };
 
-  callSelect(event: SelectEvent) {
+  callSqueezing = (controller: Controller) => {
+    const catchExceptions = this.catchExceptions;
     for (const script of this.scripts) {
-      script.onSelect(event);
+      if (catchExceptions) {
+        try {
+          script.onSqueezing({target: controller});
+        } catch (error: unknown) {
+          this.handleException(
+            error instanceof Error ? error : new Error(String(error)),
+            script,
+            'onSqueezing'
+          );
+        }
+      } else {
+        script.onSqueezing({target: controller});
+      }
     }
-  }
+  };
 
-  callSqueezeStart(event: SelectEvent) {
+  update = (time: number, frame: XRFrame) => {
+    const catchExceptions = this.catchExceptions;
     for (const script of this.scripts) {
-      script.onSqueezeStart(event);
+      if (catchExceptions) {
+        try {
+          script.update(time, frame);
+        } catch (error: unknown) {
+          this.handleException(
+            error instanceof Error ? error : new Error(String(error)),
+            script,
+            'update'
+          );
+        }
+      } else {
+        script.update(time, frame);
+      }
     }
-  }
+  };
 
-  callSqueezeEnd(event: SelectEvent) {
+  physicsStep = () => {
+    const catchExceptions = this.catchExceptions;
     for (const script of this.scripts) {
-      script.onSqueezeEnd(event);
+      if (catchExceptions) {
+        try {
+          script.physicsStep();
+        } catch (error: unknown) {
+          this.handleException(
+            error instanceof Error ? error : new Error(String(error)),
+            script,
+            'physicsStep'
+          );
+        }
+      } else {
+        script.physicsStep();
+      }
     }
-  }
+  };
 
-  callSqueeze(event: SelectEvent) {
+  callSelectStart = (event: SelectEvent) => {
+    const catchExceptions = this.catchExceptions;
     for (const script of this.scripts) {
-      script.onSqueeze(event);
+      if (catchExceptions) {
+        try {
+          script.onSelectStart(event);
+        } catch (error: unknown) {
+          this.handleException(
+            error instanceof Error ? error : new Error(String(error)),
+            script,
+            'onSelectStart'
+          );
+        }
+      } else {
+        script.onSelectStart(event);
+      }
     }
-  }
+  };
 
-  callKeyDown(event: KeyEvent) {
+  callSelectEnd = (event: SelectEvent) => {
+    const catchExceptions = this.catchExceptions;
     for (const script of this.scripts) {
-      script.onKeyDown(event);
+      if (catchExceptions) {
+        try {
+          script.onSelectEnd(event);
+        } catch (error: unknown) {
+          this.handleException(
+            error instanceof Error ? error : new Error(String(error)),
+            script,
+            'onSelectEnd'
+          );
+        }
+      } else {
+        script.onSelectEnd(event);
+      }
     }
-  }
+  };
 
-  callKeyUp(event: KeyEvent) {
+  callSelect = (event: SelectEvent) => {
+    const catchExceptions = this.catchExceptions;
     for (const script of this.scripts) {
-      script.onKeyUp(event);
+      if (catchExceptions) {
+        try {
+          script.onSelect(event);
+        } catch (error: unknown) {
+          this.handleException(
+            error instanceof Error ? error : new Error(String(error)),
+            script,
+            'onSelect'
+          );
+        }
+      } else {
+        script.onSelect(event);
+      }
     }
-  }
+  };
 
-  onXRSessionStarted(session: XRSession) {
+  callSqueezeStart = (event: SelectEvent) => {
+    const catchExceptions = this.catchExceptions;
     for (const script of this.scripts) {
-      script.onXRSessionStarted(session);
+      if (catchExceptions) {
+        try {
+          script.onSqueezeStart(event);
+        } catch (error: unknown) {
+          this.handleException(
+            error instanceof Error ? error : new Error(String(error)),
+            script,
+            'onSqueezeStart'
+          );
+        }
+      } else {
+        script.onSqueezeStart(event);
+      }
     }
-  }
+  };
 
-  onXRSessionEnded() {
+  callSqueezeEnd = (event: SelectEvent) => {
+    const catchExceptions = this.catchExceptions;
     for (const script of this.scripts) {
-      script.onXRSessionEnded();
+      if (catchExceptions) {
+        try {
+          script.onSqueezeEnd(event);
+        } catch (error: unknown) {
+          this.handleException(
+            error instanceof Error ? error : new Error(String(error)),
+            script,
+            'onSqueezeEnd'
+          );
+        }
+      } else {
+        script.onSqueezeEnd(event);
+      }
     }
-  }
+  };
 
-  onSimulatorStarted() {
+  callSqueeze = (event: SelectEvent) => {
+    const catchExceptions = this.catchExceptions;
     for (const script of this.scripts) {
-      script.onSimulatorStarted();
+      if (catchExceptions) {
+        try {
+          script.onSqueeze(event);
+        } catch (error: unknown) {
+          this.handleException(
+            error instanceof Error ? error : new Error(String(error)),
+            script,
+            'onSqueeze'
+          );
+        }
+      } else {
+        script.onSqueeze(event);
+      }
     }
-  }
+  };
+
+  callKeyDown = (event: KeyEvent) => {
+    const catchExceptions = this.catchExceptions;
+    for (const script of this.scripts) {
+      if (catchExceptions) {
+        try {
+          script.onKeyDown(event);
+        } catch (error: unknown) {
+          this.handleException(
+            error instanceof Error ? error : new Error(String(error)),
+            script,
+            'onKeyDown'
+          );
+        }
+      } else {
+        script.onKeyDown(event);
+      }
+    }
+  };
+
+  callKeyUp = (event: KeyEvent) => {
+    const catchExceptions = this.catchExceptions;
+    for (const script of this.scripts) {
+      if (catchExceptions) {
+        try {
+          script.onKeyUp(event);
+        } catch (error: unknown) {
+          this.handleException(
+            error instanceof Error ? error : new Error(String(error)),
+            script,
+            'onKeyUp'
+          );
+        }
+      } else {
+        script.onKeyUp(event);
+      }
+    }
+  };
+
+  onXRSessionStarted = (session: XRSession) => {
+    const catchExceptions = this.catchExceptions;
+    for (const script of this.scripts) {
+      if (catchExceptions) {
+        try {
+          script.onXRSessionStarted(session);
+        } catch (error: unknown) {
+          this.handleException(
+            error instanceof Error ? error : new Error(String(error)),
+            script,
+            'onXRSessionStarted'
+          );
+        }
+      } else {
+        script.onXRSessionStarted(session);
+      }
+    }
+  };
+
+  onXRSessionEnded = () => {
+    const catchExceptions = this.catchExceptions;
+    for (const script of this.scripts) {
+      if (catchExceptions) {
+        try {
+          script.onXRSessionEnded();
+        } catch (error: unknown) {
+          this.handleException(
+            error instanceof Error ? error : new Error(String(error)),
+            script,
+            'onXRSessionEnded'
+          );
+        }
+      } else {
+        script.onXRSessionEnded();
+      }
+    }
+  };
+
+  onSimulatorStarted = () => {
+    const catchExceptions = this.catchExceptions;
+    for (const script of this.scripts) {
+      if (catchExceptions) {
+        try {
+          script.onSimulatorStarted();
+        } catch (error: unknown) {
+          this.handleException(
+            error instanceof Error ? error : new Error(String(error)),
+            script,
+            'onSimulatorStarted'
+          );
+        }
+      } else {
+        script.onSimulatorStarted();
+      }
+    }
+  };
 }


### PR DESCRIPTION
This catches all exceptions in script lifecycle methods and logs them as an error instead of crashing the update loop.

This is controlled by `options.catchScriptExceptions` which is now true by default.