### PR TITLE
CC0 animation and use cdn paths

### DIFF
--- a/demos/vrm-avatar/README.md
+++ b/demos/vrm-avatar/README.md
@@ -1,6 +1,6 @@
 # VRM Avatar — XRBlocks Demo
 
-A point-to-walk VRM avatar demo built on [XRBlocks](https://github.com/google/xrblocks). Click (or pinch in XR) anywhere on the floor and the avatar walks there, then returns to idle. Spring bones, facial expressions, and Mixamo animation retargeting all work out of the box.
+A point-to-walk VRM avatar demo built on [XRBlocks](https://github.com/google/xrblocks). Click (or pinch in XR) anywhere on the floor and the avatar walks there, then returns to idle. Spring bones, facial expressions, and Mesh2Motion animation retargeting all work out of the box.
 
 ![Demo: point-to-walk avatar in XRBlocks simulator]()
 
@@ -9,7 +9,7 @@ A point-to-walk VRM avatar demo built on [XRBlocks](https://github.com/google/xr
 ## What it does
 
 - Loads any `.vrm` file using `@pixiv/three-vrm`
-- Retargets Mixamo FBX animations onto the VRM humanoid skeleton
+- Retargets CC0 Mesh2Motion GLB animations onto the VRM humanoid skeleton
 - Crossfades between idle and walk animations
 - Walks the avatar to a floor point selected by the user via controller ray or mouse click
 - Procedural eye blink using VRM expression manager
@@ -21,33 +21,17 @@ A point-to-walk VRM avatar demo built on [XRBlocks](https://github.com/google/xr
 
 ```
 demos/vrm-avatar/
-  index.html          — entry point, import map, scene setup
+  index.html          — entry point, import map
+  main.js             — entry point script (scene setup, VRMAvatarScript configuration)
   VRMAvatar.js        — utility class: VRM load, animation, blink, update()
   VRMAvatarScript.js  — xb.Script subclass: scene lifecycle, point-to-walk
-  models/             — place your .vrm file here
-  animations/         — place your Mixamo .fbx files here
 ```
 
 ---
 
-## Assets required
+## Assets loaded
 
-The VRM model is loaded automatically via CDN and requires no manual download. The Mixamo animation files are **not included in the repo** and must be downloaded manually:
-
-| File                     | Source                                                    |
-| ------------------------ | --------------------------------------------------------- |
-| `animations/Idle.fbx`    | [Mixamo](https://www.mixamo.com/) — free account required |
-| `animations/Walking.fbx` | [Mixamo](https://www.mixamo.com/) — free account required |
-
-### Downloading Mixamo animations
-
-1. Go to [mixamo.com](https://www.mixamo.com/) and sign in with a free Adobe account.
-2. Search for **Idle** — select any standing idle animation, set **In Place** if available.
-3. Click **Download**, choose **FBX Binary (.fbx)**, and select **Without Skin**.
-4. Save the file as `animations/Idle.fbx` inside `demos/vrm-avatar/`.
-5. Repeat for **Walking**, saving as `animations/Walking.fbx`.
-
-The FBX files cannot be redistributed in this repo due to Mixamo's license terms.
+The VRM model and all animation assets (T-pose, idle, and walking GLB files) are loaded automatically via CDN and a GitHub assets repository, requiring no manual downloads or local asset management.
 
 ---
 
@@ -56,8 +40,8 @@ The FBX files cannot be redistributed in this repo due to Mixamo's license terms
 **Why not `xb.ModelViewer`?**
 `VRMLoaderPlugin` must be registered on the `GLTFLoader` instance before the load call. `xb.ModelViewer` is a display container with no loader injection point, so `GLTFLoader` is used directly.
 
-**Mixamo retargeting**
-`VRMAvatar.js` includes a full `MIXAMO_VRM_RIG_MAP` (sourced from the three-vrm examples) and a `retargetMixamoClip()` function that remaps bone names and corrects rest-pose rotations. Root motion on the hips X/Z axes is zeroed out to prevent position drift on loop.
+**Mesh2Motion retargeting**
+`VRMAvatar.js` includes a full `MESH2MOTION_VRM_RIG_MAP` mapping Mesh2Motion bone naming conventions to the VRM 1.0 specification. `retargetGLBClip()` remaps bone names, utilizes `Tpose.glb` as a pristine reference rest pose, and corrects rest-pose rotations. Root motion on the hips X/Z axes is zeroed out to prevent position drift on loop.
 
 **Depth mesh floor detection**
 On device, `onSelectEnd` raycasts against `xb.core.depth.depthMesh` for accurate floor hits. When depth mesh is not enabled, it falls back to intersecting the y=0 ground plane.
@@ -66,9 +50,9 @@ On device, `onSelectEnd` raycasts against `xb.core.depth.depthMesh` for accurate
 
 ## Known gaps
 
-- **`.vrma` format** — `@pixiv/three-vrm-animation` (VRM Animation format) is not used. Mixamo FBX retargeting is sufficient for walk/idle.
+- **`.vrma` format** — `@pixiv/three-vrm-animation` (VRM Animation format) is not used. Mesh2Motion GLB retargeting is sufficient for walk/idle.
 - **First-person mode** — VRM first-person metadata (head mesh hiding) is not configured.
-- **MToon** — MToon anime-style materials load correctly at `three@0.184.0` but may render as standard material fallback on some devices.
+- **MToon** — MToon anime-style materials load correctly at `three@0.182.0` but may render as standard material fallback on some devices.
 - **Quest test** — simulator tested and working. Depth sensing is enabled via `options.enableDepth()` using the standard WebXR Depth Sensing API, which Quest 3 supports, but on-device testing has not been done yet.
 
 ---
@@ -77,7 +61,7 @@ On device, `onSelectEnd` raycasts against `xb.core.depth.depthMesh` for accurate
 
 | Package            | Version   | Source      |
 | ------------------ | --------- | ----------- |
-| `three`            | `0.184.0` | CDN         |
+| `three`            | `0.182.0` | CDN         |
 | `@pixiv/three-vrm` | `^3`      | CDN         |
 | `xrblocks`         | `0.12.0`  | Local build |
 | `xrblocks/addons/` | `0.12.0`  | Local build |

--- a/demos/vrm-avatar/VRMAvatar.js
+++ b/demos/vrm-avatar/VRMAvatar.js
@@ -1,8 +1,8 @@
 /**
  * VRMAvatar.js
  *
- * Utility class that wraps VRM loading, per-frame update, and Mixamo animation
- * retargeting. Designed as a proto-addon following the RainParticles pattern:
+ * Utility class that wraps VRM loading, per-frame update, and Mesh2Motion GLB
+ * animation retargeting. Designed as a proto-addon following the RainParticles pattern:
  * plain JS class, no XRBlocks lifecycle dependencies, fully reusable.
  *
  * Usage:
@@ -15,156 +15,174 @@
 
 import * as THREE from 'three';
 import {GLTFLoader} from 'three/addons/loaders/GLTFLoader.js';
-import {FBXLoader} from 'three/addons/loaders/FBXLoader.js';
 import {VRMLoaderPlugin, VRMUtils} from '@pixiv/three-vrm';
 
 // ---------------------------------------------------------------------------
-// Mixamo → VRM HumanoidBone name map
-// Sourced from three-vrm examples/humanoidAnimation/mixamoVRMRigMap.js
+// Mesh2Motion → VRM HumanoidBone name map
+// Fully populated for CC0 Mesh2Motion humanoid bone naming conventions.
 // ---------------------------------------------------------------------------
-const MIXAMO_VRM_RIG_MAP = {
-  mixamorigHips: 'hips',
-  mixamorigSpine: 'spine',
-  mixamorigSpine1: 'chest',
-  mixamorigSpine2: 'upperChest',
-  mixamorigNeck: 'neck',
-  mixamorigHead: 'head',
-  mixamorigLeftShoulder: 'leftShoulder',
-  mixamorigLeftArm: 'leftUpperArm',
-  mixamorigLeftForeArm: 'leftLowerArm',
-  mixamorigLeftHand: 'leftHand',
-  mixamorigLeftHandThumb1: 'leftThumbMetacarpal',
-  mixamorigLeftHandThumb2: 'leftThumbProximal',
-  mixamorigLeftHandThumb3: 'leftThumbDistal',
-  mixamorigLeftHandIndex1: 'leftIndexProximal',
-  mixamorigLeftHandIndex2: 'leftIndexIntermediate',
-  mixamorigLeftHandIndex3: 'leftIndexDistal',
-  mixamorigLeftHandMiddle1: 'leftMiddleProximal',
-  mixamorigLeftHandMiddle2: 'leftMiddleIntermediate',
-  mixamorigLeftHandMiddle3: 'leftMiddleDistal',
-  mixamorigLeftHandRing1: 'leftRingProximal',
-  mixamorigLeftHandRing2: 'leftRingIntermediate',
-  mixamorigLeftHandRing3: 'leftRingDistal',
-  mixamorigLeftHandPinky1: 'leftLittleProximal',
-  mixamorigLeftHandPinky2: 'leftLittleIntermediate',
-  mixamorigLeftHandPinky3: 'leftLittleDistal',
-  mixamorigRightShoulder: 'rightShoulder',
-  mixamorigRightArm: 'rightUpperArm',
-  mixamorigRightForeArm: 'rightLowerArm',
-  mixamorigRightHand: 'rightHand',
-  mixamorigRightHandThumb1: 'rightThumbMetacarpal',
-  mixamorigRightHandThumb2: 'rightThumbProximal',
-  mixamorigRightHandThumb3: 'rightThumbDistal',
-  mixamorigRightHandIndex1: 'rightIndexProximal',
-  mixamorigRightHandIndex2: 'rightIndexIntermediate',
-  mixamorigRightHandIndex3: 'rightIndexDistal',
-  mixamorigRightHandMiddle1: 'rightMiddleProximal',
-  mixamorigRightHandMiddle2: 'rightMiddleIntermediate',
-  mixamorigRightHandMiddle3: 'rightMiddleDistal',
-  mixamorigRightHandRing1: 'rightRingProximal',
-  mixamorigRightHandRing2: 'rightRingIntermediate',
-  mixamorigRightHandRing3: 'rightRingDistal',
-  mixamorigRightHandPinky1: 'rightLittleProximal',
-  mixamorigRightHandPinky2: 'rightLittleIntermediate',
-  mixamorigRightHandPinky3: 'rightLittleDistal',
-  mixamorigLeftUpLeg: 'leftUpperLeg',
-  mixamorigLeftLeg: 'leftLowerLeg',
-  mixamorigLeftFoot: 'leftFoot',
-  mixamorigLeftToeBase: 'leftToes',
-  mixamorigRightUpLeg: 'rightUpperLeg',
-  mixamorigRightLeg: 'rightLowerLeg',
-  mixamorigRightFoot: 'rightFoot',
-  mixamorigRightToeBase: 'rightToes',
+const MESH2MOTION_VRM_RIG_MAP = {
+  pelvis: 'hips',
+  spine_01: 'spine',
+  spine_02: 'chest',
+  spine_03: 'upperChest',
+  neck_01: 'neck',
+  head: 'head',
+
+  clavicle_l: 'leftShoulder',
+  upperarm_l: 'leftUpperArm',
+  lowerarm_l: 'leftLowerArm',
+  hand_l: 'leftHand',
+  thumb_01_l: 'leftThumbMetacarpal',
+  thumb_02_l: 'leftThumbProximal',
+  thumb_03_l: 'leftThumbDistal',
+  index_01_l: 'leftIndexProximal',
+  index_02_l: 'leftIndexIntermediate',
+  index_03_l: 'leftIndexDistal',
+  middle_01_l: 'leftMiddleProximal',
+  middle_02_l: 'leftMiddleIntermediate',
+  middle_03_l: 'leftMiddleDistal',
+  ring_01_l: 'leftRingProximal',
+  ring_02_l: 'leftRingIntermediate',
+  ring_03_l: 'leftRingDistal',
+  pinky_01_l: 'leftLittleProximal',
+  pinky_02_l: 'leftLittleIntermediate',
+  pinky_03_l: 'leftLittleDistal',
+
+  clavicle_r: 'rightShoulder',
+  upperarm_r: 'rightUpperArm',
+  lowerarm_r: 'rightLowerArm',
+  hand_r: 'rightHand',
+  thumb_01_r: 'rightThumbMetacarpal',
+  thumb_02_r: 'rightThumbProximal',
+  thumb_03_r: 'rightThumbDistal',
+  index_01_r: 'rightIndexProximal',
+  index_02_r: 'rightIndexIntermediate',
+  index_03_r: 'rightIndexDistal',
+  middle_01_r: 'rightMiddleProximal',
+  middle_02_r: 'rightMiddleIntermediate',
+  middle_03_r: 'rightMiddleDistal',
+  ring_01_r: 'rightRingProximal',
+  ring_02_r: 'rightRingIntermediate',
+  ring_03_r: 'rightRingDistal',
+  pinky_01_r: 'rightLittleProximal',
+  pinky_02_r: 'rightLittleIntermediate',
+  pinky_03_r: 'rightLittleDistal',
+
+  thigh_l: 'leftUpperLeg',
+  calf_l: 'leftLowerLeg',
+  foot_l: 'leftFoot',
+  ball_l: 'leftToes',
+
+  thigh_r: 'rightUpperLeg',
+  calf_r: 'rightLowerLeg',
+  foot_r: 'rightFoot',
+  ball_r: 'rightToes',
 };
 
 // ---------------------------------------------------------------------------
-// Retarget a Mixamo FBX AnimationClip onto a loaded VRM's humanoid skeleton.
+// Retarget a GLB AnimationClip onto a loaded VRM's humanoid skeleton.
 // Returns a new AnimationClip compatible with the VRM's bone names.
-// Based on three-vrm examples/humanoidAnimation/loadMixamoAnimation.js
 // ---------------------------------------------------------------------------
 /**
- * Retargets a Mixamo FBX AnimationClip onto a loaded VRM's humanoid skeleton.
+ * Retargets a GLB AnimationClip onto a loaded VRM's humanoid skeleton.
  * Returns a new AnimationClip compatible with the VRM's bone names.
- * @param {THREE.AnimationClip} clip The Mixamo animation clip.
- * @param {THREE.Group} fbxScene The loaded FBX scene containing the rig.
+ * @param {THREE.AnimationClip} clip The source GLB animation clip.
+ * @param {THREE.Group} gltfScene The loaded GLTF scene containing the rig.
  * @param {object} vrm The loaded VRM instance.
+ * @param {string} [rootBoneName=null] Optional specific root/hips bone name.
  * @returns {THREE.AnimationClip} A new AnimationClip compatible with the VRM's bone names.
  */
-function retargetMixamoClip(clip, fbxScene, vrm) {
+function retargetGLBClip(
+  clip,
+  gltfScene,
+  vrm,
+  restGlbScene = null,
+  rootBoneName = null
+) {
   const tracks = [];
   const restRotationInverse = new THREE.Quaternion();
   const parentRestWorldRotation = new THREE.Quaternion();
   const _quatA = new THREE.Quaternion();
 
-  // Find hips with the actual name in the FBX
+  // Use the shared rest scene (Idle) if available to guarantee a perfectly symmetric rest pose evaluation.
+  // This prevents the asymmetric split-step pose of Walking.glb Frame 0 from causing limping.
+  const referenceScene = restGlbScene || gltfScene;
+
+  // Locate hips node specifically
   let hipsNode = null;
-  fbxScene.traverse((obj) => {
-    if (!hipsNode && obj.name.match(/^mixamorig\d*Hips$/)) {
-      hipsNode = obj;
+  referenceScene.traverse((obj) => {
+    if (!hipsNode) {
+      if (rootBoneName && obj.name === rootBoneName) {
+        hipsNode = obj;
+      } else if (!rootBoneName && obj.name.match(/^(pelvis|Hips|hips)$/i)) {
+        hipsNode = obj;
+      }
     }
   });
-  const motionHipsHeight = hipsNode?.position.y || 1;
+
+  const motionHipsHeight = Math.max(0.1, hipsNode?.position.z || 1);
   const vrmHipsHeight = vrm.humanoid.normalizedRestPose.hips.position[1];
   const hipsPositionScale = vrmHipsHeight / motionHipsHeight;
 
-  // Force world matrix computation
-  fbxScene.updateMatrixWorld(true);
+  referenceScene.updateMatrixWorld(true);
 
   for (const track of clip.tracks) {
     const nameParts = track.name.split('.');
-    const mixamoRigName = nameParts[0];
+    const nodeNameOrUuid = nameParts[0];
     const propertyName = nameParts[1];
 
-    // Normalize bone name for rig map lookup
-    const normalizedName = mixamoRigName.replace(/^mixamorig\d*/, 'mixamorig');
-    const vrmBoneName = MIXAMO_VRM_RIG_MAP[normalizedName];
+    // Look up the node in the symmetric reference scene to compute correct rest quaternions
+    let sourceNode = referenceScene.getObjectByName(nodeNameOrUuid);
+    if (!sourceNode) {
+      sourceNode = referenceScene.getObjectByProperty('uuid', nodeNameOrUuid);
+    }
+    if (!sourceNode) continue;
+
+    const vrmBoneName = MESH2MOTION_VRM_RIG_MAP[sourceNode.name];
     if (!vrmBoneName) continue;
 
-    const vrmNodeName = vrm.humanoid?.getNormalizedBoneNode(vrmBoneName)?.name;
-    if (!vrmNodeName) continue;
+    const vrmNode = vrm.humanoid?.getNormalizedBoneNode(vrmBoneName);
+    if (!vrmNode) continue;
+    const vrmNodeName = vrmNode.name;
 
-    // Use actual FBX bone name (with number prefix)
-    const mixamoRigNode = fbxScene.getObjectByName(mixamoRigName);
-    if (!mixamoRigNode) continue;
-
-    // Store rotations of rest-pose using world quaternions (official approach)
-    mixamoRigNode.getWorldQuaternion(restRotationInverse).invert();
-    mixamoRigNode.parent.getWorldQuaternion(parentRestWorldRotation);
+    // Store rotations of the proven rest-pose using world quaternions (exactly as in Test 1 & 3 when the avatar looked normal)
+    sourceNode.getWorldQuaternion(restRotationInverse).invert();
+    sourceNode.parent.getWorldQuaternion(parentRestWorldRotation);
 
     if (track instanceof THREE.QuaternionKeyframeTrack) {
+      const values = new Float32Array(track.values.length);
       for (let i = 0; i < track.values.length; i += 4) {
-        const flatQuaternion = track.values.slice(i, i + 4);
-        _quatA.fromArray(flatQuaternion);
+        _quatA.fromArray(track.values, i);
 
+        // Transform rotation using proven premultiply/multiply math
         _quatA
           .premultiply(parentRestWorldRotation)
           .multiply(restRotationInverse);
 
-        _quatA.toArray(flatQuaternion);
-        flatQuaternion.forEach((v, index) => {
-          track.values[index + i] = v;
-        });
+        _quatA.toArray(values, i);
       }
 
-      // VRM1: no sign flip needed
       tracks.push(
         new THREE.QuaternionKeyframeTrack(
           `${vrmNodeName}.${propertyName}`,
           track.times,
-          track.values.slice()
+          values
         )
       );
     } else if (track instanceof THREE.VectorKeyframeTrack) {
-      // VRM1: keep Y (vertical bob) but zero X/Z on hips to strip root motion.
-      // Without this, Mixamo walk animations snap back on every loop cycle.
-      const value = track.values.map((v, i) =>
-        vrmBoneName === 'hips' && i % 3 !== 1 ? 0 : v * hipsPositionScale
-      );
+      const values = [];
+      for (let i = 0; i < track.values.length; i += 3) {
+        const z = track.values[i + 2];
+        // Map GLB Z to VRM Y, and add 0.25m (25cm) adjustment to keep feet perfectly on the floor
+        values.push(0, z * hipsPositionScale + 0.25, 0);
+      }
+
       tracks.push(
         new THREE.VectorKeyframeTrack(
           `${vrmNodeName}.${propertyName}`,
           track.times,
-          value
+          values
         )
       );
     }
@@ -245,24 +263,38 @@ export class VRMAvatar {
   }
 
   /**
-   * Loads a Mixamo FBX, retargets it onto the VRM skeleton, and registers it
+   * Loads a Mesh2Motion GLB, retargets it onto the VRM skeleton, and registers it
    * as a named action. Call after load().
    * @param {string} name Logical name, e.g., 'idle' or 'walk'.
-   * @param {string} fbxUrl URL to the Mixamo .fbx file.
+   * @param {string} glbUrl URL to the Mesh2Motion .glb file.
+   * @param {string} tposeUrl URL to the Tpose GLB.
    * @returns {Promise<void>}
    */
-  async loadMixamoAnimation(name, fbxUrl) {
-    if (!this.vrm) throw new Error('Call load() before loadMixamoAnimation().');
+  async loadGLBAnimation(name, glbUrl, tposeUrl) {
+    if (!this.vrm) throw new Error('Call load() before loadGLBAnimation().');
 
-    const fbxLoader = new FBXLoader();
-    const fbxScene = await fbxLoader.loadAsync(fbxUrl);
+    const loader = new GLTFLoader();
 
-    if (!fbxScene.animations || fbxScene.animations.length === 0) {
-      throw new Error(`No animations found in FBX: ${fbxUrl}`);
+    // Load the pristine T-pose reference scene exactly once to guarantee perfect rest pose evaluation
+    if (!this._restGlbScene) {
+      if (!tposeUrl) throw new Error('[VRMAvatar] tposeUrl is required to load animations.');
+      const tposeGltf = await loader.loadAsync(tposeUrl);
+      this._restGlbScene = tposeGltf.scene;
     }
 
-    const rawClip = fbxScene.animations[0];
-    const retargeted = retargetMixamoClip(rawClip, fbxScene, this.vrm);
+    const gltf = await loader.loadAsync(glbUrl);
+
+    if (!gltf.animations || gltf.animations.length === 0) {
+      throw new Error(`No animations found in GLB: ${glbUrl}`);
+    }
+
+    const rawClip = gltf.animations[0];
+    const retargeted = retargetGLBClip(
+      rawClip,
+      gltf.scene,
+      this.vrm,
+      this._restGlbScene
+    );
     const action = this.mixer.clipAction(retargeted);
 
     this._actions[name] = action;
@@ -275,7 +307,7 @@ export class VRMAvatar {
 
   /**
    * Crossfades to a named animation.
-   * @param {string} name Clip name registered via loadMixamoAnimation.
+   * @param {string} name Clip name registered via loadGLBAnimation.
    * @param {number} [fadeDuration=0.3] Duration of the fade in seconds.
    * @returns {void}
    */
@@ -313,6 +345,7 @@ export class VRMAvatar {
 
     this.vrm.update(delta);
   }
+
   // -------------------------------------------------------------------------
   // Expression helpers
   // -------------------------------------------------------------------------

--- a/demos/vrm-avatar/VRMAvatar.js
+++ b/demos/vrm-avatar/VRMAvatar.js
@@ -277,7 +277,8 @@ export class VRMAvatar {
 
     // Load the pristine T-pose reference scene exactly once to guarantee perfect rest pose evaluation
     if (!this._restGlbScene) {
-      if (!tposeUrl) throw new Error('[VRMAvatar] tposeUrl is required to load animations.');
+      if (!tposeUrl)
+        throw new Error('[VRMAvatar] tposeUrl is required to load animations.');
       const tposeGltf = await loader.loadAsync(tposeUrl);
       this._restGlbScene = tposeGltf.scene;
     }

--- a/demos/vrm-avatar/VRMAvatarScript.js
+++ b/demos/vrm-avatar/VRMAvatarScript.js
@@ -8,8 +8,8 @@
  *
  * Options (passed to constructor):
  *   vrmUrl        {string}  URL to the .vrm file
- *   idleUrl       {string}  URL to the Mixamo idle FBX
- *   walkUrl       {string}  URL to the Mixamo walk FBX
+ *   idleUrl       {string}  URL to the idle GLB
+ *   walkUrl       {string}  URL to the walk GLB
  *   walkSpeed     {number}  m/s avatar walking speed; default 1.0
  *   arrivalDist   {number}  metres from target to count as arrived; default 0.25
  *   rotateLerp    {number}  slerp factor per frame for turning; default 0.08
@@ -26,8 +26,9 @@ export class VRMAvatarScript extends xb.Script {
    * Constructs a new VRMAvatarScript.
    * @param {object} [opts={}] Initialization options.
    * @param {string} [opts.vrmUrl=''] URL to the .vrm file.
-   * @param {string} [opts.idleUrl=''] URL to the Mixamo idle FBX.
-   * @param {string} [opts.walkUrl=''] URL to the Mixamo walk FBX.
+   * @param {string} [opts.idleUrl=''] URL to the idle GLB.
+   * @param {string} [opts.walkUrl=''] URL to the walk GLB.
+   * @param {string} [opts.tposeUrl=''] URL to the Tpose GLB.
    * @param {number} [opts.walkSpeed=1.0] Avatar walking speed in m/s.
    * @param {number} [opts.arrivalDist=0.25] Metres from target to count as arrived.
    * @param {number} [opts.rotateLerp=0.08] Slerp factor per frame for turning.
@@ -39,8 +40,9 @@ export class VRMAvatarScript extends xb.Script {
     this._vrmUrl = opts.vrmUrl ?? '';
     this._idleUrl = opts.idleUrl ?? '';
     this._walkUrl = opts.walkUrl ?? '';
+    this._tposeUrl = opts.tposeUrl ?? '';
 
-    this._walkSpeed = opts.walkSpeed ?? 1.0; // m/s
+    this._walkSpeed = opts.walkSpeed ?? 0.6; // m/s
     this._arrivalDist = opts.arrivalDist ?? 0.25; // m
     this._rotateLerp = opts.rotateLerp ?? 0.08;
     this._spawnDistance = opts.spawnDistance ?? 1.8; // m ahead of user at spawn
@@ -73,17 +75,21 @@ export class VRMAvatarScript extends xb.Script {
       console.error('[VRMAvatarScript] vrmUrl is required.');
       return;
     }
+    if (!this._tposeUrl) {
+      console.error('[VRMAvatarScript] tposeUrl is required.');
+      return;
+    }
 
     console.log('[VRMAvatarScript] Loading VRM…');
     await this._avatar.load(this._vrmUrl);
 
     if (this._idleUrl) {
       console.log('[VRMAvatarScript] Loading idle animation…');
-      await this._avatar.loadMixamoAnimation('idle', this._idleUrl);
+      await this._avatar.loadGLBAnimation('idle', this._idleUrl, this._tposeUrl);
     }
     if (this._walkUrl) {
       console.log('[VRMAvatarScript] Loading walk animation…');
-      await this._avatar.loadMixamoAnimation('walk', this._walkUrl);
+      await this._avatar.loadGLBAnimation('walk', this._walkUrl, this._tposeUrl);
     }
 
     this.add(this._avatar.root);

--- a/demos/vrm-avatar/VRMAvatarScript.js
+++ b/demos/vrm-avatar/VRMAvatarScript.js
@@ -85,11 +85,19 @@ export class VRMAvatarScript extends xb.Script {
 
     if (this._idleUrl) {
       console.log('[VRMAvatarScript] Loading idle animation…');
-      await this._avatar.loadGLBAnimation('idle', this._idleUrl, this._tposeUrl);
+      await this._avatar.loadGLBAnimation(
+        'idle',
+        this._idleUrl,
+        this._tposeUrl
+      );
     }
     if (this._walkUrl) {
       console.log('[VRMAvatarScript] Loading walk animation…');
-      await this._avatar.loadGLBAnimation('walk', this._walkUrl, this._tposeUrl);
+      await this._avatar.loadGLBAnimation(
+        'walk',
+        this._walkUrl,
+        this._tposeUrl
+      );
     }
 
     this.add(this._avatar.root);

--- a/demos/vrm-avatar/index.html
+++ b/demos/vrm-avatar/index.html
@@ -19,8 +19,8 @@
       {
         "imports": {
           "@dimforge/rapier3d-simd-compat": "https://cdn.jsdelivr.net/npm/@dimforge/rapier3d-simd-compat@0.19.2/rapier.mjs",
-          "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
-          "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
+          "three": "https://cdn.jsdelivr.net/npm/three@0.182.0/build/three.module.js",
+          "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.182.0/examples/jsm/",
           "troika-three-text": "https://cdn.jsdelivr.net/gh/protectwise/troika@028b81cf308f0f22e5aa8e78196be56ec1997af5/packages/troika-three-text/src/index.js",
           "troika-three-utils": "https://cdn.jsdelivr.net/gh/protectwise/troika@v0.52.4/packages/troika-three-utils/src/index.js",
           "troika-worker-utils": "https://cdn.jsdelivr.net/gh/protectwise/troika@v0.52.4/packages/troika-worker-utils/src/index.js",
@@ -37,65 +37,6 @@
   </head>
 
   <body>
-    <script type="module">
-      // Provides 2D simulator UI on desktop — always import first.
-      import 'xrblocks/addons/simulator/SimulatorAddons.js';
-
-      import * as THREE from 'three';
-      import * as xb from 'xrblocks';
-
-      import {VRMAvatarScript} from './VRMAvatarScript.js';
-
-      // ---------------------------------------------------------------------------
-      // Asset URLs — swap these for your own VRM / FBX files.
-      // VRM: the sample model bundled in the three-vrm repository.
-      // FBX: free Mixamo downloads (no character needed, just animations).
-      // ---------------------------------------------------------------------------
-      const VRM_URL =
-        'https://cdn.jsdelivr.net/gh/pixiv/three-vrm@3.5.1/packages/three-vrm-animation/examples/models/VRM1_Constraint_Twist_Sample.vrm';
-      const IDLE_URL = 'animations/Idle.fbx'; // ← put your Mixamo idle FBX here
-      const WALK_URL = 'animations/Walking.fbx'; // ← put your Mixamo walk FBX here
-
-      // ---------------------------------------------------------------------------
-      // Minimal scene setup (lights + ground grid for visual reference)
-      // ---------------------------------------------------------------------------
-      class SceneSetup extends xb.Script {
-        init() {
-          this.add(new THREE.HemisphereLight(0xffffff, 0x666666, 3));
-
-          const dirLight = new THREE.DirectionalLight(0xffffff, 2);
-          dirLight.position.set(1, 3, 1).normalize();
-          this.add(dirLight);
-
-          // Ground grid for spatial reference in the simulator.
-          const grid = new THREE.GridHelper(10, 20, 0x888888, 0x444444);
-          grid.position.y = 0;
-          this.add(grid);
-        }
-      }
-
-      // ---------------------------------------------------------------------------
-      // Entry point
-      // ---------------------------------------------------------------------------
-      document.addEventListener('DOMContentLoaded', async () => {
-        xb.add(new SceneSetup());
-
-        xb.add(
-          new VRMAvatarScript({
-            vrmUrl: VRM_URL,
-            idleUrl: IDLE_URL,
-            walkUrl: WALK_URL,
-
-            rotateLerp: 0.08,
-          })
-        );
-
-        const options = new xb.Options();
-        options.enableDepth();
-        options.setAppTitle('VRM Avatar Companion');
-
-        await xb.init(options);
-      });
-    </script>
+    <script type="module" src="main.js"></script>
   </body>
 </html>

--- a/demos/vrm-avatar/main.js
+++ b/demos/vrm-avatar/main.js
@@ -1,0 +1,61 @@
+// Provides 2D simulator UI on desktop — always import first.
+import 'xrblocks/addons/simulator/SimulatorAddons.js';
+
+import * as THREE from 'three';
+import * as xb from 'xrblocks';
+
+import {VRMAvatarScript} from './VRMAvatarScript.js';
+
+// ---------------------------------------------------------------------------
+// Asset URLs — swap these for your own VRM / FBX files.
+// VRM: the sample model bundled in the three-vrm repository.
+// FBX: free Mixamo downloads (no character needed, just animations).
+// ---------------------------------------------------------------------------
+const VRM_URL =
+  'https://cdn.jsdelivr.net/gh/pixiv/three-vrm@3.5.1/packages/three-vrm-animation/examples/models/VRM1_Constraint_Twist_Sample.vrm';
+const ASSETS_BASE_URL = 'https://cdn.jsdelivr.net/gh/xrblocks/assets@main/';
+const TPOSE_URL = ASSETS_BASE_URL + 'avatars/Tpose.glb';
+const IDLE_URL = ASSETS_BASE_URL + 'avatars/IdleListening.glb';
+const WALK_URL = ASSETS_BASE_URL + 'avatars/Walking.glb';
+
+// ---------------------------------------------------------------------------
+// Minimal scene setup (lights + ground grid for visual reference)
+// ---------------------------------------------------------------------------
+class SceneSetup extends xb.Script {
+  init() {
+    this.add(new THREE.HemisphereLight(0xffffff, 0x666666, 3));
+
+    const dirLight = new THREE.DirectionalLight(0xffffff, 2);
+    dirLight.position.set(1, 3, 1).normalize();
+    this.add(dirLight);
+
+    // Ground grid for spatial reference in the simulator.
+    const grid = new THREE.GridHelper(10, 20, 0x888888, 0x444444);
+    grid.position.y = 0;
+    this.add(grid);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+document.addEventListener('DOMContentLoaded', async () => {
+  xb.add(new SceneSetup());
+
+  xb.add(
+    new VRMAvatarScript({
+      vrmUrl: VRM_URL,
+      tposeUrl: TPOSE_URL,
+      idleUrl: IDLE_URL,
+      walkUrl: WALK_URL,
+
+      rotateLerp: 0.08,
+    })
+  );
+
+  const options = new xb.Options();
+  options.enableDepth();
+  options.setAppTitle('VRM Avatar Companion');
+
+  await xb.init(options);
+});


### PR DESCRIPTION
Scrapped the use of Mixamo animations and rigging. Using CC0 animations from Mesh2Motion. Use cdn paths to load the animations automatically. The cdn paths of the animations are now pointing to the xrblocks asset repo.