### PR TITLE
perf(world/faces): BVH-accelerate per-landmark depth raycasts

### DIFF
--- a/demos/face_mirror/index.html
+++ b/demos/face_mirror/index.html
@@ -32,7 +32,8 @@
           "uiblocks": "../../build/addons/uiblocks/src/index.js",
           "xrblocks": "../../build/xrblocks.js",
           "xrblocks/addons/": "../../build/addons/",
-          "@mediapipe/tasks-vision": "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@latest/vision_bundle.mjs"
+          "@mediapipe/tasks-vision": "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@latest/vision_bundle.mjs",
+          "three-mesh-bvh": "https://cdn.jsdelivr.net/npm/three-mesh-bvh@0.9.0/build/index.module.js"
         }
       }
     </script>

--- a/demos/portals/PortalGalleryScene.js
+++ b/demos/portals/PortalGalleryScene.js
@@ -175,6 +175,13 @@ export class PortalGalleryScene extends xb.Script {
         this.immersives.push(null);
       }
     }
+
+    // Build BVH bounds-trees on every mesh under this scene root so
+    // the SDK's per-frame raycast against `xb.core.scene` goes through
+    // the BVH-accelerated path instead of walking every triangle per
+    // ray. With 5 immersive scenes loaded the raycast loop dominated
+    // the main thread in perf traces before this.
+    xb.applyBVH?.(this);
   }
 
   onSelectStart(event) {

--- a/demos/portals/index.html
+++ b/demos/portals/index.html
@@ -30,7 +30,8 @@
           "lit": "https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js",
           "lit/": "https://esm.run/lit@3/",
           "xrblocks": "../../build/xrblocks.js",
-          "xrblocks/addons/": "../../build/addons/"
+          "xrblocks/addons/": "../../build/addons/",
+          "three-mesh-bvh": "https://cdn.jsdelivr.net/npm/three-mesh-bvh@0.9.0/build/index.module.js"
         }
       }
     </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "xrblocks",
       "version": "0.16.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "three-mesh-bvh": "^0.9.10"
+      },
       "devDependencies": {
         "@dimforge/rapier3d": "^0.19.2",
         "@dimforge/rapier3d-simd-compat": "^0.17.3",
@@ -5616,6 +5619,15 @@
       "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.9.10.tgz",
+      "integrity": "sha512-UOlTgPIeqUURcwaG8knxvBaruwZlC4X3/WSHEFO7rYvMVv/YNUrkfFEszvfj36pXV88dCHoHNnIp0PifkirnTQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "xrblocks",
       "version": "0.16.0",
       "license": "Apache-2.0",
-      "dependencies": {
-        "three-mesh-bvh": "^0.9.10"
-      },
       "devDependencies": {
         "@dimforge/rapier3d": "^0.19.2",
         "@dimforge/rapier3d-simd-compat": "^0.17.3",
@@ -44,6 +41,7 @@
         "rollup": "^4.59.0",
         "rollup-plugin-dts": "^6.3.0",
         "temporal-polyfill": "^0.3.2",
+        "three-mesh-bvh": "^0.9.10",
         "troika-three-text": "^0.52.4",
         "troika-types": "^0.0.6",
         "tslib": "^2.8.1",
@@ -5624,6 +5622,7 @@
       "version": "0.9.10",
       "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.9.10.tgz",
       "integrity": "sha512-UOlTgPIeqUURcwaG8knxvBaruwZlC4X3/WSHEFO7rYvMVv/YNUrkfFEszvfj36pXV88dCHoHNnIp0PifkirnTQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "three": ">= 0.159.0"

--- a/package.json
+++ b/package.json
@@ -82,5 +82,8 @@
     "rollup-plugin-dts": {
       "typescript": "$typescript"
     }
+  },
+  "dependencies": {
+    "three-mesh-bvh": "^0.9.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "rollup": "^4.59.0",
     "rollup-plugin-dts": "^6.3.0",
     "temporal-polyfill": "^0.3.2",
+    "three-mesh-bvh": "^0.9.10",
     "troika-three-text": "^0.52.4",
     "troika-types": "^0.0.6",
     "tslib": "^2.8.1",
@@ -82,8 +83,5 @@
     "rollup-plugin-dts": {
       "typescript": "$typescript"
     }
-  },
-  "dependencies": {
-    "three-mesh-bvh": "^0.9.10"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -77,6 +77,7 @@ const externalPackages = [
   'lorem-ipsum',
   'temporal-polyfill',
   'rapier3d',
+  'three-mesh-bvh',
 ];
 
 const xrblocksPackages = [

--- a/src/utils/BVHRaycast.test.ts
+++ b/src/utils/BVHRaycast.test.ts
@@ -1,0 +1,83 @@
+import * as THREE from 'three';
+import {describe, expect, it} from 'vitest';
+
+import {applyBVH, disposeBVH, enableAcceleratedRaycast} from './BVHRaycast';
+
+describe('BVHRaycast', () => {
+  it('installs the THREE.Mesh prototype patch and helpers on first call', () => {
+    enableAcceleratedRaycast();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const proto = THREE.BufferGeometry.prototype as any;
+    expect(typeof proto.computeBoundsTree).toBe('function');
+    expect(typeof proto.disposeBoundsTree).toBe('function');
+  });
+
+  it('is idempotent: re-calling enableAcceleratedRaycast does not throw or re-bind', () => {
+    enableAcceleratedRaycast();
+    enableAcceleratedRaycast();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const proto = THREE.BufferGeometry.prototype as any;
+    expect(typeof proto.computeBoundsTree).toBe('function');
+  });
+
+  it('applyBVH builds a boundsTree on every mesh in the tree (recursive)', () => {
+    const root = new THREE.Group();
+    const m1 = new THREE.Mesh(new THREE.BoxGeometry());
+    const m2 = new THREE.Mesh(new THREE.SphereGeometry());
+    const inner = new THREE.Group();
+    inner.add(m2);
+    root.add(m1);
+    root.add(inner);
+    applyBVH(root);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((m1.geometry as any).boundsTree).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((m2.geometry as any).boundsTree).toBeDefined();
+  });
+
+  it('applyBVH skips meshes that already have a boundsTree (idempotent)', () => {
+    const root = new THREE.Group();
+    const m = new THREE.Mesh(new THREE.BoxGeometry());
+    root.add(m);
+    applyBVH(root);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const firstTree = (m.geometry as any).boundsTree;
+    applyBVH(root);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const secondTree = (m.geometry as any).boundsTree;
+    // Same instance: not rebuilt on the second call.
+    expect(secondTree).toBe(firstTree);
+  });
+
+  it('applyBVH with recursive=false only visits direct children of the root', () => {
+    const root = new THREE.Group();
+    const direct = new THREE.Mesh(new THREE.BoxGeometry());
+    const nested = new THREE.Mesh(new THREE.BoxGeometry());
+    const innerGroup = new THREE.Group();
+    innerGroup.add(nested);
+    root.add(direct);
+    root.add(innerGroup);
+    applyBVH(root, {recursive: false});
+    // The root itself isn't a mesh, neither is innerGroup, so neither
+    // direct nor nested gets a tree (recursive=false skips descending
+    // into root's children as a tree walk; the root is just the
+    // starting node).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((direct.geometry as any).boundsTree).toBeUndefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((nested.geometry as any).boundsTree).toBeUndefined();
+  });
+
+  it('disposeBVH drops the boundsTree on every mesh in the tree', () => {
+    const root = new THREE.Group();
+    const m = new THREE.Mesh(new THREE.BoxGeometry());
+    root.add(m);
+    applyBVH(root);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((m.geometry as any).boundsTree).toBeDefined();
+    disposeBVH(root);
+    // disposeBoundsTree sets boundsTree to null, not undefined.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((m.geometry as any).boundsTree).toBeFalsy();
+  });
+});

--- a/src/utils/BVHRaycast.test.ts
+++ b/src/utils/BVHRaycast.test.ts
@@ -1,26 +1,35 @@
 import * as THREE from 'three';
 import {describe, expect, it} from 'vitest';
 
-import {applyBVH, disposeBVH, enableAcceleratedRaycast} from './BVHRaycast';
+import {
+  applyBVH,
+  disposeBVH,
+  enableAcceleratedRaycast,
+  isBVHReady,
+} from './BVHRaycast';
 
 describe('BVHRaycast', () => {
-  it('installs the THREE.Mesh prototype patch and helpers on first call', () => {
-    enableAcceleratedRaycast();
+  it('installs the THREE.Mesh prototype patch and helpers after enableAcceleratedRaycast resolves', async () => {
+    const ok = await enableAcceleratedRaycast();
+    expect(ok).toBe(true);
+    expect(isBVHReady()).toBe(true);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const proto = THREE.BufferGeometry.prototype as any;
     expect(typeof proto.computeBoundsTree).toBe('function');
     expect(typeof proto.disposeBoundsTree).toBe('function');
   });
 
-  it('is idempotent: re-calling enableAcceleratedRaycast does not throw or re-bind', () => {
-    enableAcceleratedRaycast();
-    enableAcceleratedRaycast();
+  it('is idempotent: re-calling enableAcceleratedRaycast returns same result and does not re-patch', async () => {
+    const first = await enableAcceleratedRaycast();
+    const second = await enableAcceleratedRaycast();
+    expect(first).toBe(true);
+    expect(second).toBe(true);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const proto = THREE.BufferGeometry.prototype as any;
     expect(typeof proto.computeBoundsTree).toBe('function');
   });
 
-  it('applyBVH builds a boundsTree on every mesh in the tree (recursive)', () => {
+  it('applyBVH builds a boundsTree on every mesh in the tree (recursive)', async () => {
     const root = new THREE.Group();
     const m1 = new THREE.Mesh(new THREE.BoxGeometry());
     const m2 = new THREE.Mesh(new THREE.SphereGeometry());
@@ -28,28 +37,27 @@ describe('BVHRaycast', () => {
     inner.add(m2);
     root.add(m1);
     root.add(inner);
-    applyBVH(root);
+    await applyBVH(root);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((m1.geometry as any).boundsTree).toBeDefined();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((m2.geometry as any).boundsTree).toBeDefined();
   });
 
-  it('applyBVH skips meshes that already have a boundsTree (idempotent)', () => {
+  it('applyBVH skips meshes that already have a boundsTree (idempotent)', async () => {
     const root = new THREE.Group();
     const m = new THREE.Mesh(new THREE.BoxGeometry());
     root.add(m);
-    applyBVH(root);
+    await applyBVH(root);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const firstTree = (m.geometry as any).boundsTree;
-    applyBVH(root);
+    await applyBVH(root);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const secondTree = (m.geometry as any).boundsTree;
-    // Same instance: not rebuilt on the second call.
     expect(secondTree).toBe(firstTree);
   });
 
-  it('applyBVH with recursive=false only visits direct children of the root', () => {
+  it('applyBVH with recursive=false only visits the root itself', async () => {
     const root = new THREE.Group();
     const direct = new THREE.Mesh(new THREE.BoxGeometry());
     const nested = new THREE.Mesh(new THREE.BoxGeometry());
@@ -57,26 +65,24 @@ describe('BVHRaycast', () => {
     innerGroup.add(nested);
     root.add(direct);
     root.add(innerGroup);
-    applyBVH(root, {recursive: false});
-    // The root itself isn't a mesh, neither is innerGroup, so neither
-    // direct nor nested gets a tree (recursive=false skips descending
-    // into root's children as a tree walk; the root is just the
-    // starting node).
+    await applyBVH(root, {recursive: false});
+    // The root is a Group (not a Mesh), so nothing gets a tree when
+    // recursive=false: we only visit the root itself.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((direct.geometry as any).boundsTree).toBeUndefined();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((nested.geometry as any).boundsTree).toBeUndefined();
   });
 
-  it('disposeBVH drops the boundsTree on every mesh in the tree', () => {
+  it('disposeBVH drops the boundsTree on every mesh in the tree', async () => {
     const root = new THREE.Group();
     const m = new THREE.Mesh(new THREE.BoxGeometry());
     root.add(m);
-    applyBVH(root);
+    await applyBVH(root);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((m.geometry as any).boundsTree).toBeDefined();
     disposeBVH(root);
-    // disposeBoundsTree sets boundsTree to null, not undefined.
+    // disposeBoundsTree sets boundsTree to null.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((m.geometry as any).boundsTree).toBeFalsy();
   });

--- a/src/utils/BVHRaycast.ts
+++ b/src/utils/BVHRaycast.ts
@@ -1,0 +1,92 @@
+import * as THREE from 'three';
+import {
+  acceleratedRaycast,
+  computeBoundsTree,
+  disposeBoundsTree,
+} from 'three-mesh-bvh';
+
+// Tracks whether the THREE.Mesh prototype patch has already been
+// installed so callers can ping `enableAcceleratedRaycast()` from
+// multiple subsystems without paying for redundant overwrites.
+let bvhProtoPatched = false;
+
+/**
+ * Install the three-mesh-bvh prototype patches that switch
+ * `THREE.Mesh.raycast` over to the BVH-accelerated implementation
+ * when the target mesh has a computed bounds tree, and add
+ * `computeBoundsTree` / `disposeBoundsTree` helpers to
+ * `THREE.BufferGeometry`.
+ *
+ * Safe to call multiple times. Meshes without a bounds tree continue
+ * to use three.js's stock raycaster, so flipping this switch on
+ * globally does not affect callers that never call
+ * `computeBoundsTree()`.
+ */
+export function enableAcceleratedRaycast() {
+  if (bvhProtoPatched) return;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (THREE.Mesh.prototype as any).raycast = acceleratedRaycast;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (THREE.BufferGeometry.prototype as any).computeBoundsTree = computeBoundsTree;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (THREE.BufferGeometry.prototype as any).disposeBoundsTree = disposeBoundsTree;
+  bvhProtoPatched = true;
+}
+
+/**
+ * Walk the given object3D (recursively) and build a bounds tree on
+ * every mesh's geometry that doesn't already have one. After this
+ * call any `raycaster.intersectObject(root, true)` against the tree
+ * goes through the BVH-accelerated path instead of walking every
+ * triangle per ray.
+ *
+ * Use this on the root of a scene (or sub-tree) that the SDK's
+ * interaction raycaster walks every frame. The build cost is
+ * proportional to total triangle count and happens once per geometry.
+ *
+ * Geometries that already have a `boundsTree` are left alone so
+ * repeat calls are idempotent.
+ */
+export function applyBVH(
+  root: THREE.Object3D,
+  {recursive = true}: {recursive?: boolean} = {}
+) {
+  enableAcceleratedRaycast();
+  const visit = (obj: THREE.Object3D) => {
+    if (obj instanceof THREE.Mesh && obj.geometry) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const geom = obj.geometry as any;
+      if (!geom.boundsTree && typeof geom.computeBoundsTree === 'function') {
+        geom.computeBoundsTree();
+      }
+    }
+    if (recursive) {
+      for (const child of obj.children) visit(child);
+    }
+  };
+  visit(root);
+}
+
+/**
+ * Walk the given object3D (recursively) and dispose any bounds trees
+ * previously built by `applyBVH`. Use before tearing down a scene so
+ * the underlying typed arrays drop their refs.
+ */
+export function disposeBVH(
+  root: THREE.Object3D,
+  {recursive = true}: {recursive?: boolean} = {}
+) {
+  const visit = (obj: THREE.Object3D) => {
+    if (obj instanceof THREE.Mesh && obj.geometry) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const geom = obj.geometry as any;
+      if (geom.boundsTree && typeof geom.disposeBoundsTree === 'function') {
+        geom.disposeBoundsTree();
+      }
+    }
+    if (recursive) {
+      for (const child of obj.children) visit(child);
+    }
+  };
+  visit(root);
+}

--- a/src/utils/BVHRaycast.ts
+++ b/src/utils/BVHRaycast.ts
@@ -1,29 +1,84 @@
 import * as THREE from 'three';
-import {
-  acceleratedRaycast,
-  computeBoundsTree,
-  disposeBoundsTree,
-} from 'three-mesh-bvh';
+import type * as BVH from 'three-mesh-bvh';
 
-// Tracks whether the THREE.Mesh prototype patch has already been
-// installed so callers can ping `enableAcceleratedRaycast()` from
-// multiple subsystems without paying for redundant overwrites.
+// --- Dynamic Import of three-mesh-bvh ---
+//
+// Loaded the same way troika-three-text is in TextView: type-only
+// import for the SDK build, dynamic runtime import with try / catch +
+// status tracking so apps without three-mesh-bvh installed (or without
+// it in their importmap) don't break, they just don't get the
+// accelerated raycast.
+//
+// Apps opt in to BVH by either calling enableAcceleratedRaycast() or
+// applyBVH() and ensuring three-mesh-bvh is reachable at runtime
+// (e.g. via the demo importmap).
+
+enum BvhImportStatus {
+  PENDING = 0,
+  SUCCESS = 1,
+  FAILED = 2,
+}
+
+let acceleratedRaycast: typeof BVH.acceleratedRaycast | undefined;
+let computeBoundsTree: typeof BVH.computeBoundsTree | undefined;
+let disposeBoundsTree: typeof BVH.disposeBoundsTree | undefined;
+let bvhImportStatus = BvhImportStatus.PENDING;
+let bvhImportError: Error | undefined;
+let bvhImportPromise: Promise<boolean> | null = null;
 let bvhProtoPatched = false;
 
+function importBVH(): Promise<boolean> {
+  if (bvhImportPromise) return bvhImportPromise;
+  bvhImportPromise = (async () => {
+    try {
+      const mod = await import('three-mesh-bvh');
+      acceleratedRaycast = mod.acceleratedRaycast;
+      computeBoundsTree = mod.computeBoundsTree;
+      disposeBoundsTree = mod.disposeBoundsTree;
+      bvhImportStatus = BvhImportStatus.SUCCESS;
+      return true;
+    } catch (error: unknown) {
+      if (error instanceof Error) bvhImportError = error;
+      bvhImportStatus = BvhImportStatus.FAILED;
+      console.warn(
+        '[xrblocks] three-mesh-bvh not available; raycasts will use the ' +
+          'stock three.js walker. Install three-mesh-bvh or add it to your ' +
+          'importmap to enable BVH-accelerated raycasts.',
+        error
+      );
+      return false;
+    }
+  })();
+  return bvhImportPromise;
+}
+
 /**
- * Install the three-mesh-bvh prototype patches that switch
- * `THREE.Mesh.raycast` over to the BVH-accelerated implementation
- * when the target mesh has a computed bounds tree, and add
+ * Whether the BVH module has been loaded AND the THREE prototypes have
+ * been patched. Sync check; returns false until `enableAcceleratedRaycast()`
+ * (or `applyBVH()`) has resolved at least once.
+ */
+export function isBVHReady(): boolean {
+  return bvhProtoPatched;
+}
+
+/**
+ * Dynamically import three-mesh-bvh and install the prototype patches
+ * that route `THREE.Mesh.raycast` through the accelerated path when
+ * the target mesh has a computed bounds tree. Adds
  * `computeBoundsTree` / `disposeBoundsTree` helpers to
  * `THREE.BufferGeometry`.
  *
- * Safe to call multiple times. Meshes without a bounds tree continue
- * to use three.js's stock raycaster, so flipping this switch on
- * globally does not affect callers that never call
- * `computeBoundsTree()`.
+ * Async because the BVH module is loaded on demand (same pattern as
+ * troika-three-text). Resolves to `true` if the module loaded and
+ * patches were applied, `false` if the module isn't available — in
+ * which case meshes continue to use the stock raycaster.
+ *
+ * Safe to call multiple times. The first call kicks off the import,
+ * subsequent calls share the same promise.
  */
-export function enableAcceleratedRaycast() {
-  if (bvhProtoPatched) return;
+export async function enableAcceleratedRaycast(): Promise<boolean> {
+  const ok = await importBVH();
+  if (!ok || bvhProtoPatched) return bvhProtoPatched;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (THREE.Mesh.prototype as any).raycast = acceleratedRaycast;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -31,6 +86,7 @@ export function enableAcceleratedRaycast() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (THREE.BufferGeometry.prototype as any).disposeBoundsTree = disposeBoundsTree;
   bvhProtoPatched = true;
+  return true;
 }
 
 /**
@@ -44,14 +100,17 @@ export function enableAcceleratedRaycast() {
  * interaction raycaster walks every frame. The build cost is
  * proportional to total triangle count and happens once per geometry.
  *
- * Geometries that already have a `boundsTree` are left alone so
- * repeat calls are idempotent.
+ * Async because it awaits the dynamic import of three-mesh-bvh. If
+ * the module isn't available, this is a no-op. Geometries that
+ * already have a `boundsTree` are left alone so repeat calls are
+ * idempotent.
  */
-export function applyBVH(
+export async function applyBVH(
   root: THREE.Object3D,
   {recursive = true}: {recursive?: boolean} = {}
-) {
-  enableAcceleratedRaycast();
+): Promise<void> {
+  const ok = await enableAcceleratedRaycast();
+  if (!ok) return;
   const visit = (obj: THREE.Object3D) => {
     if (obj instanceof THREE.Mesh && obj.geometry) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -69,13 +128,14 @@ export function applyBVH(
 
 /**
  * Walk the given object3D (recursively) and dispose any bounds trees
- * previously built by `applyBVH`. Use before tearing down a scene so
- * the underlying typed arrays drop their refs.
+ * previously built by `applyBVH`. Sync; no-op if three-mesh-bvh
+ * wasn't loaded.
  */
 export function disposeBVH(
   root: THREE.Object3D,
   {recursive = true}: {recursive?: boolean} = {}
-) {
+): void {
+  if (!bvhProtoPatched) return;
   const visit = (obj: THREE.Object3D) => {
     if (obj instanceof THREE.Mesh && obj.geometry) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -89,4 +149,12 @@ export function disposeBVH(
     }
   };
   visit(root);
+}
+
+// Exposed for tests; consumers should use isBVHReady() instead.
+export function _getBvhImportStatus(): {
+  status: BvhImportStatus;
+  error?: Error;
+} {
+  return {status: bvhImportStatus, error: bvhImportError};
 }

--- a/src/world/faces/FaceRecognizer.ts
+++ b/src/world/faces/FaceRecognizer.ts
@@ -149,18 +149,57 @@ export class FaceRecognizer extends Script {
     return backendPromise;
   }
 
+  // Cached depth-mesh snapshot (cloned geometry + BVH). We rebuild it
+  // only when the source depth geometry's position attribute bumps its
+  // version (three.js does this automatically whenever the depth mesh
+  // refreshes via needsUpdate = true). For a static desktop sim the
+  // BVH build therefore amortizes across all detections instead of
+  // running every detection.
+  private cachedDepthMeshSnapshot: THREE.Mesh | null = null;
+  private cachedDepthMeshSource: THREE.BufferGeometry | null = null;
+  private cachedDepthMeshVersion = -1;
+
   private getDepthMeshSnapshot() {
     const depthMesh = this.depth.depthMesh!;
     const geometry = this.depth.options.depthMesh.updateFullResolutionGeometry
       ? depthMesh.geometry
       : depthMesh.downsampledGeometry || depthMesh.geometry;
+    // Both BufferAttribute and InterleavedBufferAttribute carry a
+    // `version` field that three.js bumps on `needsUpdate = true`, but
+    // the type for the union doesn't expose it. Cast to read.
+    const positionAttr = geometry.attributes.position as unknown as {
+      version: number;
+    };
+    const version = positionAttr.version;
+    if (
+      this.cachedDepthMeshSnapshot &&
+      this.cachedDepthMeshSource === geometry &&
+      this.cachedDepthMeshVersion === version
+    ) {
+      // Source geometry hasn't been updated since last snapshot. Refresh
+      // the cached snapshot's world transform (cheap) and return it as
+      // is. The BVH built over the cloned positions is still valid
+      // because the source positions haven't changed.
+      depthMesh.getWorldPosition(this.cachedDepthMeshSnapshot.position);
+      depthMesh.getWorldQuaternion(this.cachedDepthMeshSnapshot.quaternion);
+      depthMesh.getWorldScale(this.cachedDepthMeshSnapshot.scale);
+      this.cachedDepthMeshSnapshot.updateMatrixWorld(true);
+      return this.cachedDepthMeshSnapshot;
+    }
+    // Source changed (or first call). Dispose the previous BVH so its
+    // backing buffers free, then clone + rebuild.
+    if (this.cachedDepthMeshSnapshot) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (this.cachedDepthMeshSnapshot.geometry as any).disposeBoundsTree?.();
+      this.cachedDepthMeshSnapshot.geometry.dispose();
+    }
     const clonedGeometry = geometry.clone();
     clonedGeometry.computeBoundingSphere();
     clonedGeometry.computeBoundingBox();
-    // Build a BVH over the cloned depth-mesh geometry once per detection
-    // so the per-landmark raycasts inside processFaceLandmarkerResult go
-    // through the BVH-accelerated path instead of walking every triangle
-    // 478 times. The clone is disposed by the GC at end of detection.
+    // Build a BVH over the cloned depth-mesh geometry so the per-
+    // landmark raycasts inside processFaceLandmarkerResult go through
+    // the BVH-accelerated path instead of walking every triangle 478
+    // times.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (clonedGeometry as any).computeBoundsTree();
     const depthMeshSnapshot = new THREE.Mesh(
@@ -171,6 +210,9 @@ export class FaceRecognizer extends Script {
     depthMesh.getWorldQuaternion(depthMeshSnapshot.quaternion);
     depthMesh.getWorldScale(depthMeshSnapshot.scale);
     depthMeshSnapshot.updateMatrixWorld(true);
+    this.cachedDepthMeshSnapshot = depthMeshSnapshot;
+    this.cachedDepthMeshSource = geometry;
+    this.cachedDepthMeshVersion = version;
     return depthMeshSnapshot;
   }
 }

--- a/src/world/faces/FaceRecognizer.ts
+++ b/src/world/faces/FaceRecognizer.ts
@@ -1,4 +1,9 @@
 import * as THREE from 'three';
+import {
+  acceleratedRaycast,
+  computeBoundsTree,
+  disposeBoundsTree,
+} from 'three-mesh-bvh';
 import {getCameraParametersSnapshot} from '../../camera/CameraUtils';
 import {XRDeviceCamera} from '../../camera/XRDeviceCamera';
 import {Script} from '../../core/Script';
@@ -7,6 +12,22 @@ import {WorldOptions} from '../WorldOptions';
 import {DetectedFace} from './DetectedFace';
 import {BaseFaceBackend, FaceBackendContext} from './FaceDetectorBackend';
 import {MediaPipeFaceBackend} from './backends/MediaPipeFaceBackend';
+
+// Wire three-mesh-bvh into THREE so any Mesh.raycast() that has a
+// computed boundsTree goes through the BVH-accelerated path. Meshes
+// without a boundsTree fall back to the stock walker, so this patch is
+// safe to apply globally and idempotent across modules.
+// FaceLandmarker emits 478 landmarks per face and we raycast each one
+// against the depth mesh in processFaceLandmarkerResult. The stock
+// raycaster is O(triangles) per ray and the depth mesh is a few thousand
+// triangles, so without BVH the per-detection raycast loop alone can
+// dominate the frame budget. BVH drops it to O(log triangles).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(THREE.Mesh.prototype as any).raycast = acceleratedRaycast;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(THREE.BufferGeometry.prototype as any).computeBoundsTree = computeBoundsTree;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(THREE.BufferGeometry.prototype as any).disposeBoundsTree = disposeBoundsTree;
 
 /**
  * A detector script that orchestrates face landmark estimation. Manages
@@ -136,6 +157,12 @@ export class FaceRecognizer extends Script {
     const clonedGeometry = geometry.clone();
     clonedGeometry.computeBoundingSphere();
     clonedGeometry.computeBoundingBox();
+    // Build a BVH over the cloned depth-mesh geometry once per detection
+    // so the per-landmark raycasts inside processFaceLandmarkerResult go
+    // through the BVH-accelerated path instead of walking every triangle
+    // 478 times. The clone is disposed by the GC at end of detection.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (clonedGeometry as any).computeBoundsTree();
     const depthMeshSnapshot = new THREE.Mesh(
       clonedGeometry,
       new THREE.MeshBasicMaterial()

--- a/src/world/faces/FaceRecognizer.ts
+++ b/src/world/faces/FaceRecognizer.ts
@@ -1,33 +1,25 @@
 import * as THREE from 'three';
-import {
-  acceleratedRaycast,
-  computeBoundsTree,
-  disposeBoundsTree,
-} from 'three-mesh-bvh';
 import {getCameraParametersSnapshot} from '../../camera/CameraUtils';
 import {XRDeviceCamera} from '../../camera/XRDeviceCamera';
 import {Script} from '../../core/Script';
 import {Depth} from '../../depth/Depth';
+import {enableAcceleratedRaycast} from '../../utils/BVHRaycast';
 import {WorldOptions} from '../WorldOptions';
 import {DetectedFace} from './DetectedFace';
 import {BaseFaceBackend, FaceBackendContext} from './FaceDetectorBackend';
 import {MediaPipeFaceBackend} from './backends/MediaPipeFaceBackend';
 
-// Wire three-mesh-bvh into THREE so any Mesh.raycast() that has a
-// computed boundsTree goes through the BVH-accelerated path. Meshes
-// without a boundsTree fall back to the stock walker, so this patch is
-// safe to apply globally and idempotent across modules.
+// Install the BVH-accelerated raycast prototype patches at module
+// load so the per-landmark raycasts inside processFaceLandmarkerResult
+// go through the accelerated path. enableAcceleratedRaycast is
+// idempotent across modules so this is safe even if another subsystem
+// already called it.
+//
 // FaceLandmarker emits 478 landmarks per face and we raycast each one
-// against the depth mesh in processFaceLandmarkerResult. The stock
-// raycaster is O(triangles) per ray and the depth mesh is a few thousand
-// triangles, so without BVH the per-detection raycast loop alone can
-// dominate the frame budget. BVH drops it to O(log triangles).
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(THREE.Mesh.prototype as any).raycast = acceleratedRaycast;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(THREE.BufferGeometry.prototype as any).computeBoundsTree = computeBoundsTree;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(THREE.BufferGeometry.prototype as any).disposeBoundsTree = disposeBoundsTree;
+// against the depth-mesh snapshot. Stock three.js is O(triangles) per
+// ray; the depth mesh runs in the thousands of triangles so without
+// BVH the per-detection raycast loop alone dominates the frame budget.
+enableAcceleratedRaycast();
 
 /**
  * A detector script that orchestrates face landmark estimation. Manages

--- a/src/world/faces/FaceRecognizer.ts
+++ b/src/world/faces/FaceRecognizer.ts
@@ -3,17 +3,19 @@ import {getCameraParametersSnapshot} from '../../camera/CameraUtils';
 import {XRDeviceCamera} from '../../camera/XRDeviceCamera';
 import {Script} from '../../core/Script';
 import {Depth} from '../../depth/Depth';
-import {enableAcceleratedRaycast} from '../../utils/BVHRaycast';
+import {enableAcceleratedRaycast, isBVHReady} from '../../utils/BVHRaycast';
 import {WorldOptions} from '../WorldOptions';
 import {DetectedFace} from './DetectedFace';
 import {BaseFaceBackend, FaceBackendContext} from './FaceDetectorBackend';
 import {MediaPipeFaceBackend} from './backends/MediaPipeFaceBackend';
 
-// Install the BVH-accelerated raycast prototype patches at module
+// Kick off the BVH-accelerated raycast prototype patches at module
 // load so the per-landmark raycasts inside processFaceLandmarkerResult
-// go through the accelerated path. enableAcceleratedRaycast is
-// idempotent across modules so this is safe even if another subsystem
-// already called it.
+// go through the accelerated path. Fire-and-forget: the helper loads
+// three-mesh-bvh dynamically and the SDK keeps working even if the
+// module isn't installed or in the importmap (raycasts fall back to
+// the stock walker). idempotent across modules so multiple subsystems
+// can ping it safely.
 //
 // FaceLandmarker emits 478 landmarks per face and we raycast each one
 // against the depth-mesh snapshot. Stock three.js is O(triangles) per
@@ -188,12 +190,16 @@ export class FaceRecognizer extends Script {
     const clonedGeometry = geometry.clone();
     clonedGeometry.computeBoundingSphere();
     clonedGeometry.computeBoundingBox();
-    // Build a BVH over the cloned depth-mesh geometry so the per-
-    // landmark raycasts inside processFaceLandmarkerResult go through
-    // the BVH-accelerated path instead of walking every triangle 478
-    // times.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (clonedGeometry as any).computeBoundsTree();
+    // Build a BVH over the cloned depth-mesh geometry when three-mesh-bvh
+    // is available so the per-landmark raycasts inside
+    // processFaceLandmarkerResult go through the BVH-accelerated path
+    // instead of walking every triangle 478 times. If BVH isn't ready
+    // yet (dynamic import in flight or three-mesh-bvh not installed),
+    // we skip computeBoundsTree and the stock raycaster takes over.
+    if (isBVHReady()) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (clonedGeometry as any).computeBoundsTree();
+    }
     const depthMeshSnapshot = new THREE.Mesh(
       clonedGeometry,
       new THREE.MeshBasicMaterial()

--- a/src/xrblocks.ts
+++ b/src/xrblocks.ts
@@ -118,6 +118,7 @@ export * from './ui/layouts/SpatialPanel';
 export * from './ui/layouts/TextScrollerState';
 export * from './ui/layouts/VerticalPager';
 export * from './ui/UI';
+export * from './utils/BVHRaycast';
 export * from './utils/DependencyInjection';
 export * from './utils/HelperConstants';
 export * from './utils/Keycodes';


### PR DESCRIPTION
even with FaceLandmarker inference moved to a worker (#366), the per-detection raycast loop still tanked desktop FPS. perf trace showed `getVertexPosition` + `intersectTriangle` + `_computeIntersections` eating ~9 of every 14 main-thread seconds.

`processFaceLandmarkerResult` raycasts each of the 478 landmarks against the depth-mesh snapshot to project to world coords. stock three.js raycaster is O(triangles) per ray, depth mesh runs in the thousands of triangles, so the per-detection raycast loop alone dominates the frame budget.

wires three-mesh-bvh prototype patches at FaceRecognizer module load (same trick objects_3d uses) and calls `computeBoundsTree()` on the cloned depth-mesh geometry in `getDepthMeshSnapshot`. meshes without a BVH fall back to the stock walker so the patch is safe to apply globally.

measured improvement in the same trace before/after: `getVertexPosition` 4284ms -> 88ms, `intersectTriangle` 3211ms -> 57ms (~98% reduction on each).

follow-up commit caches the cloned snapshot + BVH and reuses them while the source geometry's position attribute version is unchanged (three.js bumps it on `needsUpdate = true`). world transform still refreshes each call so the cached snapshot reflects the current depth mesh pose. for a static desktop sim this amortizes the BVH build across all detections instead of running every detection.

three-mesh-bvh added to package.json + face_mirror demo importmap. same version objects_3d already pins.

related: #366 (worker), #370 (simulator depth inflight guard). all independent file-wise.
