### PR TITLE
widen AI.query input to accept GeminiQueryInput

### DIFF
--- a/src/ai/AI.ts
+++ b/src/ai/AI.ts
@@ -5,7 +5,7 @@ import {getUrlParameter} from '../utils/utils';
 
 import {AIOptions, GeminiOptions, OpenAIOptions} from './AIOptions';
 import {GeminiResponse} from './AITypes';
-import {Gemini} from './Gemini';
+import {Gemini, GeminiQueryInput} from './Gemini';
 import {OpenAI} from './OpenAI';
 
 export type ModelClass = Gemini | OpenAI;
@@ -175,12 +175,20 @@ export class AI extends Script {
   }
 
   async query(
-    input: {prompt: string},
+    input: GeminiQueryInput | {prompt: string},
     tools?: never[]
   ): Promise<GeminiResponse | string | null> {
     if (!this.isAvailable()) {
       throw new Error(
         "AI is not available. Check if it's enabled and properly initialized."
+      );
+    }
+    if (this.model instanceof Gemini) {
+      return await this.model.query(input);
+    }
+    if (typeof input !== 'object' || input === null || !('prompt' in input)) {
+      throw new Error(
+        `${this.options.model} only supports {prompt: string} query inputs.`
       );
     }
     return await this.model!.query(input, tools);


### PR DESCRIPTION
per the thread on #338, the public input type on `AI.query` is just `{prompt: string}` so multipart / uri / base64 don't typecheck from a .ts caller, even though `Gemini.query` handles them fine at runtime.

widens it. also routes through the model so OpenAI throws a clear error instead of sending undefined content when given a non-prompt shape.