### PR TITLE
MaterialSymbolsView: read viewBox via getAttribute

### DIFF
--- a/src/ui/components/MaterialSymbolsView.ts
+++ b/src/ui/components/MaterialSymbolsView.ts
@@ -119,9 +119,12 @@ export class MaterialSymbolsView extends View {
     });
     this.loadingSvgPath = undefined;
     this.loadedSvgPath = svgPath;
-    const [viewMinX, viewMinY, viewWidth, viewHeight] =
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (svgData.xml as any).attributes.viewBox.value.split(' ');
+    const viewBox = (svgData.xml as unknown as Element).getAttribute(
+      'viewBox'
+    )!;
+    const [viewMinX, viewMinY, viewWidth, viewHeight] = viewBox
+      .split(' ')
+      .map(Number);
     const paths = svgData.paths;
     const group = new THREE.Group();
 


### PR DESCRIPTION
`as any` was needed because `@types/three` mistypes `SVGResult.xml` as `XMLDocument` when at runtime it's actually `xml.documentElement` (Element).

dropped the cast, uses `getAttribute('viewBox')` instead of the quirky `.attributes.viewBox.value` named-property access. also `.map(Number)` on the split parts, since the old code relied on `as any` to launder the strings into numbers for the arithmetic below.
