### PR TITLE
Refactor prototype `.bind(this)` wrappers to arrow functions.

### DIFF
--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -89,10 +89,11 @@ export class Core {
   /** A container to hold all the systems in the scene hierarchy. */
   xrSystemsGroup = new XRSystems();
 
-  private renderSceneBound = this.renderScene.bind(this);
+  private renderSceneCallback = (cameraOverride?: THREE.Camera) =>
+    this.renderScene(cameraOverride);
 
   /** Manages the desktop XR simulator. */
-  simulator = new Simulator(this.renderSceneBound);
+  simulator = new Simulator(this.renderSceneCallback);
 
   /** Manages drag-and-drop interactions. */
   dragManager = new DragManager();
@@ -342,7 +343,7 @@ export class Core {
     );
     this.webXRSessionManager.addEventListener(
       WebXRSessionEventType.SESSION_END,
-      this.onXRSessionEnded.bind(this)
+      this.onXRSessionEnded
     );
 
     // Sets up xrButton.
@@ -359,7 +360,7 @@ export class Core {
         options.xrButton?.invalidText,
         options.xrButton?.startSimulatorText,
         options.xrButton?.showEnterSimulatorButton,
-        this.startSimulator.bind(this),
+        this.startSimulator,
         options.permissions
       );
       document.body.appendChild(this.xrButton.domElement);
@@ -393,10 +394,10 @@ export class Core {
 
     await this.scriptsManager.syncScriptsWithScene(this.scene);
 
-    this.renderer.setAnimationLoop(this.update.bind(this));
+    this.renderer.setAnimationLoop(this.update);
 
     if (this.physics) {
-      setInterval(this.physicsStep.bind(this), 1000 * this.physics.timestep);
+      setInterval(this.physicsStep, 1000 * this.physics.timestep);
     }
 
     if (this.options.reticles.enabled) {
@@ -424,7 +425,7 @@ export class Core {
    * @param time - The current time in milliseconds.
    * @param frame - The WebXR frame object, if in an XR session.
    */
-  private update(time: number, frame: XRFrame) {
+  private update = (time: number, frame: XRFrame) => {
     this.currentFrame = frame;
     this.timer.update(time);
     if (this.simulatorRunning) {
@@ -470,22 +471,22 @@ export class Core {
     this.renderSimulatorAndScene();
     this.screenshotSynthesizer.onAfterRender(
       this.renderer,
-      this.renderSceneBound,
+      this.renderSceneCallback,
       this.deviceCamera
     );
     if (this.simulatorRunning) {
       this.simulator.renderSimulatorScene();
     }
-  }
+  };
 
   /**
    * Advances the physics simulation by a fixed timestep and calls the
    * corresponding physics update on all active scripts.
    */
-  private physicsStep() {
+  private physicsStep = () => {
     this.physics!.physicsStep();
     this.scriptsManager.physicsStep();
-  }
+  };
 
   /**
    * Lifecycle callback executed when an XR session starts. Notifies all active
@@ -499,20 +500,20 @@ export class Core {
     this.scriptsManager.onXRSessionStarted(session);
   }
 
-  private async startSimulator() {
+  private startSimulator = async () => {
     this.xrButton?.domElement.remove();
     this.xrSystemsGroup.add(this.simulator);
     await this.scriptsManager.initScript(this.simulator);
     this.onSimulatorStarted();
-  }
+  };
 
   /**
    * Lifecycle callback executed when an XR session ends. Notifies all active
    * scripts.
    */
-  private onXRSessionEnded() {
+  private onXRSessionEnded = () => {
     this.scriptsManager.onXRSessionEnded();
-  }
+  };
 
   /**
    * Lifecycle callback executed when the desktop simulator starts. Notifies

--- a/src/core/components/WebXRSessionManager.ts
+++ b/src/core/components/WebXRSessionManager.ts
@@ -22,7 +22,6 @@ export type WebXRSessionManagerEventMap = THREE.Object3DEventMap & {
 export class WebXRSessionManager extends THREE.EventDispatcher<WebXRSessionManagerEventMap> {
   public currentSession?: XRSession;
   private sessionOptions?: XRSessionInit;
-  private onSessionEndedBound = this.onSessionEndedInternal.bind(this);
   private xrModeSupported?: boolean;
   private waitingForXRSession = false;
 
@@ -77,7 +76,7 @@ export class WebXRSessionManager extends THREE.EventDispatcher<WebXRSessionManag
       // Automatically start session if 'offerSession' is available
       if (navigator.xr!.offerSession !== undefined) {
         navigator.xr!.offerSession!(this.mode, this.sessionOptions)
-          .then(this.onSessionStartedInternal.bind(this))
+          .then(this.onSessionStartedInternal)
           .catch((err) => {
             console.warn(err);
           });
@@ -108,7 +107,7 @@ export class WebXRSessionManager extends THREE.EventDispatcher<WebXRSessionManag
       .finally(() => {
         this.waitingForXRSession = false;
       })
-      .then(this.onSessionStartedInternal.bind(this))
+      .then(this.onSessionStartedInternal)
       .catch((err) => {
         console.error(
           'Error requesting session',
@@ -145,8 +144,8 @@ export class WebXRSessionManager extends THREE.EventDispatcher<WebXRSessionManag
   }
 
   /** Internal callback for when a session successfully starts. */
-  private async onSessionStartedInternal(session: XRSession) {
-    session.addEventListener('end', this.onSessionEndedBound);
+  private onSessionStartedInternal = async (session: XRSession) => {
+    session.addEventListener('end', this.onSessionEndedInternal);
     await this.renderer.xr.setSession(session);
     this.currentSession = session;
 
@@ -155,14 +154,17 @@ export class WebXRSessionManager extends THREE.EventDispatcher<WebXRSessionManag
       type: WebXRSessionEventType.SESSION_START,
       session: session,
     });
-  }
+  };
 
   /** Internal callback for when the session ends. */
-  private onSessionEndedInternal(/*event*/) {
+  private onSessionEndedInternal = () => {
     // Fire the 'sessionend' event
     this.dispatchEvent({type: WebXRSessionEventType.SESSION_END});
 
-    this.currentSession?.removeEventListener('end', this.onSessionEndedBound);
+    this.currentSession?.removeEventListener(
+      'end',
+      this.onSessionEndedInternal
+    );
     this.currentSession = undefined;
-  }
+  };
 }

--- a/src/simulator/SimulatorControls.ts
+++ b/src/simulator/SimulatorControls.ts
@@ -41,13 +41,6 @@ export class SimulatorControls {
     this.setEnabled(value);
   }
 
-  private _onPointerDown = this.onPointerDown.bind(this);
-  private _onPointerUp = this.onPointerUp.bind(this);
-  private _onKeyDown = this.onKeyDown.bind(this);
-  private _onKeyUp = this.onKeyUp.bind(this);
-  private _onPointerMove = this.onPointerMove.bind(this);
-  private _onBlur = this.onBlur.bind(this);
-
   /**
    * Create the simulator controls.
    * @param hands - The simulator hands manager.
@@ -128,38 +121,38 @@ export class SimulatorControls {
 
   connect() {
     const domElement = this.renderer.domElement;
-    document.addEventListener('keyup', this._onKeyUp);
-    document.addEventListener('keydown', this._onKeyDown);
-    domElement.addEventListener('pointermove', this._onPointerMove);
-    domElement.addEventListener('pointerdown', this._onPointerDown);
-    domElement.addEventListener('pointerup', this._onPointerUp);
+    document.addEventListener('keyup', this.onKeyUp);
+    document.addEventListener('keydown', this.onKeyDown);
+    domElement.addEventListener('pointermove', this.onPointerMove);
+    domElement.addEventListener('pointerdown', this.onPointerDown);
+    domElement.addEventListener('pointerup', this.onPointerUp);
     domElement.addEventListener('contextmenu', preventDefault);
-    window.addEventListener('blur', this._onBlur);
-    document.addEventListener('visibilitychange', this._onBlur);
+    window.addEventListener('blur', this.onBlur);
+    document.addEventListener('visibilitychange', this.onBlur);
   }
 
   update() {
     this.simulatorModeControls.update();
   }
 
-  onPointerMove(event: MouseEvent) {
+  onPointerMove = (event: MouseEvent) => {
     if (!this.enabled) return;
     this.simulatorModeControls.onPointerMove(event);
-  }
+  };
 
-  onPointerDown(event: MouseEvent) {
+  onPointerDown = (event: MouseEvent) => {
     if (!this.enabled) return;
     this.simulatorModeControls.onPointerDown(event);
     this.pointerDown = true;
-  }
+  };
 
-  onPointerUp(event: MouseEvent) {
+  onPointerUp = (event: MouseEvent) => {
     if (!this.enabled) return;
     this.simulatorModeControls.onPointerUp(event);
     this.pointerDown = false;
-  }
+  };
 
-  onKeyDown(event: KeyboardEvent) {
+  onKeyDown = (event: KeyboardEvent) => {
     if (!this.enabled) return;
     // On macOS, keyup events are not fired for keys held when Command (Meta)
     // is pressed. Clear all keys to prevent stuck movement.
@@ -181,16 +174,16 @@ export class SimulatorControls {
       );
     }
     this.simulatorModeControls.onKeyDown(event);
-  }
+  };
 
-  onKeyUp(event: KeyboardEvent) {
+  onKeyUp = (event: KeyboardEvent) => {
     if (!this.enabled) return;
     this.downKeys.delete(event.code as Keycodes);
-  }
+  };
 
-  onBlur() {
+  onBlur = () => {
     this.downKeys.clear();
-  }
+  };
 
   setSimulatorMode(mode: SimulatorMode) {
     this.simulatorMode = mode;

--- a/src/simulator/SimulatorHands.ts
+++ b/src/simulator/SimulatorHands.ts
@@ -41,7 +41,6 @@ export class SimulatorHands {
     SIMULATOR_HAND_POSE_TO_JOINTS_RIGHT[SimulatorHandPose.RELAXED];
   lerpSpeed = 0.1;
   handPosePanelElement?: SimulatorHandPoseHTMLElement;
-  onHandPoseChangeRequestBound = this.onHandPoseChangeRequest.bind(this);
   input!: Input;
   loader!: GLTFLoader;
 
@@ -329,18 +328,18 @@ export class SimulatorHands {
     if (this.handPosePanelElement) {
       this.handPosePanelElement.removeEventListener(
         SimulatorHandPoseChangeRequestEvent.type,
-        this.onHandPoseChangeRequestBound
+        this.onHandPoseChangeRequest
       );
     }
     element.addEventListener(
       SimulatorHandPoseChangeRequestEvent.type,
-      this.onHandPoseChangeRequestBound
+      this.onHandPoseChangeRequest
     );
     this.handPosePanelElement = element as SimulatorHandPoseHTMLElement;
     this.updateHandPosePanel();
   }
 
-  onHandPoseChangeRequest(event: Event) {
+  onHandPoseChangeRequest = (event: Event) => {
     if (event.type != SimulatorHandPoseChangeRequestEvent.type) return;
     const handPoseChangeEvent = event as SimulatorHandPoseChangeRequestEvent;
     if (this.simulatorControllerState.currentControllerIndex === 0) {
@@ -348,7 +347,7 @@ export class SimulatorHands {
     } else {
       this.setRightHandLerpPose(handPoseChangeEvent.pose);
     }
-  }
+  };
 
   toggleHandedness() {
     this.simulatorControllerState.currentControllerIndex =

--- a/src/sound/SpeechRecognizer.ts
+++ b/src/sound/SpeechRecognizer.ts
@@ -36,11 +36,6 @@ export class SpeechRecognizer extends Script<SpeechRecognizerEventMap> {
   error?: string;
   playActivationSounds = false;
 
-  private handleStartBound = this._handleStart.bind(this);
-  private handleResultBound = this._handleResult.bind(this);
-  private handleEndBound = this._handleEnd.bind(this);
-  private handleErrorBound = this._handleError.bind(this);
-
   constructor(private soundSynthesizer: SoundSynthesizer) {
     super();
   }
@@ -64,10 +59,10 @@ export class SpeechRecognizer extends Script<SpeechRecognizerEventMap> {
     this.recognition.interimResults = this.options.interimResults;
 
     // Setup native event listeners
-    this.recognition.onstart = this.handleStartBound;
-    this.recognition.onresult = this.handleResultBound;
-    this.recognition.onend = this.handleEndBound;
-    this.recognition.onerror = this.handleErrorBound;
+    this.recognition.onstart = this._handleStart;
+    this.recognition.onresult = this._handleResult;
+    this.recognition.onend = this._handleEnd;
+    this.recognition.onerror = this._handleError;
   }
 
   onSimulatorStarted() {
@@ -126,16 +121,16 @@ export class SpeechRecognizer extends Script<SpeechRecognizerEventMap> {
   }
 
   // Private handler for the 'start' event
-  private _handleStart() {
+  private _handleStart = () => {
     console.debug('SpeechRecognizer: Listening started.');
     this.dispatchEvent({type: 'start'});
     if (this.playActivationSounds) {
       this.soundSynthesizer.playPresetTone('ACTIVATE');
     }
-  }
+  };
 
   // Private handler for the 'result' event
-  private _handleResult(event: SpeechRecognitionEvent) {
+  private _handleResult = (event: SpeechRecognitionEvent) => {
     let interimTranscript = '';
     let finalTranscript = '';
     let currentConfidence = 0;
@@ -180,10 +175,10 @@ export class SpeechRecognizer extends Script<SpeechRecognizerEventMap> {
       command: this.lastCommand,
       isFinal: !!finalTranscript,
     });
-  }
+  };
 
   // Private handler for the 'end' event (e.g., when silence is detected)
-  _handleEnd() {
+  private _handleEnd = () => {
     this.isListening = false;
     this.dispatchEvent({type: 'end'});
 
@@ -197,15 +192,15 @@ export class SpeechRecognizer extends Script<SpeechRecognizerEventMap> {
     } else if (this.playActivationSounds) {
       this.soundSynthesizer.playPresetTone('DEACTIVATE');
     }
-  }
+  };
 
   // Private handler for the 'error' event
-  _handleError(event: SpeechRecognitionErrorEvent) {
+  private _handleError = (event: SpeechRecognitionErrorEvent) => {
     console.error('SpeechRecognizer: Error:', event.error);
     this.error = event.error;
     this.isListening = false;
     this.dispatchEvent({type: 'error', error: event.error});
-  }
+  };
 
   destroy() {
     this.stop();

--- a/src/sound/SpeechSynthesizer.ts
+++ b/src/sound/SpeechSynthesizer.ts
@@ -30,7 +30,7 @@ export class SpeechSynthesizer extends Script {
     } else {
       this.loadVoices();
       if (this.synth.onvoiceschanged !== undefined) {
-        this.synth.onvoiceschanged = this.loadVoices.bind(this);
+        this.synth.onvoiceschanged = this.loadVoices;
       }
     }
     if (!this.categoryVolumes && this.synth) {
@@ -47,7 +47,7 @@ export class SpeechSynthesizer extends Script {
     }
   }
 
-  loadVoices() {
+  loadVoices = () => {
     if (!this.synth) return;
     this.voices = this.synth.getVoices();
     if (this.debug) {
@@ -67,7 +67,7 @@ export class SpeechSynthesizer extends Script {
     } else {
       console.warn('SpeechSynthesizer: No suitable default voice found.');
     }
-  }
+  };
 
   setVolume(level: number) {
     this.specificVolume = THREE.MathUtils.clamp(level, 0.0, 1.0);

--- a/src/ui/components/ScrollingTroikaTextView.ts
+++ b/src/ui/components/ScrollingTroikaTextView.ts
@@ -30,7 +30,6 @@ export class ScrollingTroikaTextView extends View {
   private pager: VerticalPager;
   private textViewWrapper: View;
   private textView: TextView;
-  private onTextSyncCompleteBound = this.onTextSyncComplete.bind(this);
   private currentText = '';
 
   constructor({
@@ -52,10 +51,7 @@ export class ScrollingTroikaTextView extends View {
       anchorY: 0,
     });
     this.textView.x = -0.5;
-    this.textView.addEventListener(
-      'synccomplete',
-      this.onTextSyncCompleteBound
-    );
+    this.textView.addEventListener('synccomplete', this.onTextSyncComplete);
     this.textViewWrapper.add(this.textView);
 
     this.add(this.scrollerState);
@@ -79,7 +75,7 @@ export class ScrollingTroikaTextView extends View {
     this.textView.setText(this.currentText);
   }
 
-  onTextSyncComplete() {
+  onTextSyncComplete = () => {
     if (this.textView.lineCount > 0) {
       this.textView.y =
         -0.5 + this.textView.lineHeight * this.textView.aspectRatio;
@@ -89,7 +85,7 @@ export class ScrollingTroikaTextView extends View {
 
       this.clipToLineHeight();
     }
-  }
+  };
 
   clipToLineHeight() {
     const lineHeight = this.textView.lineHeight * this.textView.aspectRatio;

--- a/src/ui/components/TextView.ts
+++ b/src/ui/components/TextView.ts
@@ -146,7 +146,6 @@ export class TextView extends View<TextViewEventMap> {
   /** The total number of lines after text wrapping. */
   lineCount = 0;
 
-  private _onSyncCompleteBound = this.onSyncComplete.bind(this);
   private _initializeTextCalled = false;
   private _text = 'TextView';
   set text(text) {
@@ -345,7 +344,7 @@ export class TextView extends View<TextViewEventMap> {
    * Callback executed when Troika's text sync is complete.
    * It captures layout data like total height and line count.
    */
-  onSyncComplete() {
+  onSyncComplete = () => {
     if (
       !this.useSDFText ||
       !(this.textObj instanceof Text) ||
@@ -371,7 +370,7 @@ export class TextView extends View<TextViewEventMap> {
       numberOfChars > 0 ? (firstBottom - lastBottom) / lineCount : 0;
     this.lineCount = lineCount;
     this.dispatchEvent({type: 'synccomplete'});
-  }
+  };
 
   /**
    * Private method to perform the actual initialization after the async
@@ -402,7 +401,7 @@ export class TextView extends View<TextViewEventMap> {
       this.textObj.addEventListener(
         // @ts-expect-error Missing type in Troika
         'synccomplete',
-        this._onSyncCompleteBound
+        this.onSyncComplete
       );
 
       if (this.imageOverlay) {
@@ -443,7 +442,7 @@ export class TextView extends View<TextViewEventMap> {
       this.textObj.removeEventListener(
         // @ts-expect-error Missing type in Troika
         'synccomplete',
-        this._onSyncCompleteBound
+        this.onSyncComplete
       );
     }
     super.dispose();


### PR DESCRIPTION
This refactors duplicate prototype method binding property definitions (such as `xyzBound = this.xyz.bind(this)`) and inline `.bind(this)` assignments to modern, auto-binding arrow functions.