### PR TITLE
Cache depthDataFormat in Depth and move GPU depth conversion logic to GPUDepthConverter

### DIFF
--- a/demos/splash/SplashScript.js
+++ b/demos/splash/SplashScript.js
@@ -57,11 +57,7 @@ export class SplashScript extends xb.Script {
 
     const scaleMultiplier = 0.4;
 
-    if (xb.core.depth.depthData.length > 0) {
-      xb.core.depth.depthMesh.updateFullResolutionGeometry(
-        xb.core.depth.depthData[0]
-      );
-    }
+    xb.core.depth.updateFullResolutionDepthMesh();
     paintball.splatFromIntersection(
       intersection /*scale=*/,
       xb.lerp(scaleMultiplier * 0.3, scaleMultiplier * 0.5, Math.random())
@@ -82,15 +78,7 @@ export class SplashScript extends xb.Script {
       scaleMultiplier * 0.5,
       Math.random()
     );
-    if (xb.core.depth.cpuDepthData.length > 0) {
-      xb.core.depth.depthMesh.updateFullResolutionGeometry(
-        xb.core.depth.cpuDepthData[0]
-      );
-    } else if (xb.core.depth.gpuDepthData.length > 0) {
-      xb.core.depth.depthMesh.updateFullResolutionGeometry(
-        xb.core.depth.depthMesh.convertGPUToGPU(xb.core.depth.gpuDepthData[0])
-      );
-    }
+    xb.core.depth.updateFullResolutionDepthMesh();
     paintball.splatOnMesh(
       xb.core.depth.depthMesh,
       position,
@@ -156,7 +144,7 @@ export class SplashScript extends xb.Script {
         this.physics.blendedWorld.contactPair(
           depthMeshCollider,
           ballShooter.colliders[ballIndex],
-          (manifold, flipped) => {
+          (manifold) => {
             if (!generatedDecal && manifold.numSolverContacts() > 0) {
               contactPoint.copy(manifold.solverContactPoint(0));
               forceDirection.copy(event.maxForceDirection());
@@ -186,7 +174,7 @@ export class SplashScript extends xb.Script {
     this.add(light);
   }
 
-  onPointerUp(event) {
+  onPointerUp() {
     this.mouseReticle.setPressed(false);
   }
 }

--- a/src/depth/Depth.ts
+++ b/src/depth/Depth.ts
@@ -7,6 +7,7 @@ import {clamp} from '../utils/utils';
 import {DepthMesh} from './DepthMesh';
 import {DepthOptions} from './DepthOptions';
 import {DepthTextures} from './DepthTextures';
+import {GPUDepthConverter} from './GPUDepthConverter';
 import {OcclusionPass} from './occlusion/OcclusionPass';
 
 const DEFAULT_DEPTH_WIDTH = 160;
@@ -22,12 +23,14 @@ export class Depth {
   // The main camera.
   private camera!: THREE.Camera;
   private renderer!: THREE.WebGLRenderer;
+  private gpuDepthConverter?: GPUDepthConverter;
 
   enabled = false;
   view: XRView[] = [];
   cpuDepthData: XRCPUDepthInformation[] = [];
   gpuDepthData: XRWebGLDepthInformation[] = [];
   depthArray: DepthArray[] = [];
+  depthDataFormat?: XRDepthDataFormat;
   depthMesh?: DepthMesh;
   private depthTextures?: DepthTextures;
   options = new DepthOptions();
@@ -89,6 +92,7 @@ export class Depth {
     this.options = options;
     this.renderer = renderer;
     this.enabled = options.enabled;
+    this.gpuDepthConverter = new GPUDepthConverter(renderer);
 
     if (this.options.depthTexture.enabled) {
       this.depthTextures = new DepthTextures(options);
@@ -268,6 +272,7 @@ export class Depth {
     depthDataFormat: XRDepthDataFormat
   ) {
     this.cpuDepthData[viewId] = depthData;
+    this.depthDataFormat = depthDataFormat;
     this.updateDepthMatrices(depthData, viewId);
 
     // Updates Depth Array.
@@ -305,10 +310,12 @@ export class Depth {
     // In the future, add a separate option.
     const needCpuDepth = this.options.depthMesh.enabled;
     const cpuDepth =
-      needCpuDepth && this.depthMesh
-        ? this.depthMesh.convertGPUToGPU(depthData)
+      needCpuDepth && this.gpuDepthConverter
+        ? this.gpuDepthConverter.convertGPUToCPU(depthData)
         : null;
     if (cpuDepth) {
+      this.cpuDepthData[viewId] = cpuDepth;
+      this.depthDataFormat = 'float32';
       if (this.depthArray[viewId] instanceof Float32Array) {
         this.depthArray[viewId].set(new Float32Array(cpuDepth.data));
       } else {
@@ -330,11 +337,6 @@ export class Depth {
             cpuDepth,
             this.depthProjectionInverseMatrices[0],
             'float32'
-          );
-        } else {
-          this.depthMesh.updateGPUDepth(
-            depthData,
-            this.depthProjectionInverseMatrices[0]
           );
         }
       }
@@ -480,5 +482,21 @@ export class Depth {
   pauseDepth(client: object) {
     this.depthClientsInitialized = true;
     this.depthClients.delete(client);
+  }
+
+  /**
+   * Manually updates the depth mesh geometry using the cached depth.
+   */
+  updateFullResolutionDepthMesh() {
+    if (
+      this.depthMesh &&
+      this.cpuDepthData.length > 0 &&
+      this.depthDataFormat
+    ) {
+      this.depthMesh.updateFullResolutionGeometry(
+        this.cpuDepthData[0],
+        this.depthDataFormat
+      );
+    }
   }
 }

--- a/src/depth/DepthMesh.ts
+++ b/src/depth/DepthMesh.ts
@@ -37,12 +37,6 @@ export class DepthMesh extends MeshScript {
   private options: DepthMeshOptions;
   private depthTextureMaterialUniforms?;
 
-  private depthTarget!: THREE.WebGLRenderTarget;
-  private depthTexture!: THREE.ExternalTexture;
-  private depthScene!: THREE.Scene;
-  private depthCamera!: THREE.OrthographicCamera;
-  private gpuPixels!: Float32Array;
-
   private RAPIER?: typeof RAPIER_NS;
   private blendedWorld?: RAPIER_NS.World;
   private rigidBody?: RAPIER_NS.RigidBody;
@@ -212,110 +206,6 @@ export class DepthMesh extends MeshScript {
       this.downsampledMesh.quaternion.copy(quaternion);
       this.downsampledMesh.updateMatrixWorld();
     }
-  }
-
-  updateGPUDepth(
-    depthData: Readonly<XRWebGLDepthInformation>,
-    projectionMatrixInverse: Readonly<THREE.Matrix4>
-  ) {
-    this.updateDepth(
-      this.convertGPUToGPU(depthData),
-      projectionMatrixInverse,
-      'float32'
-    );
-  }
-
-  // Converts unsigned short GPU depth from Quest 3 to float32 CPU depth.
-  convertGPUToGPU(depthData: Readonly<XRWebGLDepthInformation>) {
-    if (!this.depthTarget) {
-      this.depthTarget = new THREE.WebGLRenderTarget(
-        depthData.width,
-        depthData.height,
-        {
-          format: THREE.RedFormat,
-          type: THREE.FloatType,
-          internalFormat: 'R32F',
-          minFilter: THREE.NearestFilter,
-          magFilter: THREE.NearestFilter,
-          depthBuffer: false,
-        }
-      );
-      this.depthTexture = new THREE.ExternalTexture(depthData.texture);
-      const textureProperties = this.renderer.properties.get(
-        this.depthTexture
-      ) as {
-        __webglTexture: WebGLTexture;
-        __version: number;
-      };
-      textureProperties.__webglTexture = depthData.texture;
-      this.gpuPixels = new Float32Array(depthData.width * depthData.height);
-
-      const depthShader = new THREE.ShaderMaterial({
-        vertexShader: `
-                varying vec2 vUv;
-                void main() {
-                    vUv = uv;
-                    vUv.y = 1.0-vUv.y;
-                    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-                }
-            `,
-        fragmentShader: `
-                precision highp float;
-                precision highp sampler2DArray;
-
-                uniform sampler2DArray uTexture;
-                uniform float uCameraNear;
-                varying vec2 vUv;
-
-                void main() {
-                  float z = texture(uTexture, vec3(vUv, 0)).r;
-                  z = uCameraNear / (1.0 - z);
-                  z = clamp(z, 0.0, 20.0);
-                  gl_FragColor = vec4(z, 0, 0, 1.0);
-                }
-            `,
-        uniforms: {
-          uTexture: {value: this.depthTexture},
-          uCameraNear: {
-            value: (depthData as unknown as {depthNear: number}).depthNear,
-          },
-        },
-        blending: THREE.NoBlending,
-        depthTest: false,
-        depthWrite: false,
-        side: THREE.DoubleSide,
-      });
-      const depthMesh = new THREE.Mesh(
-        new THREE.PlaneGeometry(2, 2),
-        depthShader
-      );
-      this.depthScene = new THREE.Scene();
-      this.depthScene.add(depthMesh);
-      this.depthCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
-    }
-
-    const originalRenderTarget = this.renderer.getRenderTarget();
-    this.renderer.xr.enabled = false;
-    this.renderer.setRenderTarget(this.depthTarget);
-    this.renderer.render(this.depthScene, this.depthCamera);
-    this.renderer.readRenderTargetPixels(
-      this.depthTarget,
-      0,
-      0,
-      depthData.width,
-      depthData.height,
-      this.gpuPixels,
-      0
-    );
-    this.renderer.xr.enabled = true;
-    this.renderer.setRenderTarget(originalRenderTarget);
-
-    return {
-      width: depthData.width,
-      height: depthData.height,
-      data: this.gpuPixels.buffer,
-      rawValueToMeters: depthData.rawValueToMeters,
-    } as XRCPUDepthInformation;
   }
 
   /**

--- a/src/depth/GPUDepthConverter.ts
+++ b/src/depth/GPUDepthConverter.ts
@@ -1,0 +1,108 @@
+import * as THREE from 'three';
+
+export class GPUDepthConverter {
+  private depthTarget!: THREE.WebGLRenderTarget;
+  private depthTexture!: THREE.ExternalTexture;
+  private depthScene!: THREE.Scene;
+  private depthCamera!: THREE.OrthographicCamera;
+  private gpuPixels!: Float32Array;
+
+  constructor(private renderer: THREE.WebGLRenderer) {}
+
+  /**
+   * Converts unsigned short GPU depth from Quest 3 to float32 CPU depth.
+   */
+  convertGPUToCPU(
+    depthData: Readonly<XRWebGLDepthInformation>
+  ): XRCPUDepthInformation {
+    if (!this.depthTarget) {
+      this.depthTarget = new THREE.WebGLRenderTarget(
+        depthData.width,
+        depthData.height,
+        {
+          format: THREE.RedFormat,
+          type: THREE.FloatType,
+          internalFormat: 'R32F',
+          minFilter: THREE.NearestFilter,
+          magFilter: THREE.NearestFilter,
+          depthBuffer: false,
+        }
+      );
+      this.depthTexture = new THREE.ExternalTexture(depthData.texture);
+      const textureProperties = this.renderer.properties.get(
+        this.depthTexture
+      ) as {
+        __webglTexture: WebGLTexture;
+        __version: number;
+      };
+      textureProperties.__webglTexture = depthData.texture;
+      this.gpuPixels = new Float32Array(depthData.width * depthData.height);
+
+      const depthShader = new THREE.ShaderMaterial({
+        vertexShader: `
+                varying vec2 vUv;
+                void main() {
+                    vUv = uv;
+                    vUv.y = 1.0-vUv.y;
+                    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+                }
+            `,
+        fragmentShader: `
+                precision highp float;
+                precision highp sampler2DArray;
+
+                uniform sampler2DArray uTexture;
+                uniform float uCameraNear;
+                varying vec2 vUv;
+
+                void main() {
+                  float z = texture(uTexture, vec3(vUv, 0)).r;
+                  z = uCameraNear / (1.0 - z);
+                  z = clamp(z, 0.0, 20.0);
+                  gl_FragColor = vec4(z, 0, 0, 1.0);
+                }
+            `,
+        uniforms: {
+          uTexture: {value: this.depthTexture},
+          uCameraNear: {
+            value: (depthData as unknown as {depthNear: number}).depthNear,
+          },
+        },
+        blending: THREE.NoBlending,
+        depthTest: false,
+        depthWrite: false,
+        side: THREE.DoubleSide,
+      });
+      const depthMesh = new THREE.Mesh(
+        new THREE.PlaneGeometry(2, 2),
+        depthShader
+      );
+      this.depthScene = new THREE.Scene();
+      this.depthScene.add(depthMesh);
+      this.depthCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+    }
+
+    const originalRenderTarget = this.renderer.getRenderTarget();
+    this.renderer.xr.enabled = false;
+    this.renderer.setRenderTarget(this.depthTarget);
+    this.renderer.render(this.depthScene, this.depthCamera);
+    this.renderer.readRenderTargetPixels(
+      this.depthTarget,
+      0,
+      0,
+      depthData.width,
+      depthData.height,
+      this.gpuPixels,
+      0
+    );
+    this.renderer.xr.enabled = true;
+    this.renderer.setRenderTarget(originalRenderTarget);
+
+    return {
+      width: depthData.width,
+      height: depthData.height,
+      data: this.gpuPixels.buffer,
+      rawValueToMeters: depthData.rawValueToMeters,
+    } as XRCPUDepthInformation;
+  }
+}


### PR DESCRIPTION
- Add session-wide depthDataFormat caching to Depth.ts.
- Refactor WebGL GPU-to-CPU depth conversion into src/depth/GPUDepthConverter.ts.
- Simplify DepthMesh to strictly accept CPU depth, removing all conversion properties and logic.
- Add updateFullResolutionDepthMesh() parameterless helper to Depth.ts.
- Update demos/splash/SplashScript.js to call updateFullResolutionDepthMesh().