### PR TITLE
Upgrade @sparkjsdev/spark to 2.1.0 to fix shader issue

### DIFF
--- a/demos/3dgs_walkthrough/index.html
+++ b/demos/3dgs_walkthrough/index.html
@@ -16,7 +16,7 @@
         "imports": {
           "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
           "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
-          "@sparkjsdev/spark": "https://sparkjs.dev/releases/spark/2.0.0/spark.module.js",
+          "@sparkjsdev/spark": "https://sparkjs.dev/releases/spark/2.1.0/spark.module.js",
           "xrblocks": "../../build/xrblocks.js",
           "xrblocks/addons/": "../../build/addons/"
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@rollup/plugin-replace": "^6.0.2",
         "@rollup/plugin-terser": "^1.0.0",
         "@rollup/plugin-typescript": "^12.1.4",
-        "@sparkjsdev/spark": "^2.0.0",
+        "@sparkjsdev/spark": "^2.1.0",
         "@types/dom-speech-recognition": "^0.0.7",
         "@types/node": "^25.0.8",
         "@types/three": "^0.184.0",
@@ -1653,16 +1653,16 @@
       ]
     },
     "node_modules/@sparkjsdev/spark": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sparkjsdev/spark/-/spark-2.0.0.tgz",
-      "integrity": "sha512-W1p7NM4xXcUAVVcVus2mIFwcAC3VckyE0l4wXJuSmhcOgb6hHpqhQ/Ks9MK9ts7j23K+UwbCBwe+aTc/zgGygw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@sparkjsdev/spark/-/spark-2.1.0.tgz",
+      "integrity": "sha512-BRw+MuMzx0B3K8fDLQygt2OHEhYUV+41RX7btq9pZ3rCVrq42o57jW34VAIvC7JO/84DJh/1AutACV9ym6BfVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
       },
       "peerDependencies": {
-        "three": "^0.180.0"
+        "three": ">=0.180.0"
       }
     },
     "node_modules/@tweenjs/tween.js": {

--- a/package.json
+++ b/package.json
@@ -74,10 +74,5 @@
   },
   "peerDependencies": {
     "three": "^0.184.0"
-  },
-  "overrides": {
-    "@sparkjsdev/spark": {
-      "three": ">=0.180.0"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@rollup/plugin-replace": "^6.0.2",
     "@rollup/plugin-terser": "^1.0.0",
     "@rollup/plugin-typescript": "^12.1.4",
-    "@sparkjsdev/spark": "^2.0.0",
+    "@sparkjsdev/spark": "^2.1.0",
     "@types/dom-speech-recognition": "^0.0.7",
     "@types/node": "^25.0.8",
     "@types/three": "^0.184.0",

--- a/samples/modelviewer/index.html
+++ b/samples/modelviewer/index.html
@@ -31,7 +31,7 @@
           "lit/": "https://esm.run/lit@3/",
           "xrblocks": "../../build/xrblocks.js",
           "xrblocks/addons/": "../../build/addons/",
-          "@sparkjsdev/spark": "https://sparkjs.dev/releases/spark/2.0.0/spark.module.js"
+          "@sparkjsdev/spark": "https://sparkjs.dev/releases/spark/2.1.0/spark.module.js"
         }
       }
     </script>


### PR DESCRIPTION
Fixes a GLSL shader compilation crash caused by the 'packed' reserved keyword in v2.0.0. Also updates importmap CDN URLs in walkthrough and modelviewer demos.