### PR TITLE
fix AI.generate dispatch + isAvailable check

### DIFF
--- a/src/ai/AI.ts
+++ b/src/ai/AI.ts
@@ -258,7 +258,15 @@ export class AI extends Script {
     systemInstruction = 'Generate an image',
     model = undefined
   ) {
-    return this.model!.generate(prompt, type, systemInstruction, model);
+    if (!this.isAvailable()) {
+      throw new Error(
+        "AI is not available. Check if it's enabled and properly initialized."
+      );
+    }
+    if (this.model instanceof Gemini) {
+      return this.model.generate(prompt, type, systemInstruction, model);
+    }
+    throw new Error(`${this.options.model} does not support generate().`);
   }
 
   /**


### PR DESCRIPTION
if you've got OpenAI configured, `xb.ai.generate(...)` just throws 'Wrapper not implemented' because OpenAI's `generate` takes 0 args. same dispatch as #343, bail early for backends that don't do generate.
