### PR TITLE
perf(world/faces): run MediaPipe FaceLandmarker in a web worker

### DIFF
--- a/src/world/faces/backends/MediaPipeFaceBackend.ts
+++ b/src/world/faces/backends/MediaPipeFaceBackend.ts
@@ -6,27 +6,14 @@ import {
 } from '../../../camera/CameraUtils';
 import {DetectedFace, FaceBlendshape, FaceLandmark} from '../DetectedFace';
 import {BaseFaceBackend, FaceBackendContext} from '../FaceDetectorBackend';
+import {MEDIA_PIPE_FACE_WORKER_SOURCE} from './MediaPipeFaceWorker';
 
-let FilesetResolver: typeof MEDIAPIPE.FilesetResolver | undefined;
-let FaceLandmarker: typeof MEDIAPIPE.FaceLandmarker | undefined;
-
-// --- Attempt Dynamic Import ---
-async function loadMediaPipeModule() {
-  if (FilesetResolver && FaceLandmarker) {
-    return;
-  }
-  try {
-    const mediapipeModule = await import('@mediapipe/tasks-vision');
-    FilesetResolver = mediapipeModule.FilesetResolver;
-    FaceLandmarker = mediapipeModule.FaceLandmarker;
-    console.log(
-      "'@mediapipe/tasks-vision' MediaPipe Face Module loaded successfully."
-    );
-  } catch (error) {
-    console.error('Failed to load MediaPipe Tasks Vision module:', error);
-    throw error;
-  }
-}
+// CDN module the worker dynamic-imports for MediaPipe. Workers can't see
+// the host page's importmap so we hand them an absolute URL. Pinned to a
+// version that matches the SDK's tested matrix; bump in lockstep with
+// any importmap updates in demos/face_mirror/index.html.
+const MEDIAPIPE_MODULE_URL =
+  'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@latest/vision_bundle.mjs';
 
 /**
  * Convert a raw MediaPipe `FaceLandmarkerResult` into an array of
@@ -151,13 +138,38 @@ export function processFaceLandmarkerResult(
 
 /**
  * Face Landmark detector backend implementation using MediaPipe's
- * FaceLandmarker. Runs locally on the device. Emits 478 facial
- * landmarks per face plus optional 52 ARKit-style blendshape weights
- * and an optional rigid 4x4 facial transformation matrix.
+ * FaceLandmarker. Runs locally on the device, but offloads the
+ * inference to a Web Worker so heavy detection passes (~30 ms on a
+ * modern laptop, much more on mobile) don't stall the render loop.
+ *
+ * Pipeline per detect():
+ *   1. Main thread captures an `ImageData` snapshot from the device
+ *      camera (already async).
+ *   2. Convert to `ImageBitmap` once and transfer it (zero-copy) to
+ *      the worker.
+ *   3. Worker runs `landmarker.detect()` and posts back the structured-
+ *      clonable result.
+ *   4. Main thread runs `processFaceLandmarkerResult` (depth-mesh
+ *      raycasts + camera-frustum back-projection) which has to live on
+ *      the render thread because it touches the live depth mesh and
+ *      camera matrices.
+ *
+ * Emits 478 facial landmarks per face plus optional 52 ARKit-style
+ * blendshape weights and an optional rigid 4x4 facial transformation
+ * matrix.
  */
 export class MediaPipeFaceBackend extends BaseFaceBackend {
-  private faceLandmarker: MEDIAPIPE.FaceLandmarker | null = null;
+  private worker: Worker | null = null;
+  private workerUrl: string | null = null;
   private initializationPromise: Promise<void>;
+  private nextRequestId = 0;
+  private pendingRequests = new Map<
+    number,
+    {
+      resolve: (value: WorkerReply) => void;
+      reject: (error: Error) => void;
+    }
+  >();
 
   constructor(context: FaceBackendContext) {
     super(context);
@@ -190,51 +202,139 @@ export class MediaPipeFaceBackend extends BaseFaceBackend {
     cameraParametersSnapshot: CameraParametersSnapshot
   ): Promise<DetectedFace[]> {
     await this.initializationPromise;
-    if (!this.faceLandmarker) {
+    if (!this.worker) {
       return [];
     }
 
-    let result: MEDIAPIPE.FaceLandmarkerResult;
+    // Convert the snapshot to an ImageBitmap so the pixel buffer can be
+    // transferred (zero-copy) into the worker. ImageData itself is
+    // structured-cloneable but that means a full pixel copy per detect;
+    // ImageBitmap moves ownership.
+    let bitmap: ImageBitmap;
     try {
-      result = this.faceLandmarker.detect(snapshot.imageData);
+      bitmap = await createImageBitmap(snapshot.imageData);
     } catch (error: unknown) {
-      console.error('MediaPipe Face detection run failed:', error);
+      console.error('Failed to create ImageBitmap for face detection:', error);
       return [];
     }
 
-    if (!result || !result.faceLandmarks || result.faceLandmarks.length === 0) {
+    let workerResult: MEDIAPIPE.FaceLandmarkerResult;
+    try {
+      const reply = (await this.send({type: 'detect', imageBitmap: bitmap}, [
+        bitmap,
+      ])) as WorkerSuccessReply;
+      workerResult = reply.result as MEDIAPIPE.FaceLandmarkerResult;
+    } catch (error: unknown) {
+      console.error('MediaPipe Face detection (worker) failed:', error);
+      return [];
+    }
+
+    if (
+      !workerResult ||
+      !workerResult.faceLandmarks ||
+      workerResult.faceLandmarks.length === 0
+    ) {
       return [];
     }
 
     return processFaceLandmarkerResult(
-      result,
+      workerResult,
       depthMeshSnapshot,
       cameraParametersSnapshot
     );
   }
 
-  private async tryInitializeFaceLandmarker(): Promise<void> {
-    if (this.faceLandmarker) return;
+  /**
+   * Tear down the worker and revoke the Blob URL it was constructed
+   * from. Safe to call multiple times.
+   */
+  dispose() {
+    if (this.worker) {
+      this.worker.terminate();
+      this.worker = null;
+    }
+    if (this.workerUrl) {
+      URL.revokeObjectURL(this.workerUrl);
+      this.workerUrl = null;
+    }
+    // Reject any in-flight requests so callers don't hang.
+    for (const {reject} of this.pendingRequests.values()) {
+      reject(new Error('MediaPipeFaceBackend disposed'));
+    }
+    this.pendingRequests.clear();
+  }
 
-    await loadMediaPipeModule();
+  private async tryInitializeFaceLandmarker(): Promise<void> {
+    if (this.worker) return;
+    if (typeof Worker === 'undefined') {
+      throw new Error('Web Workers are not available in this environment');
+    }
+
+    // Spawn the worker from an inlined Blob URL so we don't have to
+    // teach the rollup pipeline about a separate worker entry point.
+    const blob = new Blob([MEDIA_PIPE_FACE_WORKER_SOURCE], {
+      type: 'text/javascript',
+    });
+    this.workerUrl = URL.createObjectURL(blob);
+    this.worker = new Worker(this.workerUrl);
+    this.worker.onmessage = (event: MessageEvent<WorkerReply>) => {
+      const {id} = event.data;
+      const pending = this.pendingRequests.get(id);
+      if (!pending) return;
+      this.pendingRequests.delete(id);
+      if (event.data.ok) {
+        pending.resolve(event.data);
+      } else {
+        pending.reject(new Error(event.data.error || 'worker error'));
+      }
+    };
+    this.worker.onerror = (event) => {
+      console.error('MediaPipe face worker errored:', event.message);
+    };
 
     const facesOptions = this.context.options.faces.backendConfig.mediapipe;
-    const vision = await FilesetResolver!.forVisionTasks(
-      facesOptions.wasmFilesUrl
-    );
-    this.faceLandmarker = await FaceLandmarker!.createFromOptions(vision, {
-      baseOptions: {
+    await this.send({
+      type: 'init',
+      config: {
+        mediapipeModuleUrl: MEDIAPIPE_MODULE_URL,
+        wasmFilesUrl: facesOptions.wasmFilesUrl,
         modelAssetPath: facesOptions.modelAssetPath,
-        delegate: 'GPU',
+        numFaces: facesOptions.numFaces,
+        minFaceDetectionConfidence: facesOptions.minFaceDetectionConfidence,
+        minFacePresenceConfidence: facesOptions.minFacePresenceConfidence,
+        minTrackingConfidence: facesOptions.minTrackingConfidence,
+        outputFaceBlendshapes: facesOptions.outputFaceBlendshapes,
+        outputFacialTransformationMatrixes:
+          facesOptions.outputFacialTransformationMatrixes,
       },
-      runningMode: 'IMAGE',
-      numFaces: facesOptions.numFaces,
-      minFaceDetectionConfidence: facesOptions.minFaceDetectionConfidence,
-      minFacePresenceConfidence: facesOptions.minFacePresenceConfidence,
-      minTrackingConfidence: facesOptions.minTrackingConfidence,
-      outputFaceBlendshapes: facesOptions.outputFaceBlendshapes,
-      outputFacialTransformationMatrixes:
-        facesOptions.outputFacialTransformationMatrixes,
+    });
+  }
+
+  /**
+   * Promise-wrap a single request/response round trip with the worker.
+   * The worker echoes back the request `id` so we can correlate replies
+   * even when multiple detect() calls overlap.
+   */
+  private send(
+    payload: WorkerRequest,
+    transfer: Transferable[] = []
+  ): Promise<WorkerReply> {
+    if (!this.worker) {
+      return Promise.reject(new Error('worker not spawned'));
+    }
+    const id = this.nextRequestId++;
+    const worker = this.worker;
+    return new Promise<WorkerReply>((resolve, reject) => {
+      this.pendingRequests.set(id, {resolve, reject});
+      worker.postMessage({id, ...payload}, transfer);
     });
   }
 }
+
+type WorkerRequest =
+  | {type: 'init'; config: Record<string, unknown>}
+  | {type: 'detect'; imageBitmap: ImageBitmap};
+
+type WorkerSuccessReply = {id: number; ok: true; result?: unknown};
+type WorkerErrorReply = {id: number; ok: false; error: string};
+type WorkerReply = WorkerSuccessReply | WorkerErrorReply;

--- a/src/world/faces/backends/MediaPipeFaceWorker.test.ts
+++ b/src/world/faces/backends/MediaPipeFaceWorker.test.ts
@@ -1,0 +1,231 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {MediaPipeFaceBackend} from './MediaPipeFaceBackend';
+
+// Mock the processing pipeline so these tests focus on the worker
+// lifecycle rather than re-asserting the world-space transform (which
+// MediaPipeFaceBackend.test.ts already covers exhaustively).
+vi.mock('./MediaPipeFaceBackend', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('./MediaPipeFaceBackend')>();
+  return {...actual};
+});
+
+vi.mock('../../../camera/CameraUtils', () => ({
+  transformRgbUvToWorld: vi.fn().mockReturnValue({
+    worldPosition: {x: 0, y: 0, z: 0},
+  }),
+}));
+
+// Stub Worker so the test never spawns a real OS-level worker. Each
+// instance captures the messages sent from the main thread and exposes
+// a `triggerMessage(data)` hook the test uses to simulate worker
+// replies. `terminate()` is recorded so the dispose-test can assert it.
+class FakeWorker {
+  static instances: FakeWorker[] = [];
+  postMessage = vi.fn();
+  terminate = vi.fn();
+  onmessage: ((event: {data: Record<string, unknown>}) => void) | null = null;
+  onerror: ((event: {message: string}) => void) | null = null;
+  url: string;
+  options?: WorkerOptions;
+  constructor(url: string | URL, options?: WorkerOptions) {
+    this.url = String(url);
+    this.options = options;
+    FakeWorker.instances.push(this);
+  }
+  triggerMessage(data: Record<string, unknown>) {
+    this.onmessage?.({data});
+  }
+}
+
+beforeEach(() => {
+  FakeWorker.instances = [];
+  vi.stubGlobal('Worker', FakeWorker);
+  vi.stubGlobal('URL', {
+    createObjectURL: vi.fn().mockReturnValue('blob:fake-url'),
+    revokeObjectURL: vi.fn(),
+  });
+  // jsdom doesn't ship Blob with a real backing buffer but the Worker
+  // constructor only needs the URL, so a no-op stub is enough.
+  vi.stubGlobal('Blob', class {});
+  // The backend pipes its snapshot through createImageBitmap before
+  // posting to the worker; return a sentinel object so we can assert on
+  // it later in the transfer list.
+  vi.stubGlobal(
+    'createImageBitmap',
+    vi.fn().mockResolvedValue({type: 'fake-bitmap', close: vi.fn()})
+  );
+});
+
+function makeContext(): never {
+  return {
+    options: {
+      faces: {
+        backendConfig: {
+          mediapipe: {
+            wasmFilesUrl: 'wasm://',
+            modelAssetPath: 'model://',
+            numFaces: 1,
+            minFaceDetectionConfidence: 0.5,
+            minFacePresenceConfidence: 0.5,
+            minTrackingConfidence: 0.5,
+            outputFaceBlendshapes: true,
+            outputFacialTransformationMatrixes: true,
+          },
+        },
+      },
+    },
+    deviceCamera: {
+      getSnapshot: vi.fn().mockResolvedValue({
+        // Match the ImageData shape the backend expects from
+        // XRDeviceCamera.getSnapshot(outputFormat: 'imageData').
+        data: new Uint8ClampedArray(4),
+        width: 1,
+        height: 1,
+      }),
+    },
+  } as never;
+}
+
+function lastInit() {
+  const worker = FakeWorker.instances.at(-1)!;
+  // The first postMessage is always 'init' with id 0.
+  return worker.postMessage.mock.calls[0][0] as {
+    id: number;
+    type: string;
+    config: Record<string, unknown>;
+  };
+}
+
+describe('MediaPipeFaceBackend worker lifecycle', () => {
+  it('spawns exactly one worker per backend and sends a single init message with the configured options', async () => {
+    const backend = new MediaPipeFaceBackend(makeContext());
+    // Init is posted synchronously from the constructor; flush microtasks.
+    await Promise.resolve();
+    expect(FakeWorker.instances).toHaveLength(1);
+    const init = lastInit();
+    expect(init.type).toBe('init');
+    expect(init.config.modelAssetPath).toBe('model://');
+    expect(init.config.numFaces).toBe(1);
+    // Drain init so the backend reports as available.
+    FakeWorker.instances[0].triggerMessage({id: init.id, ok: true});
+    expect(
+      await (
+        backend as never as {isAvailable(): Promise<boolean>}
+      ).isAvailable()
+    ).toBe(true);
+  });
+
+  it('spawns the worker as a classic (non-module) worker so MediaPipe wasm loader can use importScripts', async () => {
+    new MediaPipeFaceBackend(makeContext());
+    await Promise.resolve();
+    // We pass no { type: 'module' } so options is undefined. Module
+    // workers don't expose importScripts and MediaPipe's wasm bootstrap
+    // depends on it.
+    expect(FakeWorker.instances[0].options).toBeUndefined();
+  });
+
+  it('routes overlapping detect requests back to the right caller by id', async () => {
+    const backend = new MediaPipeFaceBackend(makeContext());
+    await Promise.resolve();
+    const worker = FakeWorker.instances[0];
+    // Finish init so detect() proceeds past the init gate.
+    worker.triggerMessage({id: 0, ok: true});
+
+    const detect = (
+      backend as never as {
+        detect(
+          s: {imageData: ImageData},
+          d: unknown,
+          c: unknown
+        ): Promise<unknown[]>;
+      }
+    ).detect.bind(backend);
+    const snap = {imageData: new Uint8ClampedArray(4) as never as ImageData};
+    const a = detect(snap, {} as never, {} as never);
+    const b = detect(snap, {} as never, {} as never);
+    // Let the createImageBitmap + send microtasks resolve so the worker
+    // has both posts.
+    await new Promise((r) => setTimeout(r, 0));
+    const sent = worker.postMessage.mock.calls
+      .map((c) => c[0] as {id: number; type: string})
+      .filter((m) => m.type === 'detect');
+    expect(sent).toHaveLength(2);
+    // Reply to the second request first to prove correlation works.
+    worker.triggerMessage({
+      id: sent[1].id,
+      ok: true,
+      result: {faceLandmarks: []},
+    });
+    worker.triggerMessage({
+      id: sent[0].id,
+      ok: true,
+      result: {faceLandmarks: []},
+    });
+    await expect(a).resolves.toEqual([]);
+    await expect(b).resolves.toEqual([]);
+  });
+
+  it('rejects detect() with the worker-reported error (logged + returns []) when the worker replies with ok=false', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const backend = new MediaPipeFaceBackend(makeContext());
+    await Promise.resolve();
+    const worker = FakeWorker.instances[0];
+    worker.triggerMessage({id: 0, ok: true});
+
+    const detect = (
+      backend as never as {
+        detect(
+          s: {imageData: ImageData},
+          d: unknown,
+          c: unknown
+        ): Promise<unknown[]>;
+      }
+    ).detect.bind(backend);
+    const snap = {imageData: new Uint8ClampedArray(4) as never as ImageData};
+    const p = detect(snap, {} as never, {} as never);
+    await new Promise((r) => setTimeout(r, 0));
+    const detectMsg = worker.postMessage.mock.calls
+      .map((c) => c[0] as {id: number; type: string})
+      .find((m) => m.type === 'detect')!;
+    worker.triggerMessage({id: detectMsg.id, ok: false, error: 'boom'});
+    await expect(p).resolves.toEqual([]);
+    expect(errSpy).toHaveBeenCalledWith(
+      'MediaPipe Face detection (worker) failed:',
+      expect.objectContaining({message: 'boom'})
+    );
+    errSpy.mockRestore();
+  });
+
+  it('terminates the worker, revokes the Blob URL, and rejects pending requests on dispose()', async () => {
+    const backend = new MediaPipeFaceBackend(makeContext());
+    await Promise.resolve();
+    const worker = FakeWorker.instances[0];
+    // Trigger init success so we can fire a detect.
+    worker.triggerMessage({id: 0, ok: true});
+    const detect = (
+      backend as never as {
+        detect(
+          s: {imageData: ImageData},
+          d: unknown,
+          c: unknown
+        ): Promise<unknown[]>;
+      }
+    ).detect.bind(backend);
+    const snap = {imageData: new Uint8ClampedArray(4) as never as ImageData};
+    const pending = detect(snap, {} as never, {} as never);
+    await new Promise((r) => setTimeout(r, 0));
+
+    backend.dispose();
+    expect(worker.terminate).toHaveBeenCalledOnce();
+    // dispose() returns [] for the inflight detect (it catches the
+    // rejection internally and logs it), so awaiting it should resolve.
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(pending).resolves.toEqual([]);
+    errSpy.mockRestore();
+    // A second dispose should be a no-op (no double-terminate).
+    backend.dispose();
+    expect(worker.terminate).toHaveBeenCalledOnce();
+  });
+});

--- a/src/world/faces/backends/MediaPipeFaceWorker.ts
+++ b/src/world/faces/backends/MediaPipeFaceWorker.ts
@@ -1,0 +1,74 @@
+// Source code for the MediaPipe FaceLandmarker web worker. Inlined as a
+// string and instantiated via Blob URL so the SDK ships in one bundle
+// without the rollup pipeline having to know about worker entry points.
+//
+// The worker dynamically imports `@mediapipe/tasks-vision` from a CDN URL
+// (workers don't share the host page's importmap), loads the
+// FaceLandmarker model once on `init`, then runs synchronous
+// `detect(imageBitmap)` calls per request. ImageBitmaps are transferable
+// so the snapshot pixel buffer doesn't get cloned across the worker
+// boundary.
+//
+// Wire protocol (all messages carry a numeric `id` so the main thread can
+// correlate request/response pairs):
+//   { id, type: 'init', config: { mediapipeModuleUrl, wasmFilesUrl,
+//                                  modelAssetPath, numFaces, ... } }
+//   { id, type: 'detect', imageBitmap: ImageBitmap }           // transfer the bitmap
+// Replies:
+//   { id, ok: true }
+//   { id, ok: true, result: FaceLandmarkerResult }
+//   { id, ok: false, error: string }
+//
+// The result object is a structured-clonable subset of MediaPipe's
+// FaceLandmarkerResult (plain landmarks, blendshape categories, transform
+// matrix data arrays). Float32Arrays inside `facialTransformationMatrixes`
+// clone cheaply, no transfer list needed.
+export const MEDIA_PIPE_FACE_WORKER_SOURCE = /* js */ `
+let landmarker = null;
+
+async function init(config) {
+  const mod = await import(config.mediapipeModuleUrl);
+  const { FilesetResolver, FaceLandmarker } = mod;
+  const vision = await FilesetResolver.forVisionTasks(config.wasmFilesUrl);
+  landmarker = await FaceLandmarker.createFromOptions(vision, {
+    baseOptions: {
+      modelAssetPath: config.modelAssetPath,
+      // CPU delegate in the worker. GPU would need an OffscreenCanvas
+      // surface and MediaPipe's wasm pipeline only spins one up when it
+      // finds a real DOM canvas, which workers don't have.
+      delegate: 'CPU',
+    },
+    runningMode: 'IMAGE',
+    numFaces: config.numFaces,
+    minFaceDetectionConfidence: config.minFaceDetectionConfidence,
+    minFacePresenceConfidence: config.minFacePresenceConfidence,
+    minTrackingConfidence: config.minTrackingConfidence,
+    outputFaceBlendshapes: config.outputFaceBlendshapes,
+    outputFacialTransformationMatrixes: config.outputFacialTransformationMatrixes,
+  });
+}
+
+self.onmessage = async (event) => {
+  const { id, type } = event.data;
+  try {
+    if (type === 'init') {
+      await init(event.data.config);
+      self.postMessage({ id, ok: true });
+    } else if (type === 'detect') {
+      if (!landmarker) throw new Error('worker not initialized');
+      const bitmap = event.data.imageBitmap;
+      const result = landmarker.detect(bitmap);
+      bitmap.close();
+      self.postMessage({ id, ok: true, result });
+    } else {
+      throw new Error('unknown message type: ' + type);
+    }
+  } catch (err) {
+    self.postMessage({
+      id,
+      ok: false,
+      error: (err && err.message) || String(err),
+    });
+  }
+};
+`;


### PR DESCRIPTION
per the review thread on #364, `FaceLandmarker.detect()` was running on the main thread and tanking render FPS on an m1 pro. now runs in a dedicated worker.

per detect: main thread captures the `ImageData` snapshot (already async), `createImageBitmap` flips it to a transferable, worker runs `landmarker.detect(bitmap)` and posts back the result. `processFaceLandmarkerResult` (depth-mesh raycasts + camera-frustum back-projection) stays on the render thread since it reads the live depth mesh + camera matrices. the only behavior change visible to callers is a new `dispose()`.

couple of gotchas worth flagging: it's a classic worker, not a module worker, because MediaPipe's wasm bootstrap uses `importScripts` which isn't available in `type: 'module'` workers (spent a while chasing a confusing `ModuleFactory not set` error before tracing it back). and the worker uses the CPU delegate, not GPU, because GPU needs an OffscreenCanvas and MediaPipe's wasm pipeline only spins one up for a real DOM canvas. CPU runs fine via xnnpack and the whole point here is freeing the main thread so CPU-in-worker > GPU-on-main.

worker source is inlined as a string and instantiated via a `Blob` URL so the rollup pipeline doesn't need a separate entry point.

`processFaceLandmarkerResult` is untouched, so the 9 existing unit tests still pass. 5 new tests cover the worker lifecycle: spawn + init payload, classic-not-module spawn, overlapping detect correlation by id, worker-reported errors logged + resolved to `[]`, and dispose teardown (terminate + revoke + reject pending, idempotent). 30 face tests total, 294 overall.

related: #367 (BVH-accelerate per-landmark raycasts), #368 (face_mirror demo polish). all three independent file-wise.
