### PR TITLE
Simulator: add Instructions button to settings panel.

### DIFF
--- a/samples/glasses_ui/main.ts
+++ b/samples/glasses_ui/main.ts
@@ -85,7 +85,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   const options = new xb.Options();
   options.camera.near = 0.001;
   options.reticles.enabled = false;
-  options.simulator.instructions.enabled = false;
   options.simulator.handPosePanel.enabled = false;
   options.simulator.renderToRenderTexture = false;
   options.uikit.enable(uikit);

--- a/samples/modelviewer/main.js
+++ b/samples/modelviewer/main.js
@@ -12,7 +12,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   options.simulator.instructions.customInstructions = [
     {
       header: html`<h1>Model Viewer</h1>`,
-      videoSrc: 'model_viewer_simulator_usage.webm',
+      videoSrc:
+        xb.XR_BLOCKS_ASSETS_PATH +
+        'samples/modelviewer/model_viewer_simulator_usage.webm',
       description: html`Click or pinch the object to rotate. Drag the platform
       to move.`,
     },

--- a/src/addons/netblocks/samples/Sample.ts
+++ b/src/addons/netblocks/samples/Sample.ts
@@ -86,7 +86,6 @@ export abstract class NetSample extends xb.Script {
       options.enableUI();
       options.reticles.enabled = true;
       options.controllers.visualizeRays = false;
-      options.simulator.instructions.enabled = false;
       const app = new ctor();
       xb.add(app);
       await xb.init(options);

--- a/src/addons/netblocks/samples/basic/transports/main.ts
+++ b/src/addons/netblocks/samples/basic/transports/main.ts
@@ -125,7 +125,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   options.enableUI();
   options.reticles.enabled = true;
   options.controllers.visualizeRays = false;
-  options.simulator.instructions.enabled = false;
   const app = new TransportsSample();
   xb.add(app);
   await xb.init(options);

--- a/src/addons/simulator/ui/SimulatorSettingsPanel.ts
+++ b/src/addons/simulator/ui/SimulatorSettingsPanel.ts
@@ -124,11 +124,40 @@ export class SimulatorSettingsPanel
       background: #222;
       color: #fff;
     }
+
+    .instructions-btn {
+      background: rgba(255, 255, 255, 0.1);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      color: #fff;
+      padding: 0.6rem 1.2rem;
+      border-radius: 5rem;
+      font-size: 0.9rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition:
+        background-color 0.2s ease,
+        border-color 0.2s ease;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      margin-top: 0.5rem;
+    }
+
+    .instructions-btn:hover {
+      background: rgba(255, 255, 255, 0.2);
+      border-color: rgba(255, 255, 255, 0.4);
+    }
+
+    .instructions-btn:active {
+      background: rgba(255, 255, 255, 0.15);
+    }
   `;
 
   @property({type: Array}) environments: xb.SimulatorEnvironment[] = [];
   @property({type: Number}) activeEnvironmentIndex = 0;
   @property({type: String}) simulatorMode = xb.SimulatorMode.USER;
+  @property({type: Boolean}) instructionsEnabled = false;
 
   @state() private _isOpen = false;
 
@@ -148,6 +177,11 @@ export class SimulatorSettingsPanel
     const newMode = select.value as xb.SimulatorMode;
     this.simulatorMode = newMode;
     this.dispatchEvent(new xb.SetSimulatorModeEvent(newMode));
+  }
+
+  private _onShowInstructions() {
+    this._isOpen = false;
+    this.dispatchEvent(new xb.ShowSimulatorInstructionsEvent());
   }
 
   render() {
@@ -205,6 +239,19 @@ export class SimulatorSettingsPanel
             )}
           </select>
         </div>
+
+        ${this.instructionsEnabled
+          ? html`
+              <div class="form-group">
+                <button
+                  class="instructions-btn"
+                  @click=${this._onShowInstructions}
+                >
+                  View Simulator Instructions
+                </button>
+              </div>
+            `
+          : ''}
       </div>
     `;
   }

--- a/src/addons/uiblocks/samples/Sample.ts
+++ b/src/addons/uiblocks/samples/Sample.ts
@@ -89,7 +89,6 @@ export abstract class Sample extends xb.Script {
       options.uikit.enable(uikit);
       options.reticles.enabled = true;
       options.controllers.visualizeRays = false;
-      options.simulator.instructions.enabled = false;
 
       const sample = new SampleClass();
       sample.setupOptions(options);

--- a/src/simulator/SimulatorInterface.ts
+++ b/src/simulator/SimulatorInterface.ts
@@ -10,6 +10,7 @@ import {
 } from './SimulatorOptions.js';
 import {SimulatorScene} from './SimulatorScene.js';
 import {SetSimulatorEnvironmentEvent} from './events/SimulatorEnvironmentEvents.js';
+import {ShowSimulatorInstructionsEvent} from './events/SimulatorInstructionsEvents.js';
 
 /** Minimal interface for the gamepad toast element. */
 interface GamepadToastElement extends HTMLElement {
@@ -84,7 +85,9 @@ export class SimulatorInterface {
         `Active Hand: ${handedness === 'left' ? 'Left' : 'Right'}`
       );
     };
-    this.showInstructions(simulatorOptions);
+    if (simulatorOptions.instructions.showAutomatically) {
+      this.showInstructions(simulatorOptions);
+    }
     if (input) this._initGamepadUI(input);
   }
 
@@ -100,6 +103,8 @@ export class SimulatorInterface {
       settingsElement.environments = simulatorOptions.environments;
       settingsElement.activeEnvironmentIndex =
         simulatorOptions.activeEnvironmentIndex;
+      settingsElement.instructionsEnabled =
+        simulatorOptions.instructions.enabled;
       document.body.appendChild(settingsElement);
       simulatorControls.setSimulatorSettingsPanelElement(settingsElement);
       settingsElement.addEventListener(
@@ -120,12 +125,21 @@ export class SimulatorInterface {
           }
         }
       );
+      settingsElement.addEventListener(
+        ShowSimulatorInstructionsEvent.type,
+        () => {
+          this.showInstructions(simulatorOptions);
+        }
+      );
       this.elements.push(settingsElement);
     }
   }
 
   showInstructions(simulatorOptions: SimulatorOptions) {
     if (simulatorOptions.instructions.enabled) {
+      if (document.querySelector(simulatorOptions.instructions.element)) {
+        return; // Already showing
+      }
       const element = document.createElement(
         simulatorOptions.instructions.element
       ) as SimulatorInstructionsHTMLElement;
@@ -161,6 +175,7 @@ export class SimulatorInterface {
   }
 
   hideUiElements() {
+    this.elements = this.elements.filter((el) => el.isConnected);
     for (const element of this.elements) {
       element.style.display = 'none';
     }
@@ -168,6 +183,7 @@ export class SimulatorInterface {
   }
 
   showUiElements() {
+    this.elements = this.elements.filter((el) => el.isConnected);
     for (const element of this.elements) {
       element.style.display = '';
     }

--- a/src/simulator/SimulatorOptions.ts
+++ b/src/simulator/SimulatorOptions.ts
@@ -60,7 +60,8 @@ export class SimulatorOptions {
     element: 'xrblocks-simulator-settings',
   };
   instructions = {
-    enabled: false,
+    enabled: true,
+    showAutomatically: false,
     element: 'xrblocks-simulator-instructions',
     customInstructions: [] as SimulatorCustomInstruction[],
   };

--- a/src/simulator/events/SimulatorEvents.ts
+++ b/src/simulator/events/SimulatorEvents.ts
@@ -1,3 +1,4 @@
 export * from './SimulatorEnvironmentEvents';
 export * from './SimulatorHandEvents';
 export * from './SimulatorModeEvents';
+export * from './SimulatorInstructionsEvents';

--- a/src/simulator/events/SimulatorInstructionsEvents.ts
+++ b/src/simulator/events/SimulatorInstructionsEvents.ts
@@ -1,0 +1,6 @@
+export class ShowSimulatorInstructionsEvent extends Event {
+  static type = 'showSimulatorInstructions';
+  constructor() {
+    super(ShowSimulatorInstructionsEvent.type, {bubbles: true, composed: true});
+  }
+}

--- a/src/simulator/interfaces/ISimulatorSettingsPanelElement.ts
+++ b/src/simulator/interfaces/ISimulatorSettingsPanelElement.ts
@@ -4,4 +4,5 @@ export interface ISimulatorSettingsPanelElement extends HTMLElement {
   environments: SimulatorEnvironment[];
   activeEnvironmentIndex: number;
   simulatorMode: SimulatorMode;
+  instructionsEnabled?: boolean;
 }

--- a/templates/uikit/main.js
+++ b/templates/uikit/main.js
@@ -108,6 +108,5 @@ options.uikit.enable(uikit);
 
 document.addEventListener('DOMContentLoaded', async function () {
   xb.add(new UikitTemplate());
-  options.simulator.instructions.enabled = false;
   await xb.init(options);
 });


### PR DESCRIPTION
- Added ShowSimulatorInstructionsEvent class and exported it.
- Enabled instructions by default and added showAutomatically option.
- Added instructionsEnabled property to ISimulatorSettingsPanelElement.
- Render 'View Simulator Instructions' button conditionally in settings panel.
- Handled instructions event and showAutomatically option in SimulatorInterface.
- Removed manual instructions.enabled overrides from samples/templates.
- Ensured settings panel closes when showing instructions.


https://github.com/user-attachments/assets/440e7c7e-859c-4ac4-8db4-b752c4b3baa5

