### PR TITLE
perf(demos/face_mirror): merge wireframe Lines into one LineSegments

### DIFF
--- a/demos/face_mirror/FaceMirror.js
+++ b/demos/face_mirror/FaceMirror.js
@@ -243,8 +243,11 @@ export class FaceMirror extends xb.Script {
   }
 
   initWireframe() {
-    // One Line3 geometry per edge: easier than a single LineSegments with
-    // index updates because we mutate positions every frame.
+    // Single LineSegments mesh holding all ~134 edges in one BufferGeometry.
+    // Previously we had one THREE.Line per edge, which is ~134 draw calls
+    // per frame just for the wireframe. Merging into LineSegments collapses
+    // that to a single draw call, freeing several ms of frame time at the
+    // cost of slightly more bookkeeping when we update positions.
     const lineMaterial = new THREE.LineBasicMaterial({
       color: 0x4796e3,
       transparent: true,
@@ -252,18 +255,18 @@ export class FaceMirror extends xb.Script {
       depthTest: false,
     });
     this.lineMaterial = lineMaterial;
-    this.lineGeometries = ALL_EDGES.map(() => {
-      const geom = new THREE.BufferGeometry();
-      geom.setAttribute(
-        'position',
-        new THREE.BufferAttribute(new Float32Array(6), 3)
-      );
-      const line = new THREE.Line(geom, lineMaterial);
-      line.frustumCulled = false;
-      line.renderOrder = 5;
-      this.add(line);
-      return geom;
-    });
+    // 2 vertices per edge, 3 floats per vertex.
+    this.linePositions = new Float32Array(ALL_EDGES.length * 2 * 3);
+    const lineGeom = new THREE.BufferGeometry();
+    lineGeom.setAttribute(
+      'position',
+      new THREE.BufferAttribute(this.linePositions, 3)
+    );
+    this.lineGeometry = lineGeom;
+    this.lineSegments = new THREE.LineSegments(lineGeom, lineMaterial);
+    this.lineSegments.frustumCulled = false;
+    this.lineSegments.renderOrder = 5;
+    this.add(this.lineSegments);
     // Point cloud of all 478 landmarks for the "data density" feel.
     const pointGeom = new THREE.BufferGeometry();
     pointGeom.setAttribute(
@@ -436,12 +439,7 @@ export class FaceMirror extends xb.Script {
 
   setWireframeVisible(v) {
     this.pointCloud.visible = v;
-    for (const g of this.lineGeometries) {
-      g.boundingSphere = null;
-    }
-    for (const child of this.children) {
-      if (child instanceof THREE.Line) child.visible = v;
-    }
+    this.lineSegments.visible = v;
   }
 
   updateWireframe(face) {
@@ -454,20 +452,33 @@ export class FaceMirror extends xb.Script {
       positions[i * 3 + 2] = wp.z;
     }
     this.pointGeometry.attributes.position.needsUpdate = true;
+    // Pack all edges into the single LineSegments position buffer.
+    // Order: 2 verts × 3 floats per edge.
+    const linePositions = this.linePositions;
     for (let e = 0; e < ALL_EDGES.length; e++) {
       const [a, b] = ALL_EDGES[e];
       const wa = face.landmarks[a]?.worldPosition;
       const wb = face.landmarks[b]?.worldPosition;
-      if (!wa || !wb) continue;
-      const arr = this.lineGeometries[e].attributes.position.array;
-      arr[0] = wa.x;
-      arr[1] = wa.y;
-      arr[2] = wa.z;
-      arr[3] = wb.x;
-      arr[4] = wb.y;
-      arr[5] = wb.z;
-      this.lineGeometries[e].attributes.position.needsUpdate = true;
+      const off = e * 6;
+      if (!wa || !wb) {
+        // Collapse the edge to a single point so it doesn't render a
+        // stale line back to (0, 0, 0) when a landmark is missing.
+        linePositions[off] = 0;
+        linePositions[off + 1] = 0;
+        linePositions[off + 2] = 0;
+        linePositions[off + 3] = 0;
+        linePositions[off + 4] = 0;
+        linePositions[off + 5] = 0;
+        continue;
+      }
+      linePositions[off] = wa.x;
+      linePositions[off + 1] = wa.y;
+      linePositions[off + 2] = wa.z;
+      linePositions[off + 3] = wb.x;
+      linePositions[off + 4] = wb.y;
+      linePositions[off + 5] = wb.z;
     }
+    this.lineGeometry.attributes.position.needsUpdate = true;
   }
 
   updateBars(face) {


### PR DESCRIPTION
the demo had one `THREE.Line` per edge of the face mesh, ~134 draw calls per frame just for the wireframe. merged into a single `THREE.LineSegments` sharing one BufferGeometry. one draw call, one needsUpdate flag per detection.

missing landmarks collapse to a zero-length segment so we don't render stale tails to the origin.

related: #366 (worker), #367 (BVH). all independent file-wise. spatial-HUD bar-fill anchoring is its own PR.