### PR TITLE
netblocks: fix import path in skill + readme examples

### DIFF
--- a/skills/xb-netblocks/SKILL.md
+++ b/skills/xb-netblocks/SKILL.md
@@ -31,7 +31,7 @@ import * as xb from 'xrblocks';
 import {
   enableNet,
   BroadcastChannelTransport,
-} from 'xrblocks/addons/netblocks/src';
+} from 'xrblocks/addons/netblocks/src/index.js';
 
 class MyApp extends xb.Script {
   async init() {
@@ -52,7 +52,10 @@ xb.init();
 ## Share an object
 
 ```ts
-import {NetObject, WebRTCTransport} from 'xrblocks/addons/netblocks/src';
+import {
+  NetObject,
+  WebRTCTransport,
+} from 'xrblocks/addons/netblocks/src/index.js';
 
 const shared = new NetObject({id: 'cube', object: this.cube});
 const net = enableNet();

--- a/src/addons/netblocks/README.md
+++ b/src/addons/netblocks/README.md
@@ -33,7 +33,7 @@ import * as xb from 'xrblocks';
 import {
   enableNet,
   BroadcastChannelTransport,
-} from 'xrblocks/addons/netblocks/src';
+} from 'xrblocks/addons/netblocks/src/index.js';
 
 class MyApp extends xb.Script {
   async init() {

--- a/src/addons/netblocks/SKILL.md
+++ b/src/addons/netblocks/SKILL.md
@@ -36,7 +36,7 @@ import * as xb from 'xrblocks';
 import {
   enableNet,
   BroadcastChannelTransport,
-} from 'xrblocks/addons/netblocks/src';
+} from 'xrblocks/addons/netblocks/src/index.js';
 
 class MyApp extends xb.Script {
   async init() {
@@ -64,7 +64,7 @@ Wrap any `Object3D` in a `NetObject` and register it; owners broadcast, non-owne
 Ownership is cooperative — claim on grab, release on drop.
 
 ```ts
-import {NetObject, WebRTCTransport} from 'xrblocks/addons/netblocks/src';
+import {NetObject, WebRTCTransport} from 'xrblocks/addons/netblocks/src/index.js';
 
 const sharedCube = new NetObject({id: 'cube', object: this.cube});
 const net = enableNet();

--- a/src/addons/netblocks/SKILL.md
+++ b/src/addons/netblocks/SKILL.md
@@ -64,7 +64,10 @@ Wrap any `Object3D` in a `NetObject` and register it; owners broadcast, non-owne
 Ownership is cooperative — claim on grab, release on drop.
 
 ```ts
-import {NetObject, WebRTCTransport} from 'xrblocks/addons/netblocks/src/index.js';
+import {
+  NetObject,
+  WebRTCTransport,
+} from 'xrblocks/addons/netblocks/src/index.js';
 
 const sharedCube = new NetObject({id: 'cube', object: this.cube});
 const net = enableNet();


### PR DESCRIPTION
`'xrblocks/addons/netblocks/src'` returns 404 on `cdn.jsdelivr.net/gh/google/xrblocks@build/...` because browser importmaps don't have node-style index resolution. needs the explicit `/index.js`.

caught while testing an eval harness against the canvas-gem skill setup, every with-skill run failed in headless chromium with `net::ERR_ABORTED` on the netblocks import.

the netblocks README already uses the `/index.js` form one block down (line 80), so this just makes the rest of the file consistent. same for the skill.
