### PR TITLE
Fix depth mesh on Quest 3.

### DIFF
--- a/src/depth/Depth.ts
+++ b/src/depth/Depth.ts
@@ -298,14 +298,9 @@ export class Depth {
     }
   }
 
-  updateGPUDepthData(
-    depthData: XRWebGLDepthInformation,
-    viewId: number,
-    depthDataFormat: XRDepthDataFormat
-  ) {
+  updateGPUDepthData(depthData: XRWebGLDepthInformation, viewId: number) {
     this.gpuDepthData[viewId] = depthData;
     this.updateDepthMatrices(depthData, viewId);
-
     // For now, assume that we need cpu depth only if depth mesh is enabled.
     // In the future, add a separate option.
     const needCpuDepth = this.options.depthMesh.enabled;
@@ -314,21 +309,13 @@ export class Depth {
         ? this.depthMesh.convertGPUToGPU(depthData)
         : null;
     if (cpuDepth) {
-      if (this.depthArray[viewId] == null) {
-        this.depthArray[viewId] =
-          depthDataFormat === 'float32'
-            ? new Float32Array(cpuDepth.data)
-            : new Uint16Array(cpuDepth.data);
-        this.width = cpuDepth.width;
-        this.height = cpuDepth.height;
+      if (this.depthArray[viewId] instanceof Float32Array) {
+        this.depthArray[viewId].set(new Float32Array(cpuDepth.data));
       } else {
-        // Copies the data from an ArrayBuffer to the existing TypedArray.
-        this.depthArray[viewId].set(
-          depthDataFormat === 'float32'
-            ? new Float32Array(cpuDepth.data)
-            : new Uint16Array(cpuDepth.data)
-        );
+        this.depthArray[viewId] = new Float32Array(cpuDepth.data);
       }
+      this.width = cpuDepth.width;
+      this.height = cpuDepth.height;
     }
 
     // Updates Depth Texture.
@@ -342,13 +329,12 @@ export class Depth {
           this.depthMesh.updateDepth(
             cpuDepth,
             this.depthProjectionInverseMatrices[0],
-            depthDataFormat
+            'float32'
           );
         } else {
           this.depthMesh.updateGPUDepth(
             depthData,
-            this.depthProjectionInverseMatrices[0],
-            depthDataFormat
+            this.depthProjectionInverseMatrices[0]
           );
         }
       }
@@ -422,11 +408,7 @@ export class Depth {
             if (!depthData) {
               return;
             }
-            this.updateGPUDepthData(
-              depthData,
-              viewId,
-              session.depthDataFormat ?? 'luminance-alpha'
-            );
+            this.updateGPUDepthData(depthData, viewId);
           } else {
             const depthData = frame.getDepthInformation(view);
             if (!depthData) {

--- a/src/depth/DepthMesh.ts
+++ b/src/depth/DepthMesh.ts
@@ -216,16 +216,16 @@ export class DepthMesh extends MeshScript {
 
   updateGPUDepth(
     depthData: Readonly<XRWebGLDepthInformation>,
-    projectionMatrixInverse: Readonly<THREE.Matrix4>,
-    depthDataFormat: XRDepthDataFormat
+    projectionMatrixInverse: Readonly<THREE.Matrix4>
   ) {
     this.updateDepth(
       this.convertGPUToGPU(depthData),
       projectionMatrixInverse,
-      depthDataFormat
+      'float32'
     );
   }
 
+  // Converts unsigned short GPU depth from Quest 3 to float32 CPU depth.
   convertGPUToGPU(depthData: Readonly<XRWebGLDepthInformation>) {
     if (!this.depthTarget) {
       this.depthTarget = new THREE.WebGLRenderTarget(

--- a/src/depth/DepthTextures.ts
+++ b/src/depth/DepthTextures.ts
@@ -72,7 +72,7 @@ export class DepthTextures {
     renderer: THREE.WebGLRenderer,
     viewId: number
   ) {
-    if (this.dataTextures.length < viewId + 1) {
+    if (this.nativeTextures.length < viewId + 1) {
       this.nativeTextures[viewId] = new THREE.ExternalTexture(
         depthData.texture
       );


### PR DESCRIPTION
I accidentally broke this in #291.

Basically, Android on mobile only support luminance-alpha so I decided to pipe the depth format throughout the depth code so it supports both luminance alpha or float32 depending on what the session returns. However, when we convert GPU depth to CPU depth, the format gets converted to float32 so we need to hardcode that.