### PR TITLE
lipsync: add skill files + fix import path in readme

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -31,8 +31,9 @@ The `xb-` prefix matches the `xb` import alias.
 | [`xb-physics`](xb-physics/SKILL.md)         | Add Rapier rigid-body physics                                     |
 | [`xb-simulator`](xb-simulator/SKILL.md)     | Develop/test in the desktop simulator                             |
 | [`xb-netblocks`](xb-netblocks/SKILL.md)     | Add multiplayer presence, shared objects, voice                   |
+| [`xb-lipsync`](xb-lipsync/SKILL.md)         | Drive audio-driven avatar mouths from any `MediaStream`           |
 | [`xb-sound`](xb-sound/SKILL.md)             | Play spatial audio, record, recognize/synthesize speech           |
 
 Deep references some skills link to live next to the code:
 [`../src/SKILL.md`](../src/SKILL.md), [`../src/addons/uiblocks/SKILL.md`](../src/addons/uiblocks/SKILL.md),
-[`../src/addons/netblocks/SKILL.md`](../src/addons/netblocks/SKILL.md).
+[`../src/addons/netblocks/SKILL.md`](../src/addons/netblocks/SKILL.md), [`../src/addons/lipsync/SKILL.md`](../src/addons/lipsync/SKILL.md).

--- a/skills/xb-lipsync/SKILL.md
+++ b/skills/xb-lipsync/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: xb-lipsync
+description: >-
+  Add audio-driven avatar mouths to an XR Blocks app with the lipsync addon — heuristic
+  vowel-formant viseme mapping that turns any `MediaStream` (mic or remote peer's voice)
+  into mouth shapes on a `StylizedFace` decal attached to an avatar's head. Zero ML
+  runtime, no model download. Use when you want shared rooms to stop being silent
+  spheres and become faces that visibly speak, or to lip-sync a TTS playback to an NPC.
+  Covers `LipsyncMouth`, `xb.StylizedFace`, the `target`/`audioContext`/`fftSize` constructor
+  options, and the `session.voice.onTrack` netblocks pairing. Lower-level pieces
+  (`FormantVisemeMapper`, `MfccExtractor`, `computeAudioFeatures`) and types
+  (`VisemeWeights`, `VisemeTarget`) are exported for swapping in a model-based mapper.
+  Full reference at src/addons/lipsync/.
+---
+
+# xb-lipsync: audio-driven mouths
+
+A `LipsyncMouth` is an `xb.Script` that pulls audio from a `MediaStream`, runs an FFT + formant analyser every frame, and writes viseme weights to a `target` (anything with `setVisemes(VisemeWeights)`, typically `xb.StylizedFace` or `user.avatar.face` on a netblocks avatar). The face primitive (`xb.StylizedFace`) is a 256×256 canvas decal anchored to the head sphere's local `-Z` so the mouth always points forward.
+
+> **Full reference**: [`../../src/addons/lipsync/SKILL.md`](../../src/addons/lipsync/SKILL.md) and [`../../src/addons/lipsync/README.md`](../../src/addons/lipsync/README.md).
+
+## When to use
+
+Pair with [`xb-netblocks`](../xb-netblocks/SKILL.md) so every remote peer's voice stream drives their own mouth. Single-user setups work too (TTS playback, mic-test puppet, NPC dialogue). For full ML-grade phoneme accuracy plug a model into the same pipeline via the exported `FormantVisemeMapper` / `MfccExtractor` surface.
+
+## Quick start
+
+Single user, mic into a standalone head:
+
+```ts
+import * as xb from 'xrblocks';
+import {LipsyncMouth} from 'xrblocks/addons/lipsync/index.js';
+
+class MyApp extends xb.Script {
+  async init() {
+    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const face = new xb.StylizedFace({showEyes: false});
+    headPivot.add(face);
+    const driver = new LipsyncMouth(stream, {target: face});
+    headPivot.add(driver);
+  }
+}
+xb.add(new MyApp());
+xb.init();
+```
+
+The scripts manager calls `init()` once and `update(time)` every frame on `driver` and `face`. `dispose()` runs after removal from the scene. The driver does NOT dispose the target face. The caller owns it.
+
+## Netblocks integration
+
+`RemoteUserAvatar` already attaches a `StylizedFace` to every remote peer, so just point `LipsyncMouth` at it. Pass a shared `AudioContext` because browsers cap contexts at around six per page.
+
+```ts
+import * as THREE from 'three';
+import {LipsyncMouth} from 'xrblocks/addons/lipsync/index.js';
+
+protected override onSession(session) {
+  const sharedCtx = THREE.AudioContext.getContext();
+  session.voice.onTrack((peerId, stream) => {
+    const user = session.users.get(peerId);
+    if (!user) return;
+    const driver = new LipsyncMouth(stream, {
+      target: user.avatar.face,
+      audioContext: sharedCtx,
+    });
+    user.avatar.add(driver);
+  });
+}
+```
+
+`session.voice.onTrack` is additive, so this runs alongside (not instead of) netblocks' own `SpatialVoice.attach`. Peers both see mouths and hear each other.
+
+## Lifecycle
+
+- Caller owns the `MediaStream`. `dispose()` disconnects audio nodes but never stops tracks.
+- Caller owns the `AudioContext` when passed in. If omitted, `LipsyncMouth` creates and closes its own.
+- Caller owns the `target` face. `dispose()` resets the target to its rest pose but never disposes it.
+- Instances are one-shot. After dispose, construct a new `LipsyncMouth`.

--- a/skills/xb-lipsync/SKILL.md
+++ b/skills/xb-lipsync/SKILL.md
@@ -48,22 +48,39 @@ The scripts manager calls `init()` once and `update(time)` every frame on `drive
 
 ## Netblocks integration
 
-`RemoteUserAvatar` already attaches a `StylizedFace` to every remote peer, so just point `LipsyncMouth` at it. Pass a shared `AudioContext` because browsers cap contexts at around six per page.
+`RemoteUserAvatar` already attaches a `StylizedFace` to every remote peer, so just point `LipsyncMouth` at it. Pass a shared `AudioContext` because browsers cap contexts at around six per page. Track drivers per peer so mic mute / unmute / leave doesn't leak.
 
 ```ts
 import * as THREE from 'three';
 import {LipsyncMouth} from 'xrblocks/addons/lipsync/index.js';
 
+private drivers = new Map<string, LipsyncMouth>();
+private sharedCtx = THREE.AudioContext.getContext();
+
+private detachDriver(peerId: string) {
+  const prior = this.drivers.get(peerId);
+  if (prior) {
+    prior.dispose();
+    prior.removeFromParent();
+    this.drivers.delete(peerId);
+  }
+}
+
 protected override onSession(session) {
-  const sharedCtx = THREE.AudioContext.getContext();
   session.voice.onTrack((peerId, stream) => {
     const user = session.users.get(peerId);
     if (!user) return;
+    this.detachDriver(peerId);
     const driver = new LipsyncMouth(stream, {
       target: user.avatar.face,
-      audioContext: sharedCtx,
+      audioContext: this.sharedCtx,
     });
     user.avatar.add(driver);
+    this.drivers.set(peerId, driver);
+  });
+  session.voice.onTrackRemoved((peerId) => this.detachDriver(peerId));
+  session.addEventListener('user-leave', (e) => {
+    this.detachDriver(e.detail.user.peerId);
   });
 }
 ```

--- a/src/addons/lipsync/README.md
+++ b/src/addons/lipsync/README.md
@@ -14,7 +14,7 @@ Single-user mic into any `Object3D` head:
 
 ```ts
 import * as xb from 'xrblocks';
-import {LipsyncMouth} from 'xrblocks/addons/lipsync';
+import {LipsyncMouth} from 'xrblocks/addons/lipsync/index.js';
 
 const face = new xb.StylizedFace({showEyes: false});
 headPivot.add(face);
@@ -32,7 +32,7 @@ Netblocks's `RemoteUserAvatar` already attaches a `face` (a `StylizedFace`) to e
 
 ```ts
 import * as THREE from 'three';
-import {LipsyncMouth} from 'xrblocks/addons/lipsync';
+import {LipsyncMouth} from 'xrblocks/addons/lipsync/index.js';
 
 protected override onSession(session) {
   const sharedCtx = THREE.AudioContext.getContext();

--- a/src/addons/lipsync/README.md
+++ b/src/addons/lipsync/README.md
@@ -28,22 +28,39 @@ That's it. Once `driver` is in the scene graph, the xrblocks scripts manager cal
 
 ## Netblocks integration
 
-Netblocks's `RemoteUserAvatar` already attaches a `face` (a `StylizedFace`) to every remote peer out of the box, so you don't have to create one yourself. Just point `LipsyncMouth` at it:
+Netblocks's `RemoteUserAvatar` already attaches a `face` (a `StylizedFace`) to every remote peer out of the box, so you don't have to create one yourself. Just point `LipsyncMouth` at it. Track drivers per peer so mic mute / unmute / leave doesn't leak.
 
 ```ts
 import * as THREE from 'three';
 import {LipsyncMouth} from 'xrblocks/addons/lipsync/index.js';
 
+private drivers = new Map<string, LipsyncMouth>();
+private sharedCtx = THREE.AudioContext.getContext();
+
+private detachDriver(peerId: string) {
+  const prior = this.drivers.get(peerId);
+  if (prior) {
+    prior.dispose();
+    prior.removeFromParent();
+    this.drivers.delete(peerId);
+  }
+}
+
 protected override onSession(session) {
-  const sharedCtx = THREE.AudioContext.getContext();
   session.voice.onTrack((peerId, stream) => {
     const user = session.users.get(peerId);
     if (!user) return;
+    this.detachDriver(peerId);
     const driver = new LipsyncMouth(stream, {
       target: user.avatar.face,
-      audioContext: sharedCtx,
+      audioContext: this.sharedCtx,
     });
     user.avatar.add(driver);
+    this.drivers.set(peerId, driver);
+  });
+  session.voice.onTrackRemoved((peerId) => this.detachDriver(peerId));
+  session.addEventListener('user-leave', (e) => {
+    this.detachDriver(e.detail.user.peerId);
   });
 }
 ```

--- a/src/addons/lipsync/SKILL.md
+++ b/src/addons/lipsync/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: lipsync
+description: >-
+  Add audio-driven avatar mouths to an XR Blocks app with the lipsync addon — heuristic
+  vowel-formant viseme mapping that turns any `MediaStream` (mic or remote peer's voice)
+  into mouth shapes on a `StylizedFace` canvas decal attached to an avatar's head. No ML
+  runtime, no model download. Use when authoring or debugging avatar mouths in
+  single-user demos or in multiplayer scenes paired with `xb-netblocks` (every remote
+  peer's voice stream drives their own face). Public surface: `LipsyncMouth` (the
+  driver), `xb.StylizedFace` (the decal, in xrblocks core), `session.voice.onTrack`
+  for the netblocks hook, plus the lower-level `FormantVisemeMapper`,
+  `MfccExtractor`, `computeAudioFeatures` and types (`VisemeWeights`, `VisemeTarget`,
+  `AudioFeatures`) for plugging in a model-based mapper later. For the DSP pipeline,
+  caveats, and samples read this folder's README.md.
+---
+
+# lipsync — audio-driven mouths for XR Blocks
+
+`lipsync` turns any avatar with a head pivot into a face that visibly mouths along to a `MediaStream`. Mental model: **a per-frame FFT + formant analyser writes viseme weights into a `target`; the `target` (typically `xb.StylizedFace`) re-rasterises a small canvas decal anchored to the head sphere's local `-Z`.** No model download, no ML runtime.
+
+> Full reference (DSP pipeline, samples, caveats, public surface): [`README.md`](./README.md). Samples: [`samples/`](./samples/).
+
+## When to use
+
+Pair with [`netblocks`](../netblocks/SKILL.md) so every remote peer's voice stream drives their own avatar's mouth, turning shared rooms from silent spheres into faces that visibly speak. Standalone use is fine too: a TTS playback, an NPC, or a single-user puppet head. The face primitive (`xb.StylizedFace`) is in xrblocks core, so any consumer can drive it via `setVisemes(VisemeWeights)`, not just lipsync.
+
+For ML-grade phoneme accuracy, the lower-level pieces (`FormantVisemeMapper`, `MfccExtractor`, `computeAudioFeatures`) and types are exported so a model-based mapper can slot in without touching the addon's public surface.
+
+## Mental model
+
+1. `MediaStream` → WebAudio `AnalyserNode` → byte frequency + time-domain buffers each frame.
+2. `computeAudioFeatures` extracts RMS, voicing, F1, F2, and a few band energies.
+3. `FormantVisemeMapper` maps F1/F2 to six viseme weights (`jawOpen`, `aa`, `oo`, `oh`, `ee`, `consonant`) with frame-rate-independent smoothing (`1 - exp(-dt / tau)`).
+4. `LipsyncMouth` writes the weights to its `target` via `setVisemes(...)`.
+5. `xb.StylizedFace` re-rasterises a 256×256 canvas (one dark mouth ellipse, optional eyes) and uploads it as a `CanvasTexture` on a small plane.
+
+## Public surface
+
+| Symbol                                                                                                                              | Where                                                   | Purpose                                                                                                                             |
+| ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `LipsyncMouth`                                                                                                                      | `xrblocks/addons/lipsync/index.js`                      | The driver `xb.Script`. Constructor: `(stream: MediaStream, {target, audioContext?, fftSize?, silenceThreshold?, silenceHoldMs?})`. |
+| `xb.StylizedFace`                                                                                                                   | xrblocks core (`import {StylizedFace} from 'xrblocks'`) | The face decal. Options: `headRadius`, `textureSize`, `showEyes`.                                                                   |
+| `RemoteUserAvatar.face`                                                                                                             | xrblocks/addons/netblocks                               | Already a `StylizedFace`, ready for `LipsyncMouth` to drive.                                                                        |
+| `FormantVisemeMapper`, `MfccExtractor`, `computeAudioFeatures`                                                                      | `xrblocks/addons/lipsync/index.js`                      | Pure modules a future ML mapper can plug into.                                                                                      |
+| Types: `VisemeWeights`, `VisemeTarget`, `FormantVisemeMapperOptions`, `MfccExtractorOptions`, `AudioFeatures`, `AudioFeatureInputs` | `xrblocks/addons/lipsync/index.js`                      | Shared shapes for custom drivers.                                                                                                   |
+
+## Lifecycle and ownership
+
+- The caller owns the `MediaStream`. `LipsyncMouth.dispose()` disconnects audio nodes but never stops tracks. If you got the stream from `getUserMedia`, stop the tracks yourself when done.
+- The caller owns the `AudioContext` when passed in. Always pass `audioContext` to reuse a shared context for any scene with more than one mouth (browsers cap contexts at around six per page). If omitted, `LipsyncMouth` creates its own and closes it on dispose.
+- The caller owns the `target` face. `dispose()` resets it to rest pose so a speaker who stops mid-vowel never leaves their avatar's mouth frozen open, but never disposes the face itself.
+- Instances are one-shot. After dispose, construct a new `LipsyncMouth`.
+
+## Browser quirks worth knowing
+
+- Microphone access requires HTTPS in modern browsers. Use `localhost` or a real cert for cross-device testing.
+- Browsers can drop a `MediaStreamAudioSourceNode` unless the same stream is also being pumped by an `HTMLMediaElement`. `LipsyncMouth` creates a muted off-DOM `<audio>` primer per stream to keep WebAudio alive. Same workaround `SpatialVoice` uses.
+- High-pitched voices (children, sopranos) push formants up and reduce vowel separation. Speaker-relative normalisation would help and is a sensible follow-up.


### PR DESCRIPTION
follow-up to #338 and #339. the rest of the addons (netblocks, uiblocks) got both `skills/xb-<name>/SKILL.md` (canvas-gem facing) and `src/addons/<name>/SKILL.md` (in-tree deep ref) wired up. lipsync was missed in the round, so gemini has no skill to load for "build me an avatar that talks" prompts.

adds the two skill files (mirroring the netblocks pattern), registers `xb-lipsync` in `skills/README.md`, and fixes two import statements in `src/addons/lipsync/README.md` that used `'xrblocks/addons/lipsync'` (404s on the `@build` cdn for the same reason netblocks did in #349) → now `.../index.js`.
