### PR TITLE
fix(demos/face_mirror): anchor spatial HUD blendshape bars left

### DIFF
--- a/demos/face_mirror/FaceMirror.js
+++ b/demos/face_mirror/FaceMirror.js
@@ -388,16 +388,12 @@ export class FaceMirror extends xb.Script {
       // CSS-style `width: 50%` thing.
       const fill = new UIPanel({
         flexGrow: 0,
-        flexShrink: 0,
-        flexBasis: 0,
         height: '100%',
         fillColor: '#4796e3',
         cornerRadius: 5,
       });
       const spacer = new UIPanel({
         flexGrow: 1,
-        flexShrink: 0,
-        flexBasis: 0,
         height: '100%',
       });
       track.add(fill);

--- a/demos/face_mirror/FaceMirror.js
+++ b/demos/face_mirror/FaceMirror.js
@@ -378,29 +378,34 @@ export class FaceMirror extends xb.Script {
         height: 10,
         fillColor: 'rgba(255, 255, 255, 0.08)',
         cornerRadius: 5,
-        // The track is the positioning container for the absolutely
-        // positioned fill child below.
-        positionType: 'relative',
+        flexDirection: 'row',
+        alignItems: 'stretch',
       });
+      // Bar value drawn as a flex-grow pair: the fill grows by `value`
+      // and the spacer grows by `1 - value`, so they always split the
+      // track exactly and the fill anchors to the left edge. Avoids
+      // percentage-width quirks we kept hitting trying to do the
+      // CSS-style `width: 50%` thing.
       const fill = new UIPanel({
-        // Pin the fill to the track's left edge via absolute
-        // positioning. Without this Yoga centers a child with explicit
-        // width along the track's cross axis, so the bar visibly
-        // expands from the centre and bleeds past the left edge as the
-        // value grows.
-        positionType: 'absolute',
-        positionLeft: 0,
-        positionTop: 0,
-        width: '0%',
+        flexGrow: 0,
+        flexShrink: 0,
+        flexBasis: 0,
         height: '100%',
         fillColor: '#4796e3',
         cornerRadius: 5,
       });
+      const spacer = new UIPanel({
+        flexGrow: 1,
+        flexShrink: 0,
+        flexBasis: 0,
+        height: '100%',
+      });
       track.add(fill);
+      track.add(spacer);
       row.add(label);
       row.add(track);
       hudPanel.add(row);
-      this.spatialBars.set(name, fill);
+      this.spatialBars.set(name, {fill, spacer});
     }
     this.hudCard.add(hudPanel);
   }
@@ -498,8 +503,11 @@ export class FaceMirror extends xb.Script {
       const pct = (v * 100).toFixed(0) + '%';
       const htmlFill = this.barEls.get(name);
       if (htmlFill) htmlFill.style.width = pct;
-      const spatialFill = this.spatialBars.get(name);
-      if (spatialFill) spatialFill.setProperties({width: pct});
+      const spatial = this.spatialBars.get(name);
+      if (spatial) {
+        spatial.fill.setProperties({flexGrow: v});
+        spatial.spacer.setProperties({flexGrow: 1 - v});
+      }
     }
   }
 
@@ -507,8 +515,9 @@ export class FaceMirror extends xb.Script {
     for (const fill of this.barEls.values()) {
       fill.style.width = '0%';
     }
-    for (const fill of this.spatialBars.values()) {
-      fill.setProperties({width: '0%'});
+    for (const spatial of this.spatialBars.values()) {
+      spatial.fill.setProperties({flexGrow: 0});
+      spatial.spacer.setProperties({flexGrow: 1});
     }
   }
 }

--- a/demos/face_mirror/FaceMirror.js
+++ b/demos/face_mirror/FaceMirror.js
@@ -378,15 +378,19 @@ export class FaceMirror extends xb.Script {
         height: 10,
         fillColor: 'rgba(255, 255, 255, 0.08)',
         cornerRadius: 5,
-        // Anchor children to the left so the fill grows rightward from
-        // 0%. Without this the fill (which has an explicit width) is
-        // centered in the track and visibly bleeds past the left edge
-        // as the bar grows.
-        flexDirection: 'row',
-        justifyContent: 'flex-start',
-        alignItems: 'flex-start',
+        // The track is the positioning container for the absolutely
+        // positioned fill child below.
+        positionType: 'relative',
       });
       const fill = new UIPanel({
+        // Pin the fill to the track's left edge via absolute
+        // positioning. Without this Yoga centers a child with explicit
+        // width along the track's cross axis, so the bar visibly
+        // expands from the centre and bleeds past the left edge as the
+        // value grows.
+        positionType: 'absolute',
+        positionLeft: 0,
+        positionTop: 0,
         width: '0%',
         height: '100%',
         fillColor: '#4796e3',

--- a/demos/face_mirror/FaceMirror.js
+++ b/demos/face_mirror/FaceMirror.js
@@ -495,11 +495,20 @@ export class FaceMirror extends xb.Script {
   }
 
   updateBars(face) {
+    if (!this.lastBarValues) this.lastBarValues = new Map();
     for (const name of FEATURED_BLENDSHAPES) {
       const v = face.getBlendshape(name);
       const pct = (v * 100).toFixed(0) + '%';
       const htmlFill = this.barEls.get(name);
       if (htmlFill) htmlFill.style.width = pct;
+      // Skip writing to the uikit panels when the value hasn't moved
+      // by more than 0.5%. Each setProperties triggers a layout pass
+      // via the yoga wasm bridge; on a 12-bar HUD that's ~24 layouts
+      // per detection at ~30fps. With this gate a held expression
+      // (eyes blink, brows neutral) collapses to one or two writes.
+      const prev = this.lastBarValues.get(name);
+      if (prev !== undefined && Math.abs(v - prev) < 0.005) continue;
+      this.lastBarValues.set(name, v);
       const spatial = this.spatialBars.get(name);
       if (spatial) {
         spatial.fill.setProperties({flexGrow: v});
@@ -509,6 +518,7 @@ export class FaceMirror extends xb.Script {
   }
 
   resetBars() {
+    if (this.lastBarValues) this.lastBarValues.clear();
     for (const fill of this.barEls.values()) {
       fill.style.width = '0%';
     }

--- a/demos/face_mirror/FaceMirror.js
+++ b/demos/face_mirror/FaceMirror.js
@@ -378,6 +378,13 @@ export class FaceMirror extends xb.Script {
         height: 10,
         fillColor: 'rgba(255, 255, 255, 0.08)',
         cornerRadius: 5,
+        // Anchor children to the left so the fill grows rightward from
+        // 0%. Without this the fill (which has an explicit width) is
+        // centered in the track and visibly bleeds past the left edge
+        // as the bar grows.
+        flexDirection: 'row',
+        justifyContent: 'flex-start',
+        alignItems: 'flex-start',
       });
       const fill = new UIPanel({
         width: '0%',

--- a/demos/face_mirror/FaceMirror.js
+++ b/demos/face_mirror/FaceMirror.js
@@ -374,9 +374,10 @@ export class FaceMirror extends xb.Script {
         width: 180,
       });
       const track = new UIPanel({
-        flex: 1,
+        flexGrow: 1,
+        flexShrink: 1,
         height: 10,
-        fillColor: 'rgba(255, 255, 255, 0.08)',
+        fillColor: 'rgba(255, 255, 255, 0.15)',
         cornerRadius: 5,
         flexDirection: 'row',
         alignItems: 'stretch',


### PR DESCRIPTION
the spatial HUD blendshape bar fills had two visible bugs depending on the day: fills centered in the track and bleeding past the left edge, or the entire track invisible.

landed on a flex-grow ratio pattern after trying a few uikit approaches:

- `width: '50%'` centered the fill in the cross axis
- `positionType: 'absolute' + positionLeft: 0` hid the fill entirely
- `flex: 1` shorthand on the track collapsed it to zero width (uikit doesn't expand the shorthand)
- explicit `flexGrow: 1, flexShrink: 1` on the track + a flex-grow pair (fill grows by `value`, spacer grows by `1 - value`) works in both static and dynamic updates

the multi-commit history walks through those attempts.

related: #366 (worker), #367 (BVH), #368 (LineSegments). all four independent file-wise.
