### PR TITLE
world: add FaceRecognizer + face_mirror demo

### DIFF
--- a/demos/face_mirror/FaceMirror.js
+++ b/demos/face_mirror/FaceMirror.js
@@ -1,0 +1,380 @@
+import * as THREE from 'three';
+import * as xb from 'xrblocks';
+
+// Indices for the canonical face mesh tesselation that ships with the
+// MediaPipe FaceLandmarker model. We render a subset of triangles as line
+// segments so the wireframe reads clearly without overwhelming the scene.
+// These are the standard MediaPipe FACEMESH_TESSELATION index pairs for the
+// face mesh perimeter + key feature contours (lips, eyes, eyebrows). Source:
+// https://github.com/google-ai-edge/mediapipe-samples (face_landmarker)
+const FACE_OVAL_PAIRS = [
+  [10, 338],
+  [338, 297],
+  [297, 332],
+  [332, 284],
+  [284, 251],
+  [251, 389],
+  [389, 356],
+  [356, 454],
+  [454, 323],
+  [323, 361],
+  [361, 288],
+  [288, 397],
+  [397, 365],
+  [365, 379],
+  [379, 378],
+  [378, 400],
+  [400, 377],
+  [377, 152],
+  [152, 148],
+  [148, 176],
+  [176, 149],
+  [149, 150],
+  [150, 136],
+  [136, 172],
+  [172, 58],
+  [58, 132],
+  [132, 93],
+  [93, 234],
+  [234, 127],
+  [127, 162],
+  [162, 21],
+  [21, 54],
+  [54, 103],
+  [103, 67],
+  [67, 109],
+  [109, 10],
+];
+const LIPS_OUTER = [
+  [61, 146],
+  [146, 91],
+  [91, 181],
+  [181, 84],
+  [84, 17],
+  [17, 314],
+  [314, 405],
+  [405, 321],
+  [321, 375],
+  [375, 291],
+  [61, 185],
+  [185, 40],
+  [40, 39],
+  [39, 37],
+  [37, 0],
+  [0, 267],
+  [267, 269],
+  [269, 270],
+  [270, 409],
+  [409, 291],
+];
+const LIPS_INNER = [
+  [78, 95],
+  [95, 88],
+  [88, 178],
+  [178, 87],
+  [87, 14],
+  [14, 317],
+  [317, 402],
+  [402, 318],
+  [318, 324],
+  [324, 308],
+  [78, 191],
+  [191, 80],
+  [80, 81],
+  [81, 82],
+  [82, 13],
+  [13, 312],
+  [312, 311],
+  [311, 310],
+  [310, 415],
+  [415, 308],
+];
+const LEFT_EYE = [
+  [263, 249],
+  [249, 390],
+  [390, 373],
+  [373, 374],
+  [374, 380],
+  [380, 381],
+  [381, 382],
+  [382, 362],
+  [263, 466],
+  [466, 388],
+  [388, 387],
+  [387, 386],
+  [386, 385],
+  [385, 384],
+  [384, 398],
+  [398, 362],
+];
+const RIGHT_EYE = [
+  [33, 7],
+  [7, 163],
+  [163, 144],
+  [144, 145],
+  [145, 153],
+  [153, 154],
+  [154, 155],
+  [155, 133],
+  [33, 246],
+  [246, 161],
+  [161, 160],
+  [160, 159],
+  [159, 158],
+  [158, 157],
+  [157, 173],
+  [173, 133],
+];
+const LEFT_EYEBROW = [
+  [276, 283],
+  [283, 282],
+  [282, 295],
+  [295, 285],
+  [300, 293],
+  [293, 334],
+  [334, 296],
+  [296, 336],
+];
+const RIGHT_EYEBROW = [
+  [46, 53],
+  [53, 52],
+  [52, 65],
+  [65, 55],
+  [70, 63],
+  [63, 105],
+  [105, 66],
+  [66, 107],
+];
+
+const ALL_EDGES = [
+  ...FACE_OVAL_PAIRS,
+  ...LIPS_OUTER,
+  ...LIPS_INNER,
+  ...LEFT_EYE,
+  ...RIGHT_EYE,
+  ...LEFT_EYEBROW,
+  ...RIGHT_EYEBROW,
+];
+
+// Blendshapes to surface on the HUD. Picked for high-signal expressions
+// that a user can easily trigger on camera and see respond. The full list
+// is 52 entries; rendering all of them would be a wall of bars.
+const FEATURED_BLENDSHAPES = [
+  'jawOpen',
+  'mouthSmileLeft',
+  'mouthSmileRight',
+  'mouthPucker',
+  'mouthFunnel',
+  'eyeBlinkLeft',
+  'eyeBlinkRight',
+  'browInnerUp',
+  'browDownLeft',
+  'browDownRight',
+  'cheekPuff',
+  'tongueOut',
+];
+
+export class FaceMirror extends xb.Script {
+  static dependencies = {
+    camera: THREE.Camera,
+    world: xb.World,
+  };
+
+  init({camera, world}) {
+    this.camera = camera;
+    this.world = world;
+    this.detecting = false;
+    this.framesSinceLastDetect = 0;
+    // Throttle to roughly every other rendered frame so we don't peg the
+    // GPU when the camera + MediaPipe + landmark-rendering loop costs
+    // ~30 ms per pass on a desktop iGPU.
+    this.detectEveryNFrames = 2;
+    this.initWireframe();
+    this.initStatusOverlay();
+  }
+
+  initWireframe() {
+    // One Line3 geometry per edge: easier than a single LineSegments with
+    // index updates because we mutate positions every frame.
+    const lineMaterial = new THREE.LineBasicMaterial({
+      color: 0x4796e3,
+      transparent: true,
+      opacity: 0.85,
+      depthTest: false,
+    });
+    this.lineMaterial = lineMaterial;
+    this.lineGeometries = ALL_EDGES.map(() => {
+      const geom = new THREE.BufferGeometry();
+      geom.setAttribute(
+        'position',
+        new THREE.BufferAttribute(new Float32Array(6), 3)
+      );
+      const line = new THREE.Line(geom, lineMaterial);
+      line.frustumCulled = false;
+      line.renderOrder = 5;
+      this.add(line);
+      return geom;
+    });
+    // Point cloud of all 478 landmarks for the "data density" feel.
+    const pointGeom = new THREE.BufferGeometry();
+    pointGeom.setAttribute(
+      'position',
+      new THREE.BufferAttribute(new Float32Array(478 * 3), 3)
+    );
+    this.pointGeometry = pointGeom;
+    this.pointCloud = new THREE.Points(
+      pointGeom,
+      new THREE.PointsMaterial({
+        color: 0x9b5de5,
+        size: 0.004,
+        transparent: true,
+        opacity: 0.6,
+        depthTest: false,
+      })
+    );
+    this.pointCloud.frustumCulled = false;
+    this.pointCloud.renderOrder = 4;
+    this.add(this.pointCloud);
+  }
+
+  initStatusOverlay() {
+    // Plain HTML overlay (cheaper than the UICore card from the pose demo
+    // and avoids pulling uiblocks just for a status line). Bottom-left so
+    // it doesn't clip the webcam preview in the bottom-right.
+    const div = document.createElement('div');
+    div.id = 'face_mirror_status';
+    div.style.cssText = `
+      position: fixed; bottom: 12px; left: 12px; min-width: 240px;
+      padding: 14px 18px; background: rgba(15, 18, 25, 0.85);
+      color: #f0f0f0; font: 14px/1.5 system-ui, sans-serif;
+      border-radius: 10px; border: 1px solid rgba(71, 150, 227, 0.4);
+      z-index: 50; max-height: 60vh; overflow: hidden;
+    `;
+    div.innerHTML = `
+      <div style="font-weight: 600; color: #00f0ff; margin-bottom: 6px;">
+        FACE LANDMARKER
+      </div>
+      <div id="face_mirror_state" style="color: #a0aec0; margin-bottom: 10px;">
+        Loading model...
+      </div>
+      <div id="face_mirror_bars"></div>
+    `;
+    document.body.appendChild(div);
+    this.stateEl = div.querySelector('#face_mirror_state');
+    this.barsEl = div.querySelector('#face_mirror_bars');
+    this.barEls = new Map();
+    for (const name of FEATURED_BLENDSHAPES) {
+      const row = document.createElement('div');
+      row.style.cssText =
+        'display: flex; align-items: center; gap: 8px; margin: 2px 0;';
+      const label = document.createElement('div');
+      label.textContent = name;
+      label.style.cssText = 'width: 130px; font-size: 12px; color: #ccc;';
+      const track = document.createElement('div');
+      track.style.cssText =
+        'flex: 1; height: 6px; background: rgba(255,255,255,0.08); border-radius: 3px; overflow: hidden;';
+      const fill = document.createElement('div');
+      fill.style.cssText =
+        'height: 100%; background: linear-gradient(90deg, #4796e3, #9b5de5); width: 0%;';
+      track.appendChild(fill);
+      row.appendChild(label);
+      row.appendChild(track);
+      this.barsEl.appendChild(row);
+      this.barEls.set(name, fill);
+    }
+  }
+
+  update() {
+    this.framesSinceLastDetect++;
+    if (!this.world.faces || this.detecting) return;
+    if (this.framesSinceLastDetect < this.detectEveryNFrames) return;
+    this.framesSinceLastDetect = 0;
+    this.detecting = true;
+    this.world.faces
+      .runDetection()
+      .then((faces) => {
+        this.detecting = false;
+        this.displayFaces(faces);
+      })
+      .catch((err) => {
+        this.detecting = false;
+        if (this.stateEl) {
+          this.stateEl.textContent =
+            'Detection error: ' + (err.message || String(err));
+        }
+        console.error('Face detection failed:', err);
+      });
+  }
+
+  displayFaces(faces) {
+    if (!faces || faces.length === 0) {
+      if (this.stateEl) {
+        this.stateEl.textContent = 'No face detected. Look at the camera.';
+      }
+      this.setWireframeVisible(false);
+      this.resetBars();
+      return;
+    }
+    const face = faces[0];
+    if (this.stateEl) {
+      this.stateEl.textContent =
+        `${face.landmarks.length} landmarks tracked` +
+        (face.blendshapes.length
+          ? ` | ${face.blendshapes.length} blendshapes`
+          : '');
+    }
+    this.setWireframeVisible(true);
+    this.updateWireframe(face);
+    this.updateBars(face);
+  }
+
+  setWireframeVisible(v) {
+    this.pointCloud.visible = v;
+    for (const g of this.lineGeometries) {
+      g.boundingSphere = null;
+    }
+    for (const child of this.children) {
+      if (child instanceof THREE.Line) child.visible = v;
+    }
+  }
+
+  updateWireframe(face) {
+    const positions = this.pointGeometry.attributes.position.array;
+    for (let i = 0; i < face.landmarks.length; i++) {
+      const wp = face.landmarks[i].worldPosition;
+      if (!wp) continue;
+      positions[i * 3] = wp.x;
+      positions[i * 3 + 1] = wp.y;
+      positions[i * 3 + 2] = wp.z;
+    }
+    this.pointGeometry.attributes.position.needsUpdate = true;
+    for (let e = 0; e < ALL_EDGES.length; e++) {
+      const [a, b] = ALL_EDGES[e];
+      const wa = face.landmarks[a]?.worldPosition;
+      const wb = face.landmarks[b]?.worldPosition;
+      if (!wa || !wb) continue;
+      const arr = this.lineGeometries[e].attributes.position.array;
+      arr[0] = wa.x;
+      arr[1] = wa.y;
+      arr[2] = wa.z;
+      arr[3] = wb.x;
+      arr[4] = wb.y;
+      arr[5] = wb.z;
+      this.lineGeometries[e].attributes.position.needsUpdate = true;
+    }
+  }
+
+  updateBars(face) {
+    for (const name of FEATURED_BLENDSHAPES) {
+      const v = face.getBlendshape(name);
+      const fill = this.barEls.get(name);
+      if (fill) fill.style.width = (v * 100).toFixed(0) + '%';
+    }
+  }
+
+  resetBars() {
+    for (const fill of this.barEls.values()) {
+      fill.style.width = '0%';
+    }
+  }
+}

--- a/demos/face_mirror/FaceMirror.js
+++ b/demos/face_mirror/FaceMirror.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import * as xb from 'xrblocks';
+import {HeadLeashBehavior, UICore, UIPanel, UIText} from 'uiblocks';
 
 // Indices for the canonical face mesh tesselation that ships with the
 // MediaPipe FaceLandmarker model. We render a subset of triangles as line
@@ -176,13 +177,12 @@ const FEATURED_BLENDSHAPES = [
 
 export class FaceMirror extends xb.Script {
   static dependencies = {
-    camera: THREE.Camera,
     world: xb.World,
   };
 
-  init({camera, world}) {
-    this.camera = camera;
+  init({world}) {
     this.world = world;
+    this.uiCore = new UICore(this);
     this.detecting = false;
     this.framesSinceLastDetect = 0;
     // Throttle to roughly every other rendered frame so we don't peg the
@@ -191,6 +191,55 @@ export class FaceMirror extends xb.Script {
     this.detectEveryNFrames = 2;
     this.initWireframe();
     this.initStatusOverlay();
+    this.initSpatialHud();
+  }
+
+  initStatusOverlay() {
+    // Plain HTML overlay for desktop sim, where DOM is crisp and readable.
+    // Bottom-left so it doesn't clip the webcam preview in the bottom-right.
+    // In immersive XR the browser hides DOM overlays automatically, so the
+    // spatial HUD (initSpatialHud) takes over there.
+    const div = document.createElement('div');
+    div.id = 'face_mirror_status';
+    div.style.cssText = `
+      position: fixed; top: 12px; right: 12px; min-width: 240px;
+      padding: 14px 18px; background: rgba(15, 18, 25, 0.85);
+      color: #f0f0f0; font: 14px/1.5 system-ui, sans-serif;
+      border-radius: 10px; border: 1px solid rgba(71, 150, 227, 0.4);
+      z-index: 50; max-height: 80vh; overflow: hidden;
+    `;
+    div.innerHTML = `
+      <div style="font-weight: 600; color: #00f0ff; margin-bottom: 6px;">
+        FACE LANDMARKER
+      </div>
+      <div id="face_mirror_state" style="color: #a0aec0; margin-bottom: 10px;">
+        Loading model...
+      </div>
+      <div id="face_mirror_bars"></div>
+    `;
+    document.body.appendChild(div);
+    this.stateEl = div.querySelector('#face_mirror_state');
+    this.barsEl = div.querySelector('#face_mirror_bars');
+    this.barEls = new Map();
+    for (const name of FEATURED_BLENDSHAPES) {
+      const row = document.createElement('div');
+      row.style.cssText =
+        'display: flex; align-items: center; gap: 8px; margin: 2px 0;';
+      const label = document.createElement('div');
+      label.textContent = name;
+      label.style.cssText = 'width: 130px; font-size: 12px; color: #ccc;';
+      const track = document.createElement('div');
+      track.style.cssText =
+        'flex: 1; height: 6px; background: rgba(255,255,255,0.08); border-radius: 3px; overflow: hidden;';
+      const fill = document.createElement('div');
+      fill.style.cssText =
+        'height: 100%; background: linear-gradient(90deg, #4796e3, #9b5de5); width: 0%;';
+      track.appendChild(fill);
+      row.appendChild(label);
+      row.appendChild(track);
+      this.barsEl.appendChild(row);
+      this.barEls.set(name, fill);
+    }
   }
 
   initWireframe() {
@@ -237,51 +286,109 @@ export class FaceMirror extends xb.Script {
     this.add(this.pointCloud);
   }
 
-  initStatusOverlay() {
-    // Plain HTML overlay (cheaper than the UICore card from the pose demo
-    // and avoids pulling uiblocks just for a status line). Bottom-left so
-    // it doesn't clip the webcam preview in the bottom-right.
-    const div = document.createElement('div');
-    div.id = 'face_mirror_status';
-    div.style.cssText = `
-      position: fixed; bottom: 12px; left: 12px; min-width: 240px;
-      padding: 14px 18px; background: rgba(15, 18, 25, 0.85);
-      color: #f0f0f0; font: 14px/1.5 system-ui, sans-serif;
-      border-radius: 10px; border: 1px solid rgba(71, 150, 227, 0.4);
-      z-index: 50; max-height: 60vh; overflow: hidden;
-    `;
-    div.innerHTML = `
-      <div style="font-weight: 600; color: #00f0ff; margin-bottom: 6px;">
-        FACE LANDMARKER
-      </div>
-      <div id="face_mirror_state" style="color: #a0aec0; margin-bottom: 10px;">
-        Loading model...
-      </div>
-      <div id="face_mirror_bars"></div>
-    `;
-    document.body.appendChild(div);
-    this.stateEl = div.querySelector('#face_mirror_state');
-    this.barsEl = div.querySelector('#face_mirror_bars');
-    this.barEls = new Map();
+  initSpatialHud() {
+    // Spatial HUD that floats in front of the user's head pose. Uses
+    // uiblocks so it renders both on desktop (in the rendered sim view)
+    // AND in immersive XR (where DOM overlays are invisible). Mirrors
+    // the visual language of the pose-detector demo: dark glassmorphic
+    // card, gradient stroke, cyan/purple accent.
+    this.hudCard = this.uiCore.createCard({
+      name: 'FaceHudCard',
+      sizeX: 0.6,
+      sizeY: 0.5,
+      behaviors: [
+        new HeadLeashBehavior({
+          // Offset is in camera-local coords: +x right, +y up, -z forward.
+          // Top-right of view so it clears both the face mesh and the
+          // simulator's settings gear in the corner.
+          offset: new THREE.Vector3(0.85, 0.35, -1.1),
+          posLerp: 0.1,
+          rotLerp: 0.1,
+        }),
+      ],
+    });
+    const hudPanel = new UIPanel({
+      width: '100%',
+      height: '100%',
+      fillColor: 'rgba(15, 18, 25, 0.85)',
+      innerShadowColor: 'rgba(100, 180, 255, 0.15)',
+      innerShadowBlur: 80,
+      strokeWidth: 3,
+      strokeColor: {
+        gradientType: 'linear',
+        rotation: 45,
+        stops: [
+          {position: 0, color: '#4796e3'},
+          {position: 1, color: '#9b5de5'},
+        ],
+      },
+      cornerRadius: 24,
+      padding: 24,
+      flexDirection: 'column',
+      justifyContent: 'flex-start',
+      alignItems: 'stretch',
+    });
+    this.titleText = new UIText('FACE LANDMARKER', {
+      fontSize: 32,
+      fontWeight: 'bold',
+      color: '#00f0ff',
+      textAlign: 'center',
+      width: '100%',
+    });
+    this.spatialStateText = new UIText('Loading model...', {
+      fontSize: 18,
+      color: '#a0aec0',
+      textAlign: 'center',
+      width: '100%',
+      paddingBottom: 12,
+    });
+    const separator = new UIPanel({
+      width: '100%',
+      height: 2,
+      fillColor: 'rgba(255, 255, 255, 0.15)',
+      marginBottom: 12,
+    });
+    hudPanel.add(this.titleText);
+    hudPanel.add(this.spatialStateText);
+    hudPanel.add(separator);
+    // 12 blendshape rows. Each row is a horizontal UIPanel: a label
+    // (fixed width) + a track (flex 1) with a fill UIPanel whose width
+    // we mutate every frame to reflect the blendshape weight. Same
+    // shape as the HTML version but in 3D space.
+    this.spatialBars = new Map();
     for (const name of FEATURED_BLENDSHAPES) {
-      const row = document.createElement('div');
-      row.style.cssText =
-        'display: flex; align-items: center; gap: 8px; margin: 2px 0;';
-      const label = document.createElement('div');
-      label.textContent = name;
-      label.style.cssText = 'width: 130px; font-size: 12px; color: #ccc;';
-      const track = document.createElement('div');
-      track.style.cssText =
-        'flex: 1; height: 6px; background: rgba(255,255,255,0.08); border-radius: 3px; overflow: hidden;';
-      const fill = document.createElement('div');
-      fill.style.cssText =
-        'height: 100%; background: linear-gradient(90deg, #4796e3, #9b5de5); width: 0%;';
-      track.appendChild(fill);
-      row.appendChild(label);
-      row.appendChild(track);
-      this.barsEl.appendChild(row);
-      this.barEls.set(name, fill);
+      const row = new UIPanel({
+        width: '100%',
+        height: 26,
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 10,
+        marginBottom: 4,
+      });
+      const label = new UIText(name, {
+        fontSize: 15,
+        color: '#cccccc',
+        width: 180,
+      });
+      const track = new UIPanel({
+        flex: 1,
+        height: 10,
+        fillColor: 'rgba(255, 255, 255, 0.08)',
+        cornerRadius: 5,
+      });
+      const fill = new UIPanel({
+        width: '0%',
+        height: '100%',
+        fillColor: '#4796e3',
+        cornerRadius: 5,
+      });
+      track.add(fill);
+      row.add(label);
+      row.add(track);
+      hudPanel.add(row);
+      this.spatialBars.set(name, fill);
     }
+    this.hudCard.add(hudPanel);
   }
 
   update() {
@@ -298,31 +405,30 @@ export class FaceMirror extends xb.Script {
       })
       .catch((err) => {
         this.detecting = false;
-        if (this.stateEl) {
-          this.stateEl.textContent =
-            'Detection error: ' + (err.message || String(err));
-        }
+        const msg = 'Detection error: ' + (err.message || String(err));
+        if (this.stateEl) this.stateEl.textContent = msg;
+        if (this.spatialStateText) this.spatialStateText.setText(msg);
         console.error('Face detection failed:', err);
       });
   }
 
   displayFaces(faces) {
     if (!faces || faces.length === 0) {
-      if (this.stateEl) {
-        this.stateEl.textContent = 'No face detected. Look at the camera.';
-      }
+      const msg = 'No face detected. Look at the camera.';
+      if (this.stateEl) this.stateEl.textContent = msg;
+      if (this.spatialStateText) this.spatialStateText.setText(msg);
       this.setWireframeVisible(false);
       this.resetBars();
       return;
     }
     const face = faces[0];
-    if (this.stateEl) {
-      this.stateEl.textContent =
-        `${face.landmarks.length} landmarks tracked` +
-        (face.blendshapes.length
-          ? ` | ${face.blendshapes.length} blendshapes`
-          : '');
-    }
+    const status =
+      `${face.landmarks.length} landmarks tracked` +
+      (face.blendshapes.length
+        ? ` | ${face.blendshapes.length} blendshapes`
+        : '');
+    if (this.stateEl) this.stateEl.textContent = status;
+    if (this.spatialStateText) this.spatialStateText.setText(status);
     this.setWireframeVisible(true);
     this.updateWireframe(face);
     this.updateBars(face);
@@ -367,14 +473,20 @@ export class FaceMirror extends xb.Script {
   updateBars(face) {
     for (const name of FEATURED_BLENDSHAPES) {
       const v = face.getBlendshape(name);
-      const fill = this.barEls.get(name);
-      if (fill) fill.style.width = (v * 100).toFixed(0) + '%';
+      const pct = (v * 100).toFixed(0) + '%';
+      const htmlFill = this.barEls.get(name);
+      if (htmlFill) htmlFill.style.width = pct;
+      const spatialFill = this.spatialBars.get(name);
+      if (spatialFill) spatialFill.setProperties({width: pct});
     }
   }
 
   resetBars() {
     for (const fill of this.barEls.values()) {
       fill.style.width = '0%';
+    }
+    for (const fill of this.spatialBars.values()) {
+      fill.setProperties({width: '0%'});
     }
   }
 }

--- a/demos/face_mirror/WebcamFallback.js
+++ b/demos/face_mirror/WebcamFallback.js
@@ -1,0 +1,127 @@
+// Webcam fallback for desktop / simulator mode.
+//
+// The SDK reads frames from `xb.core.deviceCamera.getSnapshot()`, which on a
+// real Quest returns frames from the passthrough cameras. On desktop the
+// simulator renders the 3D scene as the "camera" feed, which is fine for
+// world-facing tasks (plane detection, object recognition of the simulated
+// living-room) but useless for face detection because the simulator never
+// renders a human face.
+//
+// This module replaces `deviceCamera.getSnapshot` with one that pulls from
+// a getUserMedia() webcam stream when the page is running in the simulator
+// (no `immersive-ar` WebXR session active). Real-headset path is untouched
+// because the simulator addon never initialises when the device supports
+// WebXR.
+//
+// Permission flow: we call `getUserMedia()` directly. Chrome shows its
+// native permission prompt with the site URL and a one-click allow / deny.
+// If the user denies, the SDK keeps using the original `getSnapshot`
+// (which returns blank/scene frames) and the demo degrades to "no face
+// detected" without crashing.
+
+const VIDEO_W = 640;
+const VIDEO_H = 480;
+
+let _videoEl = null;
+let _canvasEl = null;
+let _canvasCtx = null;
+let _origGetSnapshot = null;
+
+function shouldUseWebcamFallback() {
+  // Only activate when the simulator addon is in charge (i.e. we're not in
+  // an immersive WebXR session). On a real Quest this returns false and the
+  // SDK's normal getSnapshot path runs untouched.
+  const renderer = window.xb?.core?.renderer;
+  return !renderer?.xr?.isPresenting;
+}
+
+async function requestWebcam() {
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({
+      video: {
+        width: {ideal: VIDEO_W},
+        height: {ideal: VIDEO_H},
+        facingMode: 'user',
+      },
+      audio: false,
+    });
+    _videoEl = document.createElement('video');
+    _videoEl.autoplay = true;
+    _videoEl.playsInline = true;
+    _videoEl.muted = true;
+    _videoEl.srcObject = stream;
+    await new Promise((resolve) => {
+      _videoEl.onloadedmetadata = resolve;
+    });
+    await _videoEl.play();
+    _canvasEl = document.createElement('canvas');
+    _canvasEl.width = _videoEl.videoWidth || VIDEO_W;
+    _canvasEl.height = _videoEl.videoHeight || VIDEO_H;
+    _canvasCtx = _canvasEl.getContext('2d', {willReadFrequently: true});
+    return true;
+  } catch (err) {
+    if (err && err.name === 'NotAllowedError') {
+      console.info(
+        '[face_mirror] webcam permission denied; staying on simulator camera.'
+      );
+    } else {
+      console.warn(
+        '[face_mirror] webcam unavailable; staying on simulator camera.',
+        err
+      );
+    }
+    return false;
+  }
+}
+
+export async function installWebcamFallback(xb) {
+  if (!shouldUseWebcamFallback()) {
+    return;
+  }
+  const ok = await requestWebcam();
+  if (!ok) return;
+
+  _origGetSnapshot = xb.core.deviceCamera.getSnapshot.bind(
+    xb.core.deviceCamera
+  );
+  // Route ImageData requests through a freshly-drawn frame from the webcam
+  // video element. Other output formats (base64, blob, texture) fall back
+  // to the original getter so we don't break any consumer we haven't
+  // explicitly thought about.
+  //
+  // IMPORTANT: do NOT mirror the canvas when feeding MediaPipe. The
+  // FaceLandmarker emits ARKit-style blendshape names from the SUBJECT'S
+  // point of view (`eyeBlinkLeft` is the subject's left eye, which in a
+  // non-mirrored selfie image appears on the right side of the frame).
+  // Mirroring the input swaps every Left/Right blendshape (and every
+  // landmark index). We mirror only the preview thumbnail via CSS so the
+  // user still sees a selfie-correct view of themselves; the landmarker
+  // gets the raw frame and the labels stay accurate.
+  xb.core.deviceCamera.getSnapshot = async (opts = {}) => {
+    if (opts.outputFormat !== 'imageData' || !_videoEl || !_canvasCtx) {
+      return _origGetSnapshot(opts);
+    }
+    if (_videoEl.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
+      return _origGetSnapshot(opts);
+    }
+    _canvasCtx.drawImage(_videoEl, 0, 0, _canvasEl.width, _canvasEl.height);
+    return _canvasCtx.getImageData(0, 0, _canvasEl.width, _canvasEl.height);
+  };
+
+  // Small picture-in-picture preview so the user can see what the
+  // landmarker sees. Useful for debugging head position. Mirror only the
+  // visual preview (CSS scaleX(-1)) so the user gets a selfie-correct
+  // view while MediaPipe gets the un-mirrored frame above.
+  const preview = document.createElement('div');
+  preview.style.cssText = `
+    position: fixed; bottom: 12px; right: 12px; width: 160px; height: 120px;
+    background: #000; border: 1px solid #444; border-radius: 6px;
+    overflow: hidden; z-index: 100;
+  `;
+  _videoEl.style.cssText =
+    'width: 100%; height: 100%; object-fit: cover; transform: scaleX(-1);';
+  preview.appendChild(_videoEl);
+  document.body.appendChild(preview);
+
+  console.log('[face_mirror] webcam fallback installed.');
+}

--- a/demos/face_mirror/index.html
+++ b/demos/face_mirror/index.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Face Landmarker Mirror</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Cache-Control"
+      content="no-cache, no-store, must-revalidate"
+    />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <link type="text/css" rel="stylesheet" href="../../samples/main.css" />
+    <script type="importmap">
+      {
+        "imports": {
+          "lit": "https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js",
+          "lit/": "https://esm.run/lit@3/",
+          "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
+          "three/": "https://cdn.jsdelivr.net/npm/three@0.184.0/",
+          "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
+          "troika-three-text": "https://cdn.jsdelivr.net/gh/protectwise/troika@028b81cf308f0f22e5aa8e78196be56ec1997af5/packages/troika-three-text/src/index.js",
+          "troika-three-utils": "https://cdn.jsdelivr.net/gh/protectwise/troika@v0.52.4/packages/troika-three-utils/src/index.js",
+          "troika-worker-utils": "https://cdn.jsdelivr.net/gh/protectwise/troika@v0.52.4/packages/troika-worker-utils/src/index.js",
+          "bidi-js": "https://esm.sh/bidi-js@%5E1.0.2?target=es2022",
+          "webgl-sdf-generator": "https://esm.sh/webgl-sdf-generator@1.1.1/es2022/webgl-sdf-generator.mjs",
+          "@pmndrs/uikit": "https://cdn.jsdelivr.net/npm/@pmndrs/uikit@1.0.56/dist/index.min.js",
+          "@pmndrs/uikit-pub-sub": "https://cdn.jsdelivr.net/npm/@pmndrs/uikit-pub-sub@1.0.56/dist/index.min.js",
+          "@pmndrs/msdfonts": "https://cdn.jsdelivr.net/npm/@pmndrs/msdfonts@1.0.56/dist/index.min.js",
+          "@preact/signals-core": "https://cdn.jsdelivr.net/npm/@preact/signals-core@1.12.1/dist/signals-core.mjs",
+          "yoga-layout/load": "https://cdn.jsdelivr.net/npm/yoga-layout@3.2.1/dist/src/load.js",
+          "uiblocks": "../../build/addons/uiblocks/src/index.js",
+          "xrblocks": "../../build/xrblocks.js",
+          "xrblocks/addons/": "../../build/addons/",
+          "@mediapipe/tasks-vision": "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@latest/vision_bundle.mjs"
+        }
+      }
+    </script>
+  </head>
+
+  <body>
+    <script type="module" src="main.js"></script>
+  </body>
+</html>

--- a/demos/face_mirror/main.js
+++ b/demos/face_mirror/main.js
@@ -1,0 +1,27 @@
+import 'xrblocks/addons/simulator/SimulatorAddons.js';
+import * as xb from 'xrblocks';
+import {FaceMirror} from './FaceMirror.js';
+import {installWebcamFallback} from './WebcamFallback.js';
+
+const options = new xb.Options();
+options.enableFaceDetection();
+
+options.setAppTitle('Face Landmarker Mirror');
+options.setAppDescription(
+  'Tracks the 478 MediaPipe face landmarks and 52 blendshapes in real time, ' +
+    'projects them into the scene as a wireframe with live expression bars.'
+);
+options.xrButton.showEnterSimulatorButton = true;
+
+function start() {
+  const mirror = new FaceMirror();
+  xb.add(mirror);
+  xb.init(options).then(() => {
+    // After xb.init the simulator addon is wired and xb.core.deviceCamera
+    // is available, so we can decide whether to inject a webcam stream.
+    // On real Quest hardware the device-camera path stays untouched.
+    installWebcamFallback(xb);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', start);

--- a/src/core/Options.ts
+++ b/src/core/Options.ts
@@ -282,6 +282,20 @@ export class Options {
   }
 
   /**
+   * Enables face landmark detection. Provides 478 per-face landmarks in
+   * world space, optional 52 ARKit-style blendshape weights, and an
+   * optional rigid 4x4 facial transformation matrix per detected face.
+   * @returns The instance for chaining.
+   */
+  enableFaceDetection() {
+    this.permissions.camera = true;
+    this.enableCamera();
+    this.enableDepth();
+    this.world.enableFaceDetection();
+    return this;
+  }
+
+  /**
    * Enables device camera (passthrough) with a specific facing mode.
    * @param facingMode - The desired camera facing mode, either 'environment' or
    *     'user'.

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -14,6 +14,7 @@ import {placeOnHorizontalSurface} from './HorizontalPlacement';
 // Import other modules as they are implemented in future.
 // import { LightEstimation } from '/lighting/LightEstimation.js';
 import {HumanRecognizer} from './humans/HumanRecognizer';
+import {FaceRecognizer} from './faces/FaceRecognizer';
 
 /**
  * Manages all interactions with the real-world environment perceived by the XR
@@ -71,6 +72,11 @@ export class World extends Script {
    * The human recognition/pose module instance. Null if not enabled.
    */
   humans?: HumanRecognizer;
+
+  /**
+   * The face landmark detection module instance. Null if not enabled.
+   */
+  faces?: FaceRecognizer;
 
   /**
    * A Three.js Raycaster for performing intersection tests.
@@ -140,6 +146,11 @@ export class World extends Script {
     if (this.options.humans.enabled) {
       this.humans = new HumanRecognizer();
       this.add(this.humans);
+    }
+
+    if (this.options.faces.enabled) {
+      this.faces = new FaceRecognizer();
+      this.add(this.faces);
     }
 
     // TODO: Initialize other modules as they are available & implemented.

--- a/src/world/WorldOptions.ts
+++ b/src/world/WorldOptions.ts
@@ -6,6 +6,7 @@ import {ObjectsOptions} from './objects/ObjectsOptions';
 import {PlanesOptions} from './planes/PlanesOptions';
 import {SoundsOptions} from './sounds/SoundsOptions';
 import {HumansOptions} from './humans/HumansOptions';
+import {FacesOptions} from './faces/FacesOptions';
 
 export class WorldOptions {
   debugging = false;
@@ -16,6 +17,7 @@ export class WorldOptions {
   meshes = new MeshDetectionOptions();
   sounds = new SoundsOptions();
   humans = new HumansOptions();
+  faces = new FacesOptions();
 
   constructor(options?: DeepPartial<WorldOptions>) {
     if (options) {
@@ -65,6 +67,15 @@ export class WorldOptions {
   enableHumanDetection() {
     this.enabled = true;
     this.humans.enable();
+    return this;
+  }
+
+  /**
+   * Enables face landmark detection.
+   */
+  enableFaceDetection() {
+    this.enabled = true;
+    this.faces.enable();
     return this;
   }
 }

--- a/src/world/faces/DetectedFace.test.ts
+++ b/src/world/faces/DetectedFace.test.ts
@@ -1,0 +1,140 @@
+import * as THREE from 'three';
+import {describe, it, expect} from 'vitest';
+
+import {
+  DetectedFace,
+  FaceBlendshape,
+  FaceLandmark,
+  FaceLandmarkName,
+} from './DetectedFace';
+
+// Build a 478-entry landmark array with a few specific indices populated.
+// Anything not named defaults to (0,0,0) with no worldPosition. The model
+// always emits 478 entries (468 mesh + 10 iris); tests should stay
+// representative of that shape.
+function makeLandmarks(
+  populated: Record<number, [number, number, number, [number, number, number]?]>
+): FaceLandmark[] {
+  const out: FaceLandmark[] = [];
+  for (let i = 0; i < 478; i++) {
+    const entry = populated[i];
+    if (entry) {
+      const [x, y, z, wp] = entry;
+      out.push({
+        x,
+        y,
+        z,
+        worldPosition: wp ? new THREE.Vector3(wp[0], wp[1], wp[2]) : undefined,
+      });
+    } else {
+      out.push({x: 0, y: 0, z: 0});
+    }
+  }
+  return out;
+}
+
+function makeBbox(): THREE.Box2 {
+  return new THREE.Box2(
+    new THREE.Vector2(0.3, 0.2),
+    new THREE.Vector2(0.7, 0.8)
+  );
+}
+
+describe('DetectedFace', () => {
+  it('defaults Object3D position to the projected nose-tip world position', () => {
+    // Mesh index 1 is the canonical nose tip in MediaPipe's face mesh.
+    const landmarks = makeLandmarks({1: [0.5, 0.5, 0, [0.1, 1.6, -0.4]]});
+    const face = new DetectedFace(0, landmarks, makeBbox());
+    expect(face.position.x).toBeCloseTo(0.1);
+    expect(face.position.y).toBeCloseTo(1.6);
+    expect(face.position.z).toBeCloseTo(-0.4);
+  });
+
+  it('leaves position at origin when nose tip has no world projection', () => {
+    // Provide screen coords but no worldPosition: depth raycast missed.
+    const landmarks = makeLandmarks({1: [0.5, 0.5, 0]});
+    const face = new DetectedFace(0, landmarks, makeBbox());
+    expect(face.position.x).toBe(0);
+    expect(face.position.y).toBe(0);
+    expect(face.position.z).toBe(0);
+  });
+
+  it('decomposes the facial transformation matrix onto position/quaternion/scale when present', () => {
+    const landmarks = makeLandmarks({1: [0.5, 0.5, 0, [0.1, 1.6, -0.4]]});
+    // Translation-only matrix at (0.5, 1.8, -0.7), no rotation, no scale.
+    const mat = new THREE.Matrix4().makeTranslation(0.5, 1.8, -0.7);
+    const face = new DetectedFace(0, landmarks, makeBbox(), [], mat);
+    // Decomposed translation should override the nose-tip default.
+    expect(face.position.x).toBeCloseTo(0.5);
+    expect(face.position.y).toBeCloseTo(1.8);
+    expect(face.position.z).toBeCloseTo(-0.7);
+    expect(face.scale.x).toBeCloseTo(1);
+  });
+
+  it('getLandmarkPosition returns world coords for named anchors', () => {
+    // Populate the canonical indices for nose tip (1) and left pupil (473).
+    const landmarks = makeLandmarks({
+      1: [0.5, 0.5, 0, [0, 1.6, -0.5]],
+      473: [0.55, 0.45, 0, [0.02, 1.62, -0.5]],
+    });
+    const face = new DetectedFace(0, landmarks, makeBbox());
+    const nose = face.getLandmarkPosition(FaceLandmarkName.NoseTip);
+    expect(nose).not.toBeNull();
+    expect(nose!.x).toBeCloseTo(0);
+
+    const leftPupil = face.getLandmarkPosition(FaceLandmarkName.LeftPupil);
+    expect(leftPupil).not.toBeNull();
+    expect(leftPupil!.x).toBeCloseTo(0.02);
+  });
+
+  it('getLandmarkPosition returns null when the landmark has no world projection', () => {
+    const landmarks = makeLandmarks({1: [0.5, 0.5, 0]}); // no worldPosition
+    const face = new DetectedFace(0, landmarks, makeBbox());
+    expect(face.getLandmarkPosition(FaceLandmarkName.NoseTip)).toBeNull();
+  });
+
+  it('getLandmarkPosition returns a clone so callers can mutate safely', () => {
+    const landmarks = makeLandmarks({1: [0.5, 0.5, 0, [1, 2, 3]]});
+    const face = new DetectedFace(0, landmarks, makeBbox());
+    const a = face.getLandmarkPosition(FaceLandmarkName.NoseTip)!;
+    a.set(0, 0, 0);
+    const b = face.getLandmarkPosition(FaceLandmarkName.NoseTip)!;
+    expect(b.x).toBeCloseTo(1);
+    expect(b.y).toBeCloseTo(2);
+    expect(b.z).toBeCloseTo(3);
+  });
+
+  it('getBlendshape looks up by ARKit category name and falls back to 0', () => {
+    const landmarks = makeLandmarks({});
+    const blendshapes: FaceBlendshape[] = [
+      {categoryName: 'jawOpen', score: 0.7},
+      {categoryName: 'mouthSmileLeft', score: 0.2},
+    ];
+    const face = new DetectedFace(0, landmarks, makeBbox(), blendshapes);
+    expect(face.getBlendshape('jawOpen')).toBeCloseTo(0.7);
+    expect(face.getBlendshape('mouthSmileLeft')).toBeCloseTo(0.2);
+    // Unknown / unemitted categories: 0, not undefined.
+    expect(face.getBlendshape('mouthSmileRight')).toBe(0);
+    expect(face.getBlendshape('notARealBlendshape')).toBe(0);
+  });
+
+  it('handles an empty blendshapes array (backend configured with output disabled)', () => {
+    const face = new DetectedFace(0, makeLandmarks({}), makeBbox());
+    expect(face.blendshapes).toHaveLength(0);
+    expect(face.getBlendshape('jawOpen')).toBe(0);
+  });
+
+  it('extends Object3D so it slots into the scene graph', () => {
+    const face = new DetectedFace(0, makeLandmarks({}), makeBbox());
+    expect(face).toBeInstanceOf(THREE.Object3D);
+    // Should be add()-able to a parent.
+    const parent = new THREE.Group();
+    parent.add(face);
+    expect(face.parent).toBe(parent);
+  });
+
+  it('preserves the faceId for tracking across frames', () => {
+    const face = new DetectedFace(42, makeLandmarks({}), makeBbox());
+    expect(face.faceId).toBe(42);
+  });
+});

--- a/src/world/faces/DetectedFace.ts
+++ b/src/world/faces/DetectedFace.ts
@@ -1,0 +1,167 @@
+import * as THREE from 'three';
+
+/**
+ * A single facial landmark point. MediaPipe's FaceLandmarker emits 478
+ * of these per face (468 from the canonical face mesh + 10 iris points).
+ */
+export interface FaceLandmark {
+  /**
+   * Normalized horizontal coordinate [0.0, 1.0] in screen space,
+   * where 0.0 is the left edge and 1.0 is the right edge.
+   */
+  x: number;
+  /**
+   * Normalized vertical coordinate [0.0, 1.0] in screen space,
+   * where 0.0 is the top edge and 1.0 is the bottom edge.
+   */
+  y: number;
+  /**
+   * Raw estimated depth value relative to the camera. Smaller magnitude
+   * means closer to the camera; the value is in the same arbitrary
+   * normalized space as `x` and `y`.
+   */
+  z: number;
+  /**
+   * The back-projected 3D position in WebXR world space, measured in
+   * meters. Null or undefined if depth projection was unsuccessful.
+   */
+  worldPosition?: THREE.Vector3;
+}
+
+/**
+ * A single blendshape category and its activation weight. The category
+ * names follow the ARKit blendshape vocabulary used by MediaPipe's
+ * Face Landmarker (e.g. `jawOpen`, `mouthSmileLeft`, `eyeBlinkRight`).
+ */
+export interface FaceBlendshape {
+  /**
+   * The category name (ARKit / FaceLandmarker convention).
+   */
+  categoryName: string;
+  /**
+   * Activation weight in `[0.0, 1.0]`. Zero means the blendshape is
+   * fully off; one means fully on. MediaPipe applies internal
+   * smoothing so consecutive frames don't jitter.
+   */
+  score: number;
+}
+
+/**
+ * Common facial landmark anchor names. These map to specific indices
+ * in the 478-point MediaPipe FaceLandmarker mesh and are exposed for
+ * convenience so callers can read e.g. the nose tip without memorising
+ * the index 1.
+ */
+export enum FaceLandmarkName {
+  NoseTip = 'noseTip',
+  Chin = 'chin',
+  LeftEyeOuterCorner = 'leftEyeOuterCorner',
+  LeftEyeInnerCorner = 'leftEyeInnerCorner',
+  RightEyeOuterCorner = 'rightEyeOuterCorner',
+  RightEyeInnerCorner = 'rightEyeInnerCorner',
+  LeftPupil = 'leftPupil',
+  RightPupil = 'rightPupil',
+  MouthLeftCorner = 'mouthLeftCorner',
+  MouthRightCorner = 'mouthRightCorner',
+  UpperLipCenter = 'upperLipCenter',
+  LowerLipCenter = 'lowerLipCenter',
+  ForeheadCenter = 'foreheadCenter',
+}
+
+/**
+ * Maps the named anchors above to FaceLandmarker mesh indices. Source:
+ * MediaPipe FaceLandmarker canonical face mesh topology, plus the iris
+ * sub-model (indices 468..477) for pupil centres.
+ */
+const LANDMARK_INDEX: Record<FaceLandmarkName, number> = {
+  [FaceLandmarkName.NoseTip]: 1,
+  [FaceLandmarkName.Chin]: 152,
+  [FaceLandmarkName.LeftEyeOuterCorner]: 263,
+  [FaceLandmarkName.LeftEyeInnerCorner]: 362,
+  [FaceLandmarkName.RightEyeOuterCorner]: 33,
+  [FaceLandmarkName.RightEyeInnerCorner]: 133,
+  [FaceLandmarkName.LeftPupil]: 473,
+  [FaceLandmarkName.RightPupil]: 468,
+  [FaceLandmarkName.MouthLeftCorner]: 291,
+  [FaceLandmarkName.MouthRightCorner]: 61,
+  [FaceLandmarkName.UpperLipCenter]: 13,
+  [FaceLandmarkName.LowerLipCenter]: 14,
+  [FaceLandmarkName.ForeheadCenter]: 10,
+};
+
+/**
+ * Represents a single human face detected in physical space.
+ * Inherits from `THREE.Object3D` to fit naturally into the Three.js
+ * scene graph, positioning itself at the estimated nose tip of the
+ * tracked face. When a facial transformation matrix is emitted by the
+ * backend it is decomposed onto `position`, `quaternion`, and `scale`
+ * so the Object3D directly represents the rigid head pose.
+ */
+export class DetectedFace extends THREE.Object3D {
+  /**
+   * Creates an instance of DetectedFace.
+   *
+   * @param faceId - A unique tracking identifier for this face.
+   * @param landmarks - The 478 raw + 3D-projected facial landmarks.
+   * @param detection2DBoundingBox - The 2D bounding box of the face in
+   *     normalized screen space.
+   * @param blendshapes - Optional 52 ARKit-style blendshape weights.
+   *     Empty when the backend was configured with
+   *     `outputFaceBlendshapes: false`.
+   * @param facialTransformationMatrix - Optional 4x4 rigid head pose
+   *     matrix in world space. Null when the backend was configured
+   *     with `outputFacialTransformationMatrixes: false`.
+   */
+  constructor(
+    public faceId: number,
+    public landmarks: FaceLandmark[],
+    public detection2DBoundingBox: THREE.Box2,
+    public blendshapes: FaceBlendshape[] = [],
+    public facialTransformationMatrix: THREE.Matrix4 | null = null
+  ) {
+    super();
+    // Default Object3D position to the projected nose tip so consumers
+    // can parent objects to `face.position` without first decoding a
+    // landmark index.
+    const nose = this.getLandmarkPosition(FaceLandmarkName.NoseTip);
+    if (nose) {
+      this.position.copy(nose);
+    }
+    // If a rigid facial transformation matrix is available, decompose
+    // it onto position/quaternion/scale. This overrides the nose-tip
+    // default with a more stable head pose suitable for parenting
+    // glasses or masks.
+    if (this.facialTransformationMatrix) {
+      this.facialTransformationMatrix.decompose(
+        this.position,
+        this.quaternion,
+        this.scale
+      );
+    }
+  }
+
+  /**
+   * Returns the 3D world-space position of a named facial landmark.
+   *
+   * @param name - The landmark name to look up.
+   * @returns A clone of the landmark's world position, or `null` if the
+   *     index is out of range or depth back-projection was unsuccessful.
+   */
+  getLandmarkPosition(name: FaceLandmarkName): THREE.Vector3 | null {
+    const index = LANDMARK_INDEX[name];
+    if (index === undefined) return null;
+    const lm = this.landmarks[index];
+    return lm && lm.worldPosition ? lm.worldPosition.clone() : null;
+  }
+
+  /**
+   * Returns the score for a blendshape category, or `0` if the category
+   * isn't present in the current detection.
+   *
+   * @param categoryName - The ARKit category name, e.g. `jawOpen`.
+   */
+  getBlendshape(categoryName: string): number {
+    const bs = this.blendshapes.find((b) => b.categoryName === categoryName);
+    return bs ? bs.score : 0;
+  }
+}

--- a/src/world/faces/FaceDetectorBackend.ts
+++ b/src/world/faces/FaceDetectorBackend.ts
@@ -1,0 +1,102 @@
+import * as THREE from 'three';
+import {CameraParametersSnapshot} from '../../camera/CameraUtils';
+import {XRDeviceCamera} from '../../camera/XRDeviceCamera';
+import {WorldOptions} from '../WorldOptions';
+import {DetectedFace} from './DetectedFace';
+
+/**
+ * Context provided to the face detection backend.
+ * Contains shared dependencies and configuration options necessary for the
+ * backend to run face landmark detection and map coordinates.
+ */
+export interface FaceBackendContext {
+  /**
+   * The global world configuration options, containing settings for
+   * backends, thresholds, etc.
+   */
+  readonly options: WorldOptions;
+  /**
+   * Access to the XR device's camera for capturing snapshots of the
+   * physical environment.
+   */
+  readonly deviceCamera: XRDeviceCamera;
+}
+
+/**
+ * Abstract base class for all face landmark detection backends (e.g.
+ * MediaPipe).
+ *
+ * Implements a Template Method pattern via `run()`, which orchestrates
+ * the detection pipeline by checking availability, acquiring a camera
+ * snapshot, and calling the abstract `detect()` hook implemented by
+ * specific backends.
+ */
+export abstract class BaseFaceBackend {
+  /**
+   * Creates an instance of BaseFaceBackend.
+   * @param context - The shared dependency and configuration context.
+   */
+  constructor(protected context: FaceBackendContext) {}
+
+  /**
+   * The orchestration pipeline (Template Method) for running face
+   * detection. Checks backend availability and obtains a camera
+   * snapshot before running the concrete detection model.
+   *
+   * @param depthMeshSnapshot - The current 3D depth mesh snapshot of
+   *     the physical environment.
+   * @param cameraParametersSnapshot - The current camera parameters
+   *     and matrix transforms.
+   * @returns A promise that resolves to an array of detected faces.
+   */
+  async run(
+    depthMeshSnapshot: THREE.Mesh,
+    cameraParametersSnapshot: CameraParametersSnapshot
+  ): Promise<DetectedFace[]> {
+    if (!(await this.isAvailable())) {
+      return [];
+    }
+
+    const snapshot = await this.getSnapshot();
+    if (!snapshot) {
+      return [];
+    }
+
+    return this.detect(snapshot, depthMeshSnapshot, cameraParametersSnapshot);
+  }
+
+  /**
+   * Checks whether this face detection backend is fully loaded,
+   * initialized, and available to perform inference.
+   *
+   * @returns A promise resolving to `true` if available, otherwise
+   *     `false`.
+   */
+  protected abstract isAvailable(): Promise<boolean>;
+
+  /**
+   * Acquires a snapshot image from the device camera to use for face
+   * detection.
+   *
+   * @returns A promise resolving to the camera image data snapshot, or
+   *     `null` if unavailable.
+   */
+  protected abstract getSnapshot(): Promise<{imageData: ImageData} | null>;
+
+  /**
+   * Abstract hook implemented by subclasses to perform the actual model
+   * inference and landmark extraction.
+   *
+   * @param snapshot - The camera image data snapshot.
+   * @param depthMeshSnapshot - The current 3D depth mesh snapshot of
+   *     the physical environment.
+   * @param cameraParametersSnapshot - The current camera parameters and
+   *     matrix transforms.
+   * @returns A promise resolving to the list of detected faces.
+   */
+  protected abstract detect(
+    snapshot: {imageData: ImageData},
+    depthMeshSnapshot: THREE.Mesh,
+    cameraParametersSnapshot: CameraParametersSnapshot
+  ): Promise<DetectedFace[]>;
+}

--- a/src/world/faces/FaceRecognizer.ts
+++ b/src/world/faces/FaceRecognizer.ts
@@ -1,0 +1,149 @@
+import * as THREE from 'three';
+import {getCameraParametersSnapshot} from '../../camera/CameraUtils';
+import {XRDeviceCamera} from '../../camera/XRDeviceCamera';
+import {Script} from '../../core/Script';
+import {Depth} from '../../depth/Depth';
+import {WorldOptions} from '../WorldOptions';
+import {DetectedFace} from './DetectedFace';
+import {BaseFaceBackend, FaceBackendContext} from './FaceDetectorBackend';
+import {MediaPipeFaceBackend} from './backends/MediaPipeFaceBackend';
+
+/**
+ * A detector script that orchestrates face landmark estimation. Manages
+ * the backend face detector lifecycle (e.g. MediaPipe) and exposes the
+ * detected faces, including 3D landmark positions, blendshape weights,
+ * and rigid head transforms, in the world coordinate space.
+ */
+export class FaceRecognizer extends Script {
+  static dependencies = {
+    options: WorldOptions,
+    deviceCamera: XRDeviceCamera,
+    depth: Depth,
+    camera: THREE.Camera,
+    renderer: THREE.WebGLRenderer,
+  };
+
+  private _detectorBackends = new Map<string, Promise<BaseFaceBackend>>();
+
+  // Injected dependencies
+  private options!: WorldOptions;
+  private deviceCamera!: XRDeviceCamera;
+  public depth!: Depth;
+  private camera!: THREE.PerspectiveCamera;
+  private renderer!: THREE.WebGLRenderer;
+
+  targetDevice = 'galaxyxr';
+
+  init({
+    options,
+    deviceCamera,
+    depth,
+    camera,
+    renderer,
+  }: {
+    options: WorldOptions;
+    deviceCamera: XRDeviceCamera;
+    depth: Depth;
+    camera: THREE.PerspectiveCamera;
+    renderer: THREE.WebGLRenderer;
+  }) {
+    this.options = options;
+    this.deviceCamera = deviceCamera;
+    this.depth = depth;
+    this.camera = camera;
+    this.renderer = renderer;
+  }
+
+  /**
+   * Runs the face landmark detection process based on the configured
+   * backend.
+   */
+  async runDetection(): Promise<DetectedFace[]> {
+    this.clear();
+
+    if (!this.depth || !this.depth.depthMesh) {
+      console.warn(
+        'Cannot run Face Detection: Depth module / depthMesh is not enabled or initialized.'
+      );
+      return [];
+    }
+
+    const depthMeshSnapshot = this.getDepthMeshSnapshot();
+    const cameraParametersSnapshot = getCameraParametersSnapshot(
+      this.camera,
+      this.renderer.xr.getCamera(),
+      this.deviceCamera,
+      this.targetDevice
+    );
+
+    const context = this.getBackendContext();
+    const activeBackend = this.options.faces.backendConfig.activeBackend;
+    const backendPromise = this.getOrCreateBackend(activeBackend, context);
+
+    let backend: BaseFaceBackend;
+    try {
+      backend = await backendPromise;
+    } catch (error: unknown) {
+      console.warn(
+        `Failed to load or initialize FaceRecognizer backend '${activeBackend}':`,
+        error
+      );
+      return [];
+    }
+
+    const faces = await backend.run(
+      depthMeshSnapshot,
+      cameraParametersSnapshot
+    );
+
+    return faces;
+  }
+
+  private getBackendContext(): FaceBackendContext {
+    return {
+      options: this.options,
+      deviceCamera: this.deviceCamera,
+    };
+  }
+
+  private getOrCreateBackend(
+    activeBackend: string,
+    context: FaceBackendContext
+  ): Promise<BaseFaceBackend> {
+    let backendPromise = this._detectorBackends.get(activeBackend);
+
+    if (!backendPromise) {
+      backendPromise = (async () => {
+        switch (activeBackend) {
+          case 'mediapipe':
+            return new MediaPipeFaceBackend(context);
+          default:
+            throw new Error(
+              `FaceRecognizer backend '${activeBackend}' is not supported.`
+            );
+        }
+      })();
+      this._detectorBackends.set(activeBackend, backendPromise);
+    }
+    return backendPromise;
+  }
+
+  private getDepthMeshSnapshot() {
+    const depthMesh = this.depth.depthMesh!;
+    const geometry = this.depth.options.depthMesh.updateFullResolutionGeometry
+      ? depthMesh.geometry
+      : depthMesh.downsampledGeometry || depthMesh.geometry;
+    const clonedGeometry = geometry.clone();
+    clonedGeometry.computeBoundingSphere();
+    clonedGeometry.computeBoundingBox();
+    const depthMeshSnapshot = new THREE.Mesh(
+      clonedGeometry,
+      new THREE.MeshBasicMaterial()
+    );
+    depthMesh.getWorldPosition(depthMeshSnapshot.position);
+    depthMesh.getWorldQuaternion(depthMeshSnapshot.quaternion);
+    depthMesh.getWorldScale(depthMeshSnapshot.scale);
+    depthMeshSnapshot.updateMatrixWorld(true);
+    return depthMeshSnapshot;
+  }
+}

--- a/src/world/faces/FacesOptions.test.ts
+++ b/src/world/faces/FacesOptions.test.ts
@@ -1,0 +1,67 @@
+import {describe, it, expect} from 'vitest';
+
+import {FacesOptions} from './FacesOptions';
+
+describe('FacesOptions', () => {
+  it('disables face detection by default', () => {
+    const opts = new FacesOptions();
+    expect(opts.enabled).toBe(false);
+  });
+
+  it('defaults to the mediapipe backend with the public model URL', () => {
+    const opts = new FacesOptions();
+    expect(opts.backendConfig.activeBackend).toBe('mediapipe');
+    expect(opts.backendConfig.mediapipe.modelAssetPath).toContain(
+      'face_landmarker'
+    );
+    expect(opts.backendConfig.mediapipe.wasmFilesUrl).toContain(
+      '@mediapipe/tasks-vision'
+    );
+  });
+
+  it('opts users into blendshapes and the facial transformation matrix', () => {
+    // Both are the most actionable downstream signals (lipsync, head pose).
+    // Keep them ON by default so consumers do not silently miss them.
+    const opts = new FacesOptions();
+    expect(opts.backendConfig.mediapipe.outputFaceBlendshapes).toBe(true);
+    expect(
+      opts.backendConfig.mediapipe.outputFacialTransformationMatrixes
+    ).toBe(true);
+  });
+
+  it('uses balanced confidence thresholds (0.5 across the three gates)', () => {
+    const opts = new FacesOptions();
+    const mp = opts.backendConfig.mediapipe;
+    expect(mp.minFaceDetectionConfidence).toBe(0.5);
+    expect(mp.minFacePresenceConfidence).toBe(0.5);
+    expect(mp.minTrackingConfidence).toBe(0.5);
+  });
+
+  it('deep-merges constructor overrides while keeping unspecified defaults', () => {
+    const opts = new FacesOptions({
+      backendConfig: {
+        mediapipe: {
+          numFaces: 4,
+          minFaceDetectionConfidence: 0.8,
+        },
+      },
+    });
+    // Overridden fields take the new value.
+    expect(opts.backendConfig.mediapipe.numFaces).toBe(4);
+    expect(opts.backendConfig.mediapipe.minFaceDetectionConfidence).toBeCloseTo(
+      0.8
+    );
+    // Untouched fields keep their defaults so partial config does not zero
+    // out unrelated tuning.
+    expect(opts.backendConfig.mediapipe.minTrackingConfidence).toBe(0.5);
+    expect(opts.backendConfig.mediapipe.outputFaceBlendshapes).toBe(true);
+    expect(opts.backendConfig.activeBackend).toBe('mediapipe');
+  });
+
+  it('enable() flips enabled and returns the instance for chaining', () => {
+    const opts = new FacesOptions();
+    const ret = opts.enable();
+    expect(opts.enabled).toBe(true);
+    expect(ret).toBe(opts);
+  });
+});

--- a/src/world/faces/FacesOptions.ts
+++ b/src/world/faces/FacesOptions.ts
@@ -1,0 +1,64 @@
+import {deepMerge} from '../../utils/OptionsUtils';
+import {DeepPartial} from '../../utils/Types';
+
+/**
+ * Configuration options for the Face Landmark Detection system.
+ */
+export class FacesOptions {
+  enabled = false;
+
+  /**
+   * Configuration options for the active face detection backend.
+   */
+  backendConfig = {
+    activeBackend: 'mediapipe',
+    mediapipe: {
+      wasmFilesUrl:
+        'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@latest/wasm',
+      modelAssetPath:
+        'https://storage.googleapis.com/mediapipe-models/face_landmarker/face_landmarker/float16/latest/face_landmarker.task',
+      /**
+       * The maximum number of simultaneous faces to track.
+       */
+      numFaces: 1,
+      /**
+       * The minimum confidence score [0.0, 1.0] required for a face to be
+       * detected.
+       */
+      minFaceDetectionConfidence: 0.5,
+      /**
+       * The minimum confidence score [0.0, 1.0] required to confirm a face is
+       * still present.
+       */
+      minFacePresenceConfidence: 0.5,
+      /**
+       * The minimum confidence score [0.0, 1.0] required for tracking
+       * landmarks between frames.
+       */
+      minTrackingConfidence: 0.5,
+      /**
+       * Whether to compute and emit per-face blendshape weights (52
+       * ARKit-compatible categories). Required for facial expression
+       * mirroring, lipsync feeds, and avatar animation.
+       */
+      outputFaceBlendshapes: true,
+      /**
+       * Whether to compute and emit the 4x4 facial transformation matrix
+       * for each face. Provides a stable rigid head pose for parenting
+       * objects to the head (glasses, masks, hats).
+       */
+      outputFacialTransformationMatrixes: true,
+    },
+  };
+
+  constructor(options?: DeepPartial<FacesOptions>) {
+    if (options) {
+      deepMerge(this, options);
+    }
+  }
+
+  enable() {
+    this.enabled = true;
+    return this;
+  }
+}

--- a/src/world/faces/backends/MediaPipeFaceBackend.test.ts
+++ b/src/world/faces/backends/MediaPipeFaceBackend.test.ts
@@ -1,0 +1,261 @@
+import * as THREE from 'three';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+
+import {DetectedFace} from '../DetectedFace';
+import {processFaceLandmarkerResult} from './MediaPipeFaceBackend';
+
+// Mock CameraUtils.transformRgbUvToWorld so the test never touches a real
+// depth mesh. We control whether the raycast "hits" by returning either a
+// world position object or null, which exercises both the depth-mesh path
+// and the camera-frustum fallback path inside processFaceLandmarkerResult.
+vi.mock('../../../camera/CameraUtils', () => ({
+  transformRgbUvToWorld: vi.fn(),
+}));
+
+import {transformRgbUvToWorld} from '../../../camera/CameraUtils';
+
+// Minimal snapshot inputs. The function only touches
+// cameraParametersSnapshot when the raycast misses; the depth mesh is
+// passed through to transformRgbUvToWorld (which we've mocked) so it
+// can be any THREE.Mesh.
+function makeSnapshots() {
+  const depthMeshSnapshot = new THREE.Mesh(new THREE.BufferGeometry());
+  const worldFromView = new THREE.Matrix4().makeTranslation(0, 1.6, 0);
+  // Identity worldFromClip means clip-space points stay where they are
+  // in world space, which makes the fallback math easy to assert.
+  const worldFromClip = new THREE.Matrix4();
+  return {
+    depthMeshSnapshot,
+    cameraParametersSnapshot: {
+      worldFromView,
+      worldFromClip,
+      // The fallback only reads worldFromView and worldFromClip; the
+      // other fields can be omitted for these tests.
+    } as never,
+  };
+}
+
+// Build a synthetic MediaPipe FaceLandmarkerResult shaped exactly like
+// the @mediapipe/tasks-vision package emits. The mesh always carries 478
+// landmarks but for tests we only need a handful populated.
+function makeMpResult({
+  numFaces = 1,
+  withBlendshapes = false,
+  withMatrix = false,
+}: {
+  numFaces?: number;
+  withBlendshapes?: boolean;
+  withMatrix?: boolean;
+} = {}): never {
+  const faceLandmarks: Array<Array<{x: number; y: number; z: number}>> = [];
+  for (let f = 0; f < numFaces; f++) {
+    const pts = [];
+    for (let i = 0; i < 478; i++) {
+      // Spread the synthetic landmarks across the bounding region so the
+      // backend's bbox computation has something non-degenerate to chew on.
+      pts.push({
+        x: 0.3 + ((i + f * 50) % 100) / 250,
+        y: 0.2 + ((i * 3 + f * 30) % 100) / 200,
+        z: i * 0.0001,
+      });
+    }
+    faceLandmarks.push(pts);
+  }
+  const result: Record<string, unknown> = {faceLandmarks};
+  if (withBlendshapes) {
+    result.faceBlendshapes = faceLandmarks.map((_, i) => ({
+      categories: [
+        {categoryName: 'jawOpen', score: 0.4 + i * 0.1},
+        {categoryName: 'mouthSmileLeft', score: 0.2},
+      ],
+    }));
+  }
+  if (withMatrix) {
+    result.facialTransformationMatrixes = faceLandmarks.map((_, i) => ({
+      // Column-major translation matrix moving the face to (0, 1+i, -0.5).
+      // Identity rotation/scale so decompose is round-trippable.
+      data: new Float32Array([
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        1 + i,
+        -0.5,
+        1,
+      ]),
+    }));
+  }
+  return result as never;
+}
+
+describe('processFaceLandmarkerResult', () => {
+  beforeEach(() => {
+    vi.mocked(transformRgbUvToWorld).mockReset();
+  });
+
+  it('returns an empty array when the MediaPipe result has no faces', () => {
+    const {depthMeshSnapshot, cameraParametersSnapshot} = makeSnapshots();
+    const result = makeMpResult({numFaces: 0});
+    const out = processFaceLandmarkerResult(
+      result,
+      depthMeshSnapshot,
+      cameraParametersSnapshot
+    );
+    expect(out).toEqual([]);
+    expect(transformRgbUvToWorld).not.toHaveBeenCalled();
+  });
+
+  it('produces one DetectedFace per landmark cluster with a faceId equal to its index', () => {
+    const {depthMeshSnapshot, cameraParametersSnapshot} = makeSnapshots();
+    vi.mocked(transformRgbUvToWorld).mockReturnValue({
+      worldPosition: new THREE.Vector3(0, 1.6, -0.5),
+    } as never);
+    const result = makeMpResult({numFaces: 3});
+    const out = processFaceLandmarkerResult(
+      result,
+      depthMeshSnapshot,
+      cameraParametersSnapshot
+    );
+    expect(out).toHaveLength(3);
+    expect(out[0]).toBeInstanceOf(DetectedFace);
+    expect(out.map((f) => f.faceId)).toEqual([0, 1, 2]);
+    // Each face should carry all 478 landmarks.
+    for (const face of out) {
+      expect(face.landmarks).toHaveLength(478);
+    }
+  });
+
+  it('uses the depth-mesh raycast result when transformRgbUvToWorld returns a hit', () => {
+    const {depthMeshSnapshot, cameraParametersSnapshot} = makeSnapshots();
+    const expectedHit = new THREE.Vector3(0.42, 1.65, -0.55);
+    vi.mocked(transformRgbUvToWorld).mockReturnValue({
+      worldPosition: expectedHit,
+    } as never);
+    const result = makeMpResult();
+    const out = processFaceLandmarkerResult(
+      result,
+      depthMeshSnapshot,
+      cameraParametersSnapshot
+    );
+    expect(out[0].landmarks[0].worldPosition).toBe(expectedHit);
+  });
+
+  it('falls back to camera-frustum back-projection when the depth raycast misses', () => {
+    const {depthMeshSnapshot, cameraParametersSnapshot} = makeSnapshots();
+    vi.mocked(transformRgbUvToWorld).mockReturnValue(null as never);
+    const result = makeMpResult();
+    const out = processFaceLandmarkerResult(
+      result,
+      depthMeshSnapshot,
+      cameraParametersSnapshot
+    );
+    // Every landmark should still have a worldPosition (the fallback
+    // always produces one), so the SDK never returns half-populated
+    // faces to the caller.
+    for (const lm of out[0].landmarks) {
+      expect(lm.worldPosition).toBeDefined();
+      expect(Number.isFinite(lm.worldPosition!.x)).toBe(true);
+      expect(Number.isFinite(lm.worldPosition!.y)).toBe(true);
+      expect(Number.isFinite(lm.worldPosition!.z)).toBe(true);
+    }
+  });
+
+  it('emits an empty blendshapes array when MediaPipe did not return any', () => {
+    const {depthMeshSnapshot, cameraParametersSnapshot} = makeSnapshots();
+    vi.mocked(transformRgbUvToWorld).mockReturnValue({
+      worldPosition: new THREE.Vector3(0, 1.6, -0.5),
+    } as never);
+    const result = makeMpResult({withBlendshapes: false});
+    const out = processFaceLandmarkerResult(
+      result,
+      depthMeshSnapshot,
+      cameraParametersSnapshot
+    );
+    expect(out[0].blendshapes).toEqual([]);
+  });
+
+  it('passes blendshape categories through verbatim (name + score)', () => {
+    const {depthMeshSnapshot, cameraParametersSnapshot} = makeSnapshots();
+    vi.mocked(transformRgbUvToWorld).mockReturnValue({
+      worldPosition: new THREE.Vector3(0, 1.6, -0.5),
+    } as never);
+    const result = makeMpResult({withBlendshapes: true});
+    const out = processFaceLandmarkerResult(
+      result,
+      depthMeshSnapshot,
+      cameraParametersSnapshot
+    );
+    expect(out[0].blendshapes).toEqual([
+      {categoryName: 'jawOpen', score: 0.4},
+      {categoryName: 'mouthSmileLeft', score: 0.2},
+    ]);
+    // The lookup helper should match the verbatim category names.
+    expect(out[0].getBlendshape('jawOpen')).toBeCloseTo(0.4);
+  });
+
+  it('leaves facialTransformationMatrix null when MediaPipe did not return one', () => {
+    const {depthMeshSnapshot, cameraParametersSnapshot} = makeSnapshots();
+    vi.mocked(transformRgbUvToWorld).mockReturnValue({
+      worldPosition: new THREE.Vector3(0, 1.6, -0.5),
+    } as never);
+    const result = makeMpResult({withMatrix: false});
+    const out = processFaceLandmarkerResult(
+      result,
+      depthMeshSnapshot,
+      cameraParametersSnapshot
+    );
+    expect(out[0].facialTransformationMatrix).toBeNull();
+  });
+
+  it('builds the facial transformation matrix from the column-major MediaPipe data and decomposes onto the Object3D', () => {
+    const {depthMeshSnapshot, cameraParametersSnapshot} = makeSnapshots();
+    vi.mocked(transformRgbUvToWorld).mockReturnValue({
+      worldPosition: new THREE.Vector3(0, 1.6, -0.5),
+    } as never);
+    const result = makeMpResult({withMatrix: true});
+    const out = processFaceLandmarkerResult(
+      result,
+      depthMeshSnapshot,
+      cameraParametersSnapshot
+    );
+    // The mock matrix translates to (0, 1, -0.5) for face 0. The
+    // decomposed transform should override the depth-projected nose
+    // tip so callers can parent objects directly to face.position.
+    expect(out[0].facialTransformationMatrix).not.toBeNull();
+    expect(out[0].position.x).toBeCloseTo(0);
+    expect(out[0].position.y).toBeCloseTo(1);
+    expect(out[0].position.z).toBeCloseTo(-0.5);
+  });
+
+  it('computes a tight normalized 2D bounding box from the landmark spread', () => {
+    const {depthMeshSnapshot, cameraParametersSnapshot} = makeSnapshots();
+    vi.mocked(transformRgbUvToWorld).mockReturnValue({
+      worldPosition: new THREE.Vector3(0, 1.6, -0.5),
+    } as never);
+    const result = makeMpResult();
+    const out = processFaceLandmarkerResult(
+      result,
+      depthMeshSnapshot,
+      cameraParametersSnapshot
+    );
+    const bb = out[0].detection2DBoundingBox;
+    // makeMpResult spreads landmarks roughly between (0.3, 0.2) and
+    // (0.7, 0.7) in normalized image space, so the bbox should land
+    // somewhere inside that range and never overflow [0, 1].
+    expect(bb.min.x).toBeGreaterThanOrEqual(0);
+    expect(bb.min.y).toBeGreaterThanOrEqual(0);
+    expect(bb.max.x).toBeLessThanOrEqual(1);
+    expect(bb.max.y).toBeLessThanOrEqual(1);
+    expect(bb.max.x).toBeGreaterThan(bb.min.x);
+    expect(bb.max.y).toBeGreaterThan(bb.min.y);
+  });
+});

--- a/src/world/faces/backends/MediaPipeFaceBackend.ts
+++ b/src/world/faces/backends/MediaPipeFaceBackend.ts
@@ -29,6 +29,127 @@ async function loadMediaPipeModule() {
 }
 
 /**
+ * Convert a raw MediaPipe `FaceLandmarkerResult` into an array of
+ * `DetectedFace` objects with world-space positions, blendshape
+ * weights, and rigid head transforms.
+ *
+ * Extracted as a free function so unit tests can drive it directly
+ * without standing up the full backend lifecycle.
+ *
+ * For each landmark we try a depth-mesh raycast (`transformRgbUvToWorld`)
+ * first; when the ray misses the mesh we fall back to back-projecting
+ * through the camera frustum, placing the point ~0.5 m from the camera
+ * modulated by the landmark's relative z. The 0.5 m default is tuned
+ * for selfie / desktop sim use; passthrough Quest views typically hit
+ * the depth mesh path so the fallback rarely runs there.
+ */
+export function processFaceLandmarkerResult(
+  result: MEDIAPIPE.FaceLandmarkerResult,
+  depthMeshSnapshot: THREE.Mesh,
+  cameraParametersSnapshot: CameraParametersSnapshot
+): DetectedFace[] {
+  const detectedFaces: DetectedFace[] = [];
+
+  for (let i = 0; i < result.faceLandmarks.length; i++) {
+    const mpLandmarks = result.faceLandmarks[i];
+
+    const landmarks: FaceLandmark[] = [];
+    let xmin = 1;
+    let ymin = 1;
+    let xmax = 0;
+    let ymax = 0;
+
+    for (let j = 0; j < mpLandmarks.length; j++) {
+      const lm = mpLandmarks[j];
+
+      xmin = Math.min(xmin, lm.x);
+      ymin = Math.min(ymin, lm.y);
+      xmax = Math.max(xmax, lm.x);
+      ymax = Math.max(ymax, lm.y);
+
+      // Transform screen UV to WebXR world position via depth mesh
+      // raycast (preferred) or camera-frustum back-projection
+      // fallback when the ray misses the mesh.
+      const uv = new THREE.Vector2(lm.x, lm.y);
+      const worldCoords = transformRgbUvToWorld(
+        uv,
+        depthMeshSnapshot,
+        cameraParametersSnapshot
+      );
+
+      let wp: THREE.Vector3 | undefined;
+      if (worldCoords) {
+        wp = worldCoords.worldPosition;
+      } else {
+        const origin = new THREE.Vector3().applyMatrix4(
+          cameraParametersSnapshot.worldFromView
+        );
+        const clipVec = new THREE.Vector3(
+          2 * lm.x - 1,
+          2 * (1.0 - lm.y) - 1,
+          -1
+        );
+        const direction = clipVec
+          .applyMatrix4(cameraParametersSnapshot.worldFromClip)
+          .sub(origin)
+          .normalize();
+        // Faces sit ~0.5 m from the camera in selfie/sim use, modulate
+        // by the landmark's z so the back of the head stays behind
+        // the front of the face along the view ray.
+        wp = origin.addScaledVector(direction, 0.5 + (lm.z || 0));
+      }
+
+      landmarks.push({
+        x: lm.x,
+        y: lm.y,
+        z: lm.z,
+        worldPosition: wp,
+      });
+    }
+
+    const boundingBox = new THREE.Box2(
+      new THREE.Vector2(xmin, ymin),
+      new THREE.Vector2(xmax, ymax)
+    );
+
+    // Blendshapes are one Classifications object per face. Each
+    // `categories` entry has `categoryName` and `score`. The browser
+    // model emits them already smoothed across frames.
+    const blendshapes: FaceBlendshape[] = [];
+    const mpBlendshapes = result.faceBlendshapes?.[i];
+    if (mpBlendshapes && mpBlendshapes.categories) {
+      for (const c of mpBlendshapes.categories) {
+        blendshapes.push({
+          categoryName: c.categoryName,
+          score: c.score,
+        });
+      }
+    }
+
+    // Facial transformation matrixes are stored as a column-major
+    // Float32Array(16). THREE.Matrix4.fromArray() consumes the same
+    // layout directly.
+    let facialTransform: THREE.Matrix4 | null = null;
+    const mpMatrix = result.facialTransformationMatrixes?.[i];
+    if (mpMatrix && mpMatrix.data) {
+      facialTransform = new THREE.Matrix4().fromArray(mpMatrix.data);
+    }
+
+    const face = new DetectedFace(
+      i,
+      landmarks,
+      boundingBox,
+      blendshapes,
+      facialTransform
+    );
+
+    detectedFaces.push(face);
+  }
+
+  return detectedFaces;
+}
+
+/**
  * Face Landmark detector backend implementation using MediaPipe's
  * FaceLandmarker. Runs locally on the device. Emits 478 facial
  * landmarks per face plus optional 52 ARKit-style blendshape weights
@@ -85,117 +206,11 @@ export class MediaPipeFaceBackend extends BaseFaceBackend {
       return [];
     }
 
-    return this.processDetectionResult(
+    return processFaceLandmarkerResult(
       result,
       depthMeshSnapshot,
       cameraParametersSnapshot
     );
-  }
-
-  private processDetectionResult(
-    result: MEDIAPIPE.FaceLandmarkerResult,
-    depthMeshSnapshot: THREE.Mesh,
-    cameraParametersSnapshot: CameraParametersSnapshot
-  ): DetectedFace[] {
-    const detectedFaces: DetectedFace[] = [];
-
-    for (let i = 0; i < result.faceLandmarks.length; i++) {
-      const mpLandmarks = result.faceLandmarks[i];
-
-      const landmarks: FaceLandmark[] = [];
-      let xmin = 1;
-      let ymin = 1;
-      let xmax = 0;
-      let ymax = 0;
-
-      for (let j = 0; j < mpLandmarks.length; j++) {
-        const lm = mpLandmarks[j];
-
-        xmin = Math.min(xmin, lm.x);
-        ymin = Math.min(ymin, lm.y);
-        xmax = Math.max(xmax, lm.x);
-        ymax = Math.max(ymax, lm.y);
-
-        // Transform screen UV to WebXR world position via depth mesh
-        // raycast (preferred) or camera-frustum back-projection
-        // fallback when the ray misses the mesh.
-        const uv = new THREE.Vector2(lm.x, lm.y);
-        const worldCoords = transformRgbUvToWorld(
-          uv,
-          depthMeshSnapshot,
-          cameraParametersSnapshot
-        );
-
-        let wp: THREE.Vector3 | undefined;
-        if (worldCoords) {
-          wp = worldCoords.worldPosition;
-        } else {
-          const origin = new THREE.Vector3().applyMatrix4(
-            cameraParametersSnapshot.worldFromView
-          );
-          const clipVec = new THREE.Vector3(
-            2 * lm.x - 1,
-            2 * (1.0 - lm.y) - 1,
-            -1
-          );
-          const direction = clipVec
-            .applyMatrix4(cameraParametersSnapshot.worldFromClip)
-            .sub(origin)
-            .normalize();
-          // Faces sit ~0.5 m from the camera in selfie/sim use, modulate
-          // by the landmark's z so the back of the head stays behind
-          // the front of the face along the view ray.
-          wp = origin.addScaledVector(direction, 0.5 + (lm.z || 0));
-        }
-
-        landmarks.push({
-          x: lm.x,
-          y: lm.y,
-          z: lm.z,
-          worldPosition: wp,
-        });
-      }
-
-      const boundingBox = new THREE.Box2(
-        new THREE.Vector2(xmin, ymin),
-        new THREE.Vector2(xmax, ymax)
-      );
-
-      // Blendshapes are one Classifications object per face. Each
-      // `categories` entry has `categoryName` and `score`. The browser
-      // model emits them already smoothed across frames.
-      const blendshapes: FaceBlendshape[] = [];
-      const mpBlendshapes = result.faceBlendshapes?.[i];
-      if (mpBlendshapes && mpBlendshapes.categories) {
-        for (const c of mpBlendshapes.categories) {
-          blendshapes.push({
-            categoryName: c.categoryName,
-            score: c.score,
-          });
-        }
-      }
-
-      // Facial transformation matrixes are stored as a column-major
-      // Float32Array(16). THREE.Matrix4.fromArray() consumes the same
-      // layout directly.
-      let facialTransform: THREE.Matrix4 | null = null;
-      const mpMatrix = result.facialTransformationMatrixes?.[i];
-      if (mpMatrix && mpMatrix.data) {
-        facialTransform = new THREE.Matrix4().fromArray(mpMatrix.data);
-      }
-
-      const face = new DetectedFace(
-        i,
-        landmarks,
-        boundingBox,
-        blendshapes,
-        facialTransform
-      );
-
-      detectedFaces.push(face);
-    }
-
-    return detectedFaces;
   }
 
   private async tryInitializeFaceLandmarker(): Promise<void> {

--- a/src/world/faces/backends/MediaPipeFaceBackend.ts
+++ b/src/world/faces/backends/MediaPipeFaceBackend.ts
@@ -1,0 +1,225 @@
+import * as THREE from 'three';
+import type * as MEDIAPIPE from '@mediapipe/tasks-vision';
+import {
+  CameraParametersSnapshot,
+  transformRgbUvToWorld,
+} from '../../../camera/CameraUtils';
+import {DetectedFace, FaceBlendshape, FaceLandmark} from '../DetectedFace';
+import {BaseFaceBackend, FaceBackendContext} from '../FaceDetectorBackend';
+
+let FilesetResolver: typeof MEDIAPIPE.FilesetResolver | undefined;
+let FaceLandmarker: typeof MEDIAPIPE.FaceLandmarker | undefined;
+
+// --- Attempt Dynamic Import ---
+async function loadMediaPipeModule() {
+  if (FilesetResolver && FaceLandmarker) {
+    return;
+  }
+  try {
+    const mediapipeModule = await import('@mediapipe/tasks-vision');
+    FilesetResolver = mediapipeModule.FilesetResolver;
+    FaceLandmarker = mediapipeModule.FaceLandmarker;
+    console.log(
+      "'@mediapipe/tasks-vision' MediaPipe Face Module loaded successfully."
+    );
+  } catch (error) {
+    console.error('Failed to load MediaPipe Tasks Vision module:', error);
+    throw error;
+  }
+}
+
+/**
+ * Face Landmark detector backend implementation using MediaPipe's
+ * FaceLandmarker. Runs locally on the device. Emits 478 facial
+ * landmarks per face plus optional 52 ARKit-style blendshape weights
+ * and an optional rigid 4x4 facial transformation matrix.
+ */
+export class MediaPipeFaceBackend extends BaseFaceBackend {
+  private faceLandmarker: MEDIAPIPE.FaceLandmarker | null = null;
+  private initializationPromise: Promise<void>;
+
+  constructor(context: FaceBackendContext) {
+    super(context);
+    this.initializationPromise = this.tryInitializeFaceLandmarker();
+  }
+
+  protected override async isAvailable(): Promise<boolean> {
+    try {
+      await this.initializationPromise;
+      return true;
+    } catch (e) {
+      console.error('MediaPipe Face Landmarker is not available:', e);
+      return false;
+    }
+  }
+
+  protected override async getSnapshot(): Promise<{
+    imageData: ImageData;
+  } | null> {
+    const imageData = await this.context.deviceCamera.getSnapshot({
+      outputFormat: 'imageData',
+    });
+    if (!imageData) return null;
+    return {imageData};
+  }
+
+  protected override async detect(
+    snapshot: {imageData: ImageData},
+    depthMeshSnapshot: THREE.Mesh,
+    cameraParametersSnapshot: CameraParametersSnapshot
+  ): Promise<DetectedFace[]> {
+    await this.initializationPromise;
+    if (!this.faceLandmarker) {
+      return [];
+    }
+
+    let result: MEDIAPIPE.FaceLandmarkerResult;
+    try {
+      result = this.faceLandmarker.detect(snapshot.imageData);
+    } catch (error: unknown) {
+      console.error('MediaPipe Face detection run failed:', error);
+      return [];
+    }
+
+    if (!result || !result.faceLandmarks || result.faceLandmarks.length === 0) {
+      return [];
+    }
+
+    return this.processDetectionResult(
+      result,
+      depthMeshSnapshot,
+      cameraParametersSnapshot
+    );
+  }
+
+  private processDetectionResult(
+    result: MEDIAPIPE.FaceLandmarkerResult,
+    depthMeshSnapshot: THREE.Mesh,
+    cameraParametersSnapshot: CameraParametersSnapshot
+  ): DetectedFace[] {
+    const detectedFaces: DetectedFace[] = [];
+
+    for (let i = 0; i < result.faceLandmarks.length; i++) {
+      const mpLandmarks = result.faceLandmarks[i];
+
+      const landmarks: FaceLandmark[] = [];
+      let xmin = 1;
+      let ymin = 1;
+      let xmax = 0;
+      let ymax = 0;
+
+      for (let j = 0; j < mpLandmarks.length; j++) {
+        const lm = mpLandmarks[j];
+
+        xmin = Math.min(xmin, lm.x);
+        ymin = Math.min(ymin, lm.y);
+        xmax = Math.max(xmax, lm.x);
+        ymax = Math.max(ymax, lm.y);
+
+        // Transform screen UV to WebXR world position via depth mesh
+        // raycast (preferred) or camera-frustum back-projection
+        // fallback when the ray misses the mesh.
+        const uv = new THREE.Vector2(lm.x, lm.y);
+        const worldCoords = transformRgbUvToWorld(
+          uv,
+          depthMeshSnapshot,
+          cameraParametersSnapshot
+        );
+
+        let wp: THREE.Vector3 | undefined;
+        if (worldCoords) {
+          wp = worldCoords.worldPosition;
+        } else {
+          const origin = new THREE.Vector3().applyMatrix4(
+            cameraParametersSnapshot.worldFromView
+          );
+          const clipVec = new THREE.Vector3(
+            2 * lm.x - 1,
+            2 * (1.0 - lm.y) - 1,
+            -1
+          );
+          const direction = clipVec
+            .applyMatrix4(cameraParametersSnapshot.worldFromClip)
+            .sub(origin)
+            .normalize();
+          // Faces sit ~0.5 m from the camera in selfie/sim use, modulate
+          // by the landmark's z so the back of the head stays behind
+          // the front of the face along the view ray.
+          wp = origin.addScaledVector(direction, 0.5 + (lm.z || 0));
+        }
+
+        landmarks.push({
+          x: lm.x,
+          y: lm.y,
+          z: lm.z,
+          worldPosition: wp,
+        });
+      }
+
+      const boundingBox = new THREE.Box2(
+        new THREE.Vector2(xmin, ymin),
+        new THREE.Vector2(xmax, ymax)
+      );
+
+      // Blendshapes are one Classifications object per face. Each
+      // `categories` entry has `categoryName` and `score`. The browser
+      // model emits them already smoothed across frames.
+      const blendshapes: FaceBlendshape[] = [];
+      const mpBlendshapes = result.faceBlendshapes?.[i];
+      if (mpBlendshapes && mpBlendshapes.categories) {
+        for (const c of mpBlendshapes.categories) {
+          blendshapes.push({
+            categoryName: c.categoryName,
+            score: c.score,
+          });
+        }
+      }
+
+      // Facial transformation matrixes are stored as a column-major
+      // Float32Array(16). THREE.Matrix4.fromArray() consumes the same
+      // layout directly.
+      let facialTransform: THREE.Matrix4 | null = null;
+      const mpMatrix = result.facialTransformationMatrixes?.[i];
+      if (mpMatrix && mpMatrix.data) {
+        facialTransform = new THREE.Matrix4().fromArray(mpMatrix.data);
+      }
+
+      const face = new DetectedFace(
+        i,
+        landmarks,
+        boundingBox,
+        blendshapes,
+        facialTransform
+      );
+
+      detectedFaces.push(face);
+    }
+
+    return detectedFaces;
+  }
+
+  private async tryInitializeFaceLandmarker(): Promise<void> {
+    if (this.faceLandmarker) return;
+
+    await loadMediaPipeModule();
+
+    const facesOptions = this.context.options.faces.backendConfig.mediapipe;
+    const vision = await FilesetResolver!.forVisionTasks(
+      facesOptions.wasmFilesUrl
+    );
+    this.faceLandmarker = await FaceLandmarker!.createFromOptions(vision, {
+      baseOptions: {
+        modelAssetPath: facesOptions.modelAssetPath,
+        delegate: 'GPU',
+      },
+      runningMode: 'IMAGE',
+      numFaces: facesOptions.numFaces,
+      minFaceDetectionConfidence: facesOptions.minFaceDetectionConfidence,
+      minFacePresenceConfidence: facesOptions.minFacePresenceConfidence,
+      minTrackingConfidence: facesOptions.minTrackingConfidence,
+      outputFaceBlendshapes: facesOptions.outputFaceBlendshapes,
+      outputFacialTransformationMatrixes:
+        facesOptions.outputFacialTransformationMatrixes,
+    });
+  }
+}

--- a/src/xrblocks.ts
+++ b/src/xrblocks.ts
@@ -145,6 +145,9 @@ export * from './world/WorldOptions';
 export * from './world/humans/DetectedBodyPose';
 export * from './world/humans/HumanRecognizer';
 export * from './world/humans/HumansOptions';
+export * from './world/faces/DetectedFace';
+export * from './world/faces/FaceRecognizer';
+export * from './world/faces/FacesOptions';
 
 export type {IconButtonOptions} from './ui/components/IconButton';
 export type {IconViewOptions} from './ui/components/IconView';


### PR DESCRIPTION
adds xb.world.faces using MediaPipe's FaceLandmarker. the SDK now has objects, pose, and faces under the same backend-strategy pattern.

Each detected face exposes the 478-point face mesh in world space, optional 52 ARKit-style blendshape weights, and optional 4x4 rigid head pose. The blendshapes are the input the lipsync addon has been missing: until now there was no in-tree feed for them, so any avatar expression mirroring required wiring MediaPipe by hand in the demo. with this, `xb.world.faces` is the official source.

ships with a `face_mirror` demo: per-frame wireframe of the face mesh contours (face oval, lips, eyes, eyebrows) projected via the depth mesh, plus a live HUD of 12 high-signal blendshapes.

Desktop testability: the SDK reads from `xb.core.deviceCamera`, which on a Quest is passthrough and on desktop is the rendered sim scene. Neither shows a human face by default. the demo includes a small webcam fallback wrapper: when not in a WebXR session, call getUserMedia and route ImageData through a canvas. real-headset path is untouched. one gotcha worth flagging here too: don't mirror the canvas before feeding it to FaceLandmarker, it swaps every Left/Right blendshape and landmark index because the model uses subject-pov ARKit names. preview thumbnail mirrors via CSS instead.

On Quest the passthrough cameras look outward so the demo labels the faces of other people in front of you rather than your own. that's actually the more interesting use case (external avatar mirroring for video calls in XR, expression-driven NPCs, person-anchored UI, reading emotions, etc.).