### PR TITLE
Add uikit options for automatic @pmndrs/uikit renderer setup

### DIFF
--- a/samples/glasses_ui/main.ts
+++ b/samples/glasses_ui/main.ts
@@ -1,6 +1,6 @@
 import 'xrblocks/addons/simulator/SimulatorAddons.js';
 
-import {reversePainterSortStable} from '@pmndrs/uikit';
+import * as uikit from '@pmndrs/uikit';
 import * as THREE from 'three';
 import * as xb from 'xrblocks';
 import {SystemUI} from 'xrblocks/addons/glasses/ui/SystemUI.js';
@@ -86,10 +86,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   options.simulator.instructions.enabled = false;
   options.simulator.handPosePanel.enabled = false;
   options.simulator.renderToRenderTexture = false;
+  options.uikit.enable(uikit);
   xb.add(new GlassesUISample());
   await xb.init(options);
-  // Setup for @pmndrs/uikit.
-  const renderer = xb.core.renderer;
-  renderer.localClippingEnabled = true;
-  renderer.setTransparentSort(reversePainterSortStable);
 });

--- a/samples/uiblocks/index.html
+++ b/samples/uiblocks/index.html
@@ -33,7 +33,7 @@
 
   <body>
     <script type="module">
-      import {reversePainterSortStable} from '@pmndrs/uikit';
+      import * as uikit from '@pmndrs/uikit';
       import * as THREE from 'three';
       import {
         UICore,
@@ -53,10 +53,6 @@
         }
 
         async init() {
-          const renderer = xb.core.renderer;
-          renderer.localClippingEnabled = true;
-          renderer.setTransparentSort(reversePainterSortStable);
-
           if (xb.core.input.raycaster) {
             xb.core.input.raycaster.sortFunction = raycastSortFunction;
           }
@@ -198,6 +194,7 @@
       document.addEventListener('DOMContentLoaded', () => {
         const options = new xb.Options();
         options.enableUI();
+        options.uikit.enable(uikit);
         options.setAppTitle('uiblocks Sample');
         xb.add(new MainScript());
         xb.init(options);

--- a/src/addons/uiblocks/README.md
+++ b/src/addons/uiblocks/README.md
@@ -127,10 +127,10 @@ Create a base document mounting an entry `main.js` module script:
 
 #### 2. Initialize the UI Framework (`main.js`)
 
-Compose layout blocks extending `xb.Script` using standard transparency depth filters overriding ambient sort structures accurately:
+Compose layout blocks extending `xb.Script` and use the uikit option for automatic renderer configuration:
 
 ```javascript
-import {reversePainterSortStable} from '@pmndrs/uikit';
+import * as uikit from '@pmndrs/uikit';
 import * as THREE from 'three';
 import {UICore, UIPanel, UIText, raycastSortFunction} from 'uiblocks';
 import * as xb from 'xrblocks';
@@ -142,10 +142,6 @@ class CustomScript extends xb.Script {
   }
 
   async init() {
-    // Configure Depth Filters for transparency sorting
-    const renderer = xb.core.renderer;
-    renderer.localClippingEnabled = true;
-    renderer.setTransparentSort(reversePainterSortStable);
     // This is a must-have for raycasting to work.
     if (xb.core.input.raycaster) {
       xb.core.input.raycaster.sortFunction = raycastSortFunction;
@@ -190,16 +186,11 @@ class CustomScript extends xb.Script {
 
 // Bootstrap immersive loop
 async function start() {
-  await xb.core.init({
-    canvas: document.createElement('canvas'),
-  });
-  document.body.appendChild(xb.core.canvas);
-
-  xb.core.scene.add(new THREE.AmbientLight(0xffffff, 1));
-  xb.core.scene.add(new THREE.DirectionalLight(0xffffff, 1));
-
-  xb.core.addScript(new CustomScript());
-  xb.core.start();
+  const options = new xb.Options();
+  options.enableUI();
+  options.uikit.enable(uikit);
+  xb.add(new CustomScript());
+  await xb.init(options);
 }
 document.addEventListener('DOMContentLoaded', start);
 ```

--- a/src/addons/uiblocks/samples/Sample.ts
+++ b/src/addons/uiblocks/samples/Sample.ts
@@ -1,4 +1,4 @@
-import {reversePainterSortStable} from '@pmndrs/uikit';
+import * as uikit from '@pmndrs/uikit';
 import * as THREE from 'three';
 import {UICard, UICore, UIPanel, UIText, raycastSortFunction} from 'uiblocks';
 import * as xb from 'xrblocks';
@@ -21,9 +21,6 @@ export abstract class Sample extends xb.Script {
   }
 
   async init() {
-    const renderer = xb.core.renderer;
-    renderer.localClippingEnabled = true;
-    renderer.setTransparentSort(reversePainterSortStable);
     (xb.core.input.raycaster as RaycasterWithSort).sortFunction =
       raycastSortFunction;
 
@@ -89,6 +86,7 @@ export abstract class Sample extends xb.Script {
     async function start() {
       const options = new xb.Options();
       options.enableUI();
+      options.uikit.enable(uikit);
       options.reticles.enabled = true;
       options.controllers.visualizeRays = false;
       options.simulator.instructions.enabled = false;

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -38,6 +38,7 @@ import {XRButton} from './components/XRButton';
 import {XREffects} from './components/XREffects';
 import {XRTransition} from './components/XRTransition';
 import {Options} from './Options';
+import {UIKitOptions} from './UIKitOptions';
 import {Script} from './Script';
 import {User} from './User';
 import {PermissionsManager} from './components/PermissionsManager';
@@ -190,6 +191,7 @@ export class Core {
     this.registry.register(options.simulator, SimulatorOptions);
     this.registry.register(options.world, WorldOptions);
     this.registry.register(options.world.meshes, MeshDetectionOptions);
+    this.registry.register(options.uikit, UIKitOptions);
     this.registry.register(options.ai, AIOptions);
     this.registry.register(options.sound, SoundOptions);
     this.registry.register(options.gestures, GestureRecognitionOptions);
@@ -226,6 +228,15 @@ export class Core {
       return null;
     };
     this.registry.register(this.renderer);
+
+    if (options.uikit.enabled) {
+      this.renderer.localClippingEnabled = true;
+      if (options.uikit.reversePainterSortStable) {
+        this.renderer.setTransparentSort(
+          options.uikit.reversePainterSortStable
+        );
+      }
+    }
 
     this.renderer.xr.setReferenceSpaceType(options.referenceSpaceType);
     // For desktop simulator:

--- a/src/core/Options.ts
+++ b/src/core/Options.ts
@@ -14,6 +14,7 @@ import {SimulatorOptions} from '../simulator/SimulatorOptions';
 import {SoundOptions} from '../sound/SoundOptions';
 import {deepMerge} from '../utils/OptionsUtils';
 import {DeepPartial, DeepReadonly} from '../utils/Types';
+import {UIKitOptions} from './UIKitOptions.js';
 import {WorldOptions} from '../world/WorldOptions';
 import {getUrlParameter} from '../utils/utils';
 
@@ -113,6 +114,7 @@ export class Options {
   ai = new AIOptions();
   simulator = new SimulatorOptions();
   world = new WorldOptions();
+  uikit = new UIKitOptions();
   physics = new PhysicsOptions();
   transition = new XRTransitionOptions();
   camera = {

--- a/src/core/UIKitOptions.ts
+++ b/src/core/UIKitOptions.ts
@@ -1,0 +1,26 @@
+import type {RenderItem} from 'three';
+
+/**
+ * Options for configuring integration with \@pmndrs/uikit.
+ */
+export class UIKitOptions {
+  /** Whether UIKit support is enabled. */
+  enabled = false;
+
+  /** The custom sorting function provided by \@pmndrs/uikit. */
+  reversePainterSortStable?: (a: RenderItem, b: RenderItem) => number;
+
+  /**
+   * Enables \@pmndrs/uikit integration.
+   *
+   * @param uikit - The imported `@pmndrs/uikit` module instance.
+   * @returns The instance for chaining.
+   */
+  enable(uikit: {
+    reversePainterSortStable: (a: RenderItem, b: RenderItem) => number;
+  }): this {
+    this.enabled = true;
+    this.reversePainterSortStable = uikit.reversePainterSortStable;
+    return this;
+  }
+}

--- a/src/xrblocks.ts
+++ b/src/xrblocks.ts
@@ -21,6 +21,7 @@ export * from './core/components/XRButton';
 export * from './core/components/XREffects';
 export * from './core/Core';
 export * from './core/Options';
+export * from './core/UIKitOptions';
 export * from './core/Script';
 export * from './core/User';
 export * from './depth/Depth';

--- a/templates/uikit/main.js
+++ b/templates/uikit/main.js
@@ -104,12 +104,10 @@ class UikitTemplate extends xb.Script {
 
 const options = new xb.Options();
 options.enableUI();
+options.uikit.enable(uikit);
 
 document.addEventListener('DOMContentLoaded', async function () {
   xb.add(new UikitTemplate());
   options.simulator.instructions.enabled = false;
   await xb.init(options);
-  const renderer = xb.core.renderer;
-  renderer.localClippingEnabled = true;
-  renderer.setTransparentSort(uikit.reversePainterSortStable);
 });


### PR DESCRIPTION
Introduces the UIKitOptions class that automatically configures Three.js's WebGLRenderer when @pmndrs/uikit is enabled (setting localClippingEnabled to true and registering reversePainterSortStable as the custom transparent sort). This also sets the stage to make uikit available to internal XR Blocks components in the future.

Before:
```javascript
import {reversePainterSortStable} from '@pmndrs/uikit';
// ...
await xb.init(options);
const renderer = xb.core.renderer;
renderer.localClippingEnabled = true;
renderer.setTransparentSort(reversePainterSortStable);
```

After:
```javascript
import * as uikit from '@pmndrs/uikit';
// ...
options.uikit.enable(uikit);
await xb.init(options);
```