### PR TITLE
Add support for downsampled depth mesh geometry in ObjectDetector

### DIFF
--- a/src/world/objects/ObjectDetector.ts
+++ b/src/world/objects/ObjectDetector.ts
@@ -202,16 +202,20 @@ export class ObjectDetector extends Script {
   }
 
   private getDepthMeshSnapshot() {
-    const clonedGeometry = this.depth.depthMesh!.geometry.clone();
+    const depthMesh = this.depth.depthMesh!;
+    const geometry = this.depth.options.depthMesh.updateFullResolutionGeometry
+      ? depthMesh.geometry
+      : depthMesh.downsampledGeometry || depthMesh.geometry;
+    const clonedGeometry = geometry.clone();
     clonedGeometry.computeBoundingSphere();
     clonedGeometry.computeBoundingBox();
     const depthMeshSnapshot = new THREE.Mesh(
       clonedGeometry,
       new THREE.MeshBasicMaterial()
     );
-    this.depth.depthMesh!.getWorldPosition(depthMeshSnapshot.position);
-    this.depth.depthMesh!.getWorldQuaternion(depthMeshSnapshot.quaternion);
-    this.depth.depthMesh!.getWorldScale(depthMeshSnapshot.scale);
+    depthMesh.getWorldPosition(depthMeshSnapshot.position);
+    depthMesh.getWorldQuaternion(depthMeshSnapshot.quaternion);
+    depthMesh.getWorldScale(depthMeshSnapshot.scale);
     depthMeshSnapshot.updateMatrixWorld(true);
     return depthMeshSnapshot;
   }


### PR DESCRIPTION
When `updateFullResolutionGeometry` is disabled (the default behavior in xrDepthMeshOptions), the full-resolution `depthMesh.geometry` is never updated with depth data and remains a flat 1x1 plane. This caused raycasting during object detection to hit the flat plane at the camera's origin (distance 0), placing all detected objects exactly at the camera's world coordinates (e.g., (0, 1.5, 0)).

This change updates `getDepthMeshSnapshot` to clone `depthMesh.downsampledGeometry` if available. Since `downsampledGeometry` is always updated with the active depth data, this ensures raycasting operates on the real depth mesh surface and places 3D markers correctly.