### PR TITLE
Upgrade actions/cache to v5 in workflows

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: 📦 Cache Node Modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-root-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Cache Node Modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-root-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/docs-build-check.yml
+++ b/.github/workflows/docs-build-check.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Cache Root Node Modules
         id: cache-root-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-root-${{ hashFiles('package-lock.json') }}
@@ -50,7 +50,7 @@ jobs:
 
       - name: Cache Docs Node Modules
         id: cache-docs-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: docs/node_modules
           key: ${{ runner.os }}-node-docs-${{ hashFiles('docs/package-lock.json') }}

--- a/.github/workflows/lint-format-check.yml
+++ b/.github/workflows/lint-format-check.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Cache Node Modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: ${{ runner.os }}-node-root-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
Upgrade actions/cache from v4 to v5 in build-check, build-branch, docs-build-check, and lint-format-check workflows to execute on Node 24 and eliminate deprecation warnings for Node 20 actions. Workflows will be forced to run on Node 24 from June 6, 2026.