### PR TITLE
perf(simulator): don't stack depth-readback requests in flight

### DIFF
--- a/src/simulator/SimulatorDepth.test.ts
+++ b/src/simulator/SimulatorDepth.test.ts
@@ -3,18 +3,12 @@ import {beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {SimulatorDepth} from './SimulatorDepth';
 
-// SimulatorDepth's update() does three things:
-//   1. Skip when an earlier async readback hasn't resolved yet
-//      (`updateInFlight`).
-//   2. Skip when the depth camera hasn't moved beyond the configured
-//      epsilons (`depthHasChanged`).
-//   3. Render the depth scene + start the async readback otherwise.
-//
-// These tests focus on the throttle logic. The actual WebGL render and
-// readback pipeline is mocked away so we don't need a real renderer.
+// SimulatorDepth.update() spawns an async readback per call. The
+// inflight guard prevents stacking a second readback while the first
+// is still resolving (the readback uses a setTimeout fence poll that
+// typically takes longer than a frame).
 
 function makeMockRenderer() {
-  // Async pixel readback returns a promise we can settle from the test.
   let resolveReadback: (() => void) | null = null;
   const renderer = {
     render: vi.fn(),
@@ -41,17 +35,7 @@ function makeMockRenderer() {
   };
 }
 
-function makeMockScene() {
-  return {overrideMaterial: null} as never;
-}
-
-function makeMockDepth() {
-  return {
-    updateCPUDepthData: vi.fn(),
-  } as never;
-}
-
-describe('SimulatorDepth.update throttle', () => {
+describe('SimulatorDepth.update inflight guard', () => {
   let depthSim: SimulatorDepth;
   let renderer: ReturnType<typeof makeMockRenderer>;
 
@@ -66,17 +50,14 @@ describe('SimulatorDepth.update throttle', () => {
         ) {}
       };
     renderer = makeMockRenderer();
-    const scene = makeMockScene();
     const camera = new THREE.PerspectiveCamera();
-    depthSim = new SimulatorDepth(scene);
-    depthSim.init(
-      renderer.renderer as unknown as THREE.WebGLRenderer,
-      camera,
-      makeMockDepth()
-    );
+    depthSim = new SimulatorDepth({overrideMaterial: null} as never);
+    depthSim.init(renderer.renderer as unknown as THREE.WebGLRenderer, camera, {
+      updateCPUDepthData: vi.fn(),
+    } as never);
   });
 
-  it('renders the depth scene on the first update so a static scene gets a depth pass', () => {
+  it('renders + starts a readback on the first update', () => {
     depthSim.update();
     expect(renderer.renderer.render).toHaveBeenCalledTimes(1);
     expect(renderer.renderer.readRenderTargetPixelsAsync).toHaveBeenCalledTimes(
@@ -84,68 +65,34 @@ describe('SimulatorDepth.update throttle', () => {
     );
   });
 
-  it('skips render + readback when the camera has not moved since the last completed update', async () => {
-    depthSim.update();
-    renderer.settleReadback();
-    await Promise.resolve();
-    await Promise.resolve();
-    depthSim.update();
-    depthSim.update();
-    expect(renderer.renderer.render).toHaveBeenCalledTimes(1);
-    expect(renderer.renderer.readRenderTargetPixelsAsync).toHaveBeenCalledTimes(
-      1
-    );
-  });
-
-  it('re-runs the depth pass when the camera translates beyond motionPositionEpsilon', async () => {
-    depthSim.update();
-    renderer.settleReadback();
-    await Promise.resolve();
-    await Promise.resolve();
-    // Disable the auto-copy so our manual move sticks past
-    // updateDepthCamera() inside update().
-    depthSim.autoUpdateDepthCameraTransform = false;
-    depthSim.depthCamera.position.x += 0.02;
-    depthSim.update();
-    expect(renderer.renderer.render).toHaveBeenCalledTimes(2);
-  });
-
-  it('re-runs the depth pass when the camera rotates beyond motionRotationEpsilon', async () => {
-    depthSim.update();
-    renderer.settleReadback();
-    await Promise.resolve();
-    await Promise.resolve();
-    depthSim.autoUpdateDepthCameraTransform = false;
-    // Rotate 5 deg about y, well above the ~0.5 deg default.
-    depthSim.depthCamera.quaternion.setFromAxisAngle(
-      new THREE.Vector3(0, 1, 0),
-      (5 * Math.PI) / 180
-    );
-    depthSim.update();
-    expect(renderer.renderer.render).toHaveBeenCalledTimes(2);
-  });
-
-  it('does NOT queue a second readback while an earlier one is still in flight', () => {
+  it('does NOT queue a second pass while an earlier readback is still in flight', () => {
     depthSim.update();
     expect(renderer.pendingReadback()).toBe(true);
-    // Move beyond the epsilon so the motion gate would otherwise pass.
-    depthSim.depthCamera.position.x += 0.05;
     depthSim.update();
-    // Render + readback still at 1 because the inflight guard kicked in.
+    depthSim.update();
     expect(renderer.renderer.render).toHaveBeenCalledTimes(1);
     expect(renderer.renderer.readRenderTargetPixelsAsync).toHaveBeenCalledTimes(
       1
     );
   });
 
-  it('runs a fresh pass once the inflight readback resolves and the camera has moved', async () => {
+  it('runs a fresh pass once the inflight readback resolves', async () => {
     depthSim.update();
     renderer.settleReadback();
+    // Flush the .finally() chain.
     await Promise.resolve();
     await Promise.resolve();
-    depthSim.autoUpdateDepthCameraTransform = false;
-    depthSim.depthCamera.position.x += 0.05;
     depthSim.update();
     expect(renderer.renderer.render).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps re-firing on every frame in a steady state once readbacks resolve in order', async () => {
+    for (let i = 0; i < 5; i++) {
+      depthSim.update();
+      renderer.settleReadback();
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+    expect(renderer.renderer.render).toHaveBeenCalledTimes(5);
   });
 });

--- a/src/simulator/SimulatorDepth.test.ts
+++ b/src/simulator/SimulatorDepth.test.ts
@@ -1,0 +1,151 @@
+import * as THREE from 'three';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {SimulatorDepth} from './SimulatorDepth';
+
+// SimulatorDepth's update() does three things:
+//   1. Skip when an earlier async readback hasn't resolved yet
+//      (`updateInFlight`).
+//   2. Skip when the depth camera hasn't moved beyond the configured
+//      epsilons (`depthHasChanged`).
+//   3. Render the depth scene + start the async readback otherwise.
+//
+// These tests focus on the throttle logic. The actual WebGL render and
+// readback pipeline is mocked away so we don't need a real renderer.
+
+function makeMockRenderer() {
+  // Async pixel readback returns a promise we can settle from the test.
+  let resolveReadback: (() => void) | null = null;
+  const renderer = {
+    render: vi.fn(),
+    setRenderTarget: vi.fn(),
+    getRenderTarget: vi.fn().mockReturnValue(null),
+    readRenderTargetPixelsAsync: vi.fn(() => {
+      return new Promise<void>((res) => {
+        resolveReadback = res;
+      });
+    }),
+    getContext: vi.fn(() => ({
+      bindBuffer: vi.fn(),
+      PIXEL_PACK_BUFFER: 0x88eb,
+    })),
+  };
+  return {
+    renderer,
+    settleReadback: () => {
+      const r = resolveReadback;
+      resolveReadback = null;
+      r?.();
+    },
+    pendingReadback: () => resolveReadback !== null,
+  };
+}
+
+function makeMockScene() {
+  return {overrideMaterial: null} as never;
+}
+
+function makeMockDepth() {
+  return {
+    updateCPUDepthData: vi.fn(),
+  } as never;
+}
+
+describe('SimulatorDepth.update throttle', () => {
+  let depthSim: SimulatorDepth;
+  let renderer: ReturnType<typeof makeMockRenderer>;
+
+  beforeEach(() => {
+    // jsdom doesn't ship XRRigidTransform; the readback path constructs
+    // one so stub it before init.
+    (globalThis as unknown as {XRRigidTransform: unknown}).XRRigidTransform =
+      class {
+        constructor(
+          public position: unknown,
+          public orientation: unknown
+        ) {}
+      };
+    renderer = makeMockRenderer();
+    const scene = makeMockScene();
+    const camera = new THREE.PerspectiveCamera();
+    depthSim = new SimulatorDepth(scene);
+    depthSim.init(
+      renderer.renderer as unknown as THREE.WebGLRenderer,
+      camera,
+      makeMockDepth()
+    );
+  });
+
+  it('renders the depth scene on the first update so a static scene gets a depth pass', () => {
+    depthSim.update();
+    expect(renderer.renderer.render).toHaveBeenCalledTimes(1);
+    expect(renderer.renderer.readRenderTargetPixelsAsync).toHaveBeenCalledTimes(
+      1
+    );
+  });
+
+  it('skips render + readback when the camera has not moved since the last completed update', async () => {
+    depthSim.update();
+    renderer.settleReadback();
+    await Promise.resolve();
+    await Promise.resolve();
+    depthSim.update();
+    depthSim.update();
+    expect(renderer.renderer.render).toHaveBeenCalledTimes(1);
+    expect(renderer.renderer.readRenderTargetPixelsAsync).toHaveBeenCalledTimes(
+      1
+    );
+  });
+
+  it('re-runs the depth pass when the camera translates beyond motionPositionEpsilon', async () => {
+    depthSim.update();
+    renderer.settleReadback();
+    await Promise.resolve();
+    await Promise.resolve();
+    // Disable the auto-copy so our manual move sticks past
+    // updateDepthCamera() inside update().
+    depthSim.autoUpdateDepthCameraTransform = false;
+    depthSim.depthCamera.position.x += 0.02;
+    depthSim.update();
+    expect(renderer.renderer.render).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-runs the depth pass when the camera rotates beyond motionRotationEpsilon', async () => {
+    depthSim.update();
+    renderer.settleReadback();
+    await Promise.resolve();
+    await Promise.resolve();
+    depthSim.autoUpdateDepthCameraTransform = false;
+    // Rotate 5 deg about y, well above the ~0.5 deg default.
+    depthSim.depthCamera.quaternion.setFromAxisAngle(
+      new THREE.Vector3(0, 1, 0),
+      (5 * Math.PI) / 180
+    );
+    depthSim.update();
+    expect(renderer.renderer.render).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT queue a second readback while an earlier one is still in flight', () => {
+    depthSim.update();
+    expect(renderer.pendingReadback()).toBe(true);
+    // Move beyond the epsilon so the motion gate would otherwise pass.
+    depthSim.depthCamera.position.x += 0.05;
+    depthSim.update();
+    // Render + readback still at 1 because the inflight guard kicked in.
+    expect(renderer.renderer.render).toHaveBeenCalledTimes(1);
+    expect(renderer.renderer.readRenderTargetPixelsAsync).toHaveBeenCalledTimes(
+      1
+    );
+  });
+
+  it('runs a fresh pass once the inflight readback resolves and the camera has moved', async () => {
+    depthSim.update();
+    renderer.settleReadback();
+    await Promise.resolve();
+    await Promise.resolve();
+    depthSim.autoUpdateDepthCameraTransform = false;
+    depthSim.depthCamera.position.x += 0.05;
+    depthSim.update();
+    expect(renderer.renderer.render).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/simulator/SimulatorDepth.ts
+++ b/src/simulator/SimulatorDepth.ts
@@ -28,27 +28,13 @@ export class SimulatorDepth {
 
   private projectionMatrixArray = new Float32Array(16);
 
-  // Throttle state. The depth pass is expensive (a full scene render to
-  // a 160x160 render target + a getRenderTargetPixelsAsync readback that
-  // burns several ms of main-thread time per call on desktop). We
-  // therefore:
-  //   1. Don't queue a new updateDepth while the previous async pass is
-  //      still in flight. Without this guard simulatorUpdate fires one
-  //      promise per frame and the readback fence polling stacks up.
-  //   2. Skip the pass entirely (no render + no readback) when the depth
-  //      camera hasn't moved or rotated meaningfully since the last
-  //      completed update. A static desktop scene therefore computes
-  //      depth once on first frame and again only when the user drags.
+  // Don't queue a new updateDepth while the previous async pass is
+  // still in flight. simulatorUpdate fires once per frame, but
+  // updateDepth() resolves via a WebGL fence poll that typically takes
+  // longer than a frame on desktop. Without this guard the
+  // setTimeout-based fence polling chains stack up and dominate the
+  // main thread.
   private updateInFlight = false;
-  private lastDepthPos = new THREE.Vector3(NaN, NaN, NaN);
-  private lastDepthQuat = new THREE.Quaternion(NaN, NaN, NaN, NaN);
-  /**
-   * Translation (m) and rotation (rad) thresholds below which the depth
-   * pass is skipped. Tuned for desktop sim: 1 cm and ~0.5 deg keep depth
-   * crisp during a drag without firing on JS-numerical noise.
-   */
-  motionPositionEpsilon = 0.01;
-  motionRotationEpsilon = 0.01;
 
   constructor(private simulatorScene: SimulatorScene) {}
 
@@ -86,32 +72,16 @@ export class SimulatorDepth {
 
   update() {
     this.updateDepthCamera();
-    // Skip both the render-to-target and the readback when an earlier
-    // updateDepth() is still resolving its readback fence. We'd just
-    // race ourselves and stack up promises.
+    // Skip if an earlier updateDepth() is still resolving its readback
+    // fence. We'd just race ourselves and stack up promises (the
+    // setTimeout-based fence poll inside readRenderTargetPixelsAsync
+    // was a dominant main-thread cost in perf traces before this).
     if (this.updateInFlight) return;
-    // Skip when the depth camera hasn't meaningfully changed since the
-    // last completed update. depthHasChanged uses configurable
-    // translation + rotation epsilons so JS-numerical noise on a held
-    // camera doesn't force a needless pass.
-    if (!this.depthHasChanged()) return;
-    this.lastDepthPos.copy(this.depthCamera.position);
-    this.lastDepthQuat.copy(this.depthCamera.quaternion);
     this.renderDepthScene();
     this.updateInFlight = true;
     this.updateDepth().finally(() => {
       this.updateInFlight = false;
     });
-  }
-
-  private depthHasChanged(): boolean {
-    // Force the first update through (lastDepthPos seeded with NaN).
-    if (Number.isNaN(this.lastDepthPos.x)) return true;
-    const dpos = this.depthCamera.position.distanceTo(this.lastDepthPos);
-    if (dpos > this.motionPositionEpsilon) return true;
-    // Quaternion angleTo gives radians between two orientations.
-    const dquat = this.depthCamera.quaternion.angleTo(this.lastDepthQuat);
-    return dquat > this.motionRotationEpsilon;
   }
 
   private updateDepthCamera() {

--- a/src/simulator/SimulatorDepth.ts
+++ b/src/simulator/SimulatorDepth.ts
@@ -28,6 +28,28 @@ export class SimulatorDepth {
 
   private projectionMatrixArray = new Float32Array(16);
 
+  // Throttle state. The depth pass is expensive (a full scene render to
+  // a 160x160 render target + a getRenderTargetPixelsAsync readback that
+  // burns several ms of main-thread time per call on desktop). We
+  // therefore:
+  //   1. Don't queue a new updateDepth while the previous async pass is
+  //      still in flight. Without this guard simulatorUpdate fires one
+  //      promise per frame and the readback fence polling stacks up.
+  //   2. Skip the pass entirely (no render + no readback) when the depth
+  //      camera hasn't moved or rotated meaningfully since the last
+  //      completed update. A static desktop scene therefore computes
+  //      depth once on first frame and again only when the user drags.
+  private updateInFlight = false;
+  private lastDepthPos = new THREE.Vector3(NaN, NaN, NaN);
+  private lastDepthQuat = new THREE.Quaternion(NaN, NaN, NaN, NaN);
+  /**
+   * Translation (m) and rotation (rad) thresholds below which the depth
+   * pass is skipped. Tuned for desktop sim: 1 cm and ~0.5 deg keep depth
+   * crisp during a drag without firing on JS-numerical noise.
+   */
+  motionPositionEpsilon = 0.01;
+  motionRotationEpsilon = 0.01;
+
   constructor(private simulatorScene: SimulatorScene) {}
 
   /**
@@ -64,8 +86,32 @@ export class SimulatorDepth {
 
   update() {
     this.updateDepthCamera();
+    // Skip both the render-to-target and the readback when an earlier
+    // updateDepth() is still resolving its readback fence. We'd just
+    // race ourselves and stack up promises.
+    if (this.updateInFlight) return;
+    // Skip when the depth camera hasn't meaningfully changed since the
+    // last completed update. depthHasChanged uses configurable
+    // translation + rotation epsilons so JS-numerical noise on a held
+    // camera doesn't force a needless pass.
+    if (!this.depthHasChanged()) return;
+    this.lastDepthPos.copy(this.depthCamera.position);
+    this.lastDepthQuat.copy(this.depthCamera.quaternion);
     this.renderDepthScene();
-    this.updateDepth();
+    this.updateInFlight = true;
+    this.updateDepth().finally(() => {
+      this.updateInFlight = false;
+    });
+  }
+
+  private depthHasChanged(): boolean {
+    // Force the first update through (lastDepthPos seeded with NaN).
+    if (Number.isNaN(this.lastDepthPos.x)) return true;
+    const dpos = this.depthCamera.position.distanceTo(this.lastDepthPos);
+    if (dpos > this.motionPositionEpsilon) return true;
+    // Quaternion angleTo gives radians between two orientations.
+    const dquat = this.depthCamera.quaternion.angleTo(this.lastDepthQuat);
+    return dquat > this.motionRotationEpsilon;
   }
 
   private updateDepthCamera() {


### PR DESCRIPTION
`SimulatorDepth.update()` was firing one render-to-target + one async readback per frame on the main thread. the readback uses `WebGLRenderer.readRenderTargetPixelsAsync` which polls a WebGL fence via setTimeout, and the fence-polling chain showed up dominating desktop perf traces of every depth-consuming demo (face_mirror, objects_3d, human_pose_detector). on a recent face_mirror trace this stack accounted for ~5 of every 12 main-thread seconds.

adds an inflight guard: don't fire a new readback while the previous promise is still resolving. without it `simulatorUpdate` stacks one per frame and the fence-polling chains overlap. when the in-flight readback resolves, the next `simulatorUpdate` runs a fresh pass normally.

initially also tried a motion gate (skip the pass when the depth camera hadn't moved), but two issues made it not worth it: scene-driven motion (animated object in SimulatorScene) wouldn't refresh depth until the camera moved, and slow tweens got skipped repeatedly then caught up in a burst. dropped it in the follow-up commit. inflight guard alone is the only behavior change.

real-headset path is untouched, `SimulatorDepth` only runs in the desktop simulator addon.

4 tests cover the guard: first-frame pass, no-double-fire while in flight, resume after readback resolves, steady-state per-frame.

context: surfaced while tracing face_mirror FPS for #366 / #367. independent of those, applies to every demo that consumes depth.
