### PR TITLE
refactor: migrate THREE.Clock to THREE.Timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ code below:
       import * as xb from 'xrblocks';
 
       /**
-       * A basic example of XRBlocks to render a cylinder and pinch to change its color.
+       * A basic example of XR Blocks to render a cylinder and pinch to change its color.
        */
       class MainScript extends xb.Script {
         init() {

--- a/demos/portals/PortalGalleryScene.js
+++ b/demos/portals/PortalGalleryScene.js
@@ -53,7 +53,6 @@ export class PortalGalleryScene extends xb.Script {
   portals = [];
   labels = [];
   immersives = []; // index -> ImmersiveInstance | null
-  clock = new THREE.Clock();
   _held = null;
   _activeIndex = -1; // Portal index user has walked into, or -1.
   _activeImmersive = null;
@@ -222,7 +221,7 @@ export class PortalGalleryScene extends xb.Script {
   }
 
   update() {
-    const dt = Math.min(this.clock.getDelta(), 0.05);
+    const dt = Math.min(xb.getDeltaTime(), 0.05);
     const cam = xb.core.camera;
 
     // Animate fade transition and keep it centered on camera.

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -65,7 +65,7 @@ export class Core {
   registry = new Registry();
 
   /**
-   * A clock for tracking time deltas. Call clock.getDeltaTime().
+   * A timer for tracking time deltas. Call timer.getDelta() or getDeltaTime().
    */
   timer = new THREE.Timer();
 

--- a/src/input/GazeController.ts
+++ b/src/input/GazeController.ts
@@ -32,7 +32,7 @@ export class GazeController
   extends Script<GazeControllerEventMap>
   implements Controller
 {
-  static dependencies = {camera: THREE.Camera};
+  static dependencies = {camera: THREE.Camera, timer: THREE.Timer};
 
   /**
    * User data for the controller, including its connection status, unique ID,
@@ -68,15 +68,16 @@ export class GazeController
   lastReticlePosition = new THREE.Vector3();
 
   /**
-   * A clock to measure the time delta between frames for smooth animation and
+   * A timer to measure the time delta between frames for smooth animation and
    * movement calculation.
    */
-  clock = new THREE.Clock();
+  timer!: THREE.Timer;
 
   camera!: THREE.Camera;
 
-  init({camera}: {camera: THREE.Camera}) {
+  init({camera, timer}: {camera: THREE.Camera; timer: THREE.Timer}) {
     this.camera = camera;
+    this.timer = timer;
   }
 
   /**
@@ -89,7 +90,7 @@ export class GazeController
     this.position.copy(this.camera.position);
     this.quaternion.copy(this.camera.quaternion);
     this.updateMatrixWorld();
-    const delta = this.clock.getDelta();
+    const delta = this.timer.getDelta();
     this.activationAmount.update(delta);
     const movement =
       this.lastReticlePosition.distanceTo(this.reticle.position) / delta;

--- a/src/ui/interaction/ModelViewer.ts
+++ b/src/ui/interaction/ModelViewer.ts
@@ -72,6 +72,7 @@ export class ModelViewer extends Script implements Draggable {
     scene: THREE.Scene,
     renderer: THREE.WebGLRenderer,
     registry: Registry,
+    timer: THREE.Timer,
   };
 
   draggable = true;
@@ -85,7 +86,7 @@ export class ModelViewer extends Script implements Draggable {
   clipActions: THREE.AnimationAction[] = [];
 
   private data?: GLTFData | SplatData;
-  private clock = new THREE.Clock();
+  private timer!: THREE.Timer;
   private animationMixer?: THREE.AnimationMixer;
   private gltfMesh?: GLTF;
   private splatMesh?: SplatMesh;
@@ -121,18 +122,21 @@ export class ModelViewer extends Script implements Draggable {
     scene,
     renderer,
     registry,
+    timer,
   }: {
     camera: THREE.Camera;
     depth: Depth;
     scene: THREE.Scene;
     renderer: THREE.WebGLRenderer;
     registry: Registry;
+    timer: THREE.Timer;
   }) {
     this.camera = camera;
     this.depth = depth;
     this.scene = scene;
     this.renderer = renderer;
     this.registry = registry;
+    this.timer = timer;
 
     for (const shader of this.occludableShaders) {
       this.depth!.occludableShaders.add(shader);
@@ -424,7 +428,7 @@ export class ModelViewer extends Script implements Draggable {
   }
 
   update() {
-    const delta = this.clock.getDelta();
+    const delta = this.timer.getDelta();
     if (this.animationMixer) {
       this.animationMixer.update(delta);
     }


### PR DESCRIPTION
- Inject global THREE.Timer into ModelViewer and GazeController via static dependencies.
- Replace local clocks with the injected timer to avoid duplicate time updates.
- Remove clock in PortalGalleryScene demo and query xb.getDeltaTime() directly.
- Update stale JSDoc comments referencing 'Clock' or 'clock.getDeltaTime()' in Core and GazeController.