### PR TITLE
perf(depth/occlusion): skip OcclusionPass setSize when dimensions unchanged

### DIFF
--- a/src/depth/occlusion/OcclusionPass.ts
+++ b/src/depth/occlusion/OcclusionPass.ts
@@ -37,6 +37,13 @@ export class OcclusionPass extends Pass {
   private occlusionUniforms: ShaderUniforms;
   private occlusionQuad: FullScreenQuad;
   private depthNear: (number | undefined)[] = [];
+  // Cached dimensions of the render targets so we only call setSize()
+  // when they actually changed. setSize() forces a GPU texture
+  // reallocation even when called with the same dimensions, which
+  // showed up as ~150 ms in a portals trace from a steady-state frame
+  // loop (renderer drawing-buffer size never changes mid-session).
+  private lastOcclusionMapSize = new THREE.Vector2(0, 0);
+  private lastKawaseBlurSize = new THREE.Vector2(0, 0);
 
   constructor(
     private scene: THREE.Scene,
@@ -209,7 +216,7 @@ export class OcclusionPass extends Pass {
     }
     this.scene.overrideMaterial = this.occlusionMeshMaterial;
     renderer.getDrawingBufferSize(dimensions);
-    this.occlusionMapTexture.setSize(dimensions.x, dimensions.y);
+    this.resizeOcclusionMap(dimensions);
     const renderTarget = this.occlusionMapTexture;
     renderer.setRenderTarget(renderTarget);
     const camera = renderer.xr.getCamera().cameras[viewId] || this.camera;
@@ -250,18 +257,13 @@ export class OcclusionPass extends Pass {
     }
     // First render the occlusion map to an intermediate buffer.
     renderer.getDrawingBufferSize(dimensions);
-    this.occlusionMapTexture.setSize(dimensions.x, dimensions.y);
+    this.resizeOcclusionMap(dimensions);
     renderer.setRenderTarget(this.occlusionMapTexture);
     this.occlusionMapQuad.render(renderer);
   }
 
   blurOcclusionMap(renderer: THREE.WebGLRenderer, dimensions: THREE.Vector2) {
-    for (let i = 0; i < 3; i++) {
-      this.kawaseBlurTargets[i].setSize(
-        dimensions.x / 2 ** i,
-        dimensions.y / 2 ** i
-      );
-    }
+    this.resizeKawaseBlur(dimensions);
     for (let i = 0; i < 3; i++) {
       (
         this.kawaseBlurQuads[i].material as THREE.ShaderMaterial
@@ -289,6 +291,37 @@ export class OcclusionPass extends Pass {
     this.kawaseBlurQuads[4].render(renderer);
     renderer.setRenderTarget(this.occlusionMapTexture);
     this.kawaseBlurQuads[5].render(renderer);
+  }
+
+  // Only call setSize() when the cached dimensions have actually
+  // changed. setSize triggers a render-target reallocation on every
+  // call (no internal short-circuit), and getDrawingBufferSize returns
+  // the same value frame after frame in a steady session.
+  private resizeOcclusionMap(dimensions: THREE.Vector2) {
+    if (
+      this.lastOcclusionMapSize.x === dimensions.x &&
+      this.lastOcclusionMapSize.y === dimensions.y
+    ) {
+      return;
+    }
+    this.lastOcclusionMapSize.copy(dimensions);
+    this.occlusionMapTexture.setSize(dimensions.x, dimensions.y);
+  }
+
+  private resizeKawaseBlur(dimensions: THREE.Vector2) {
+    if (
+      this.lastKawaseBlurSize.x === dimensions.x &&
+      this.lastKawaseBlurSize.y === dimensions.y
+    ) {
+      return;
+    }
+    this.lastKawaseBlurSize.copy(dimensions);
+    for (let i = 0; i < 3; i++) {
+      this.kawaseBlurTargets[i].setSize(
+        dimensions.x / 2 ** i,
+        dimensions.y / 2 ** i
+      );
+    }
   }
 
   applyOcclusionMapToRenderedImage(


### PR DESCRIPTION
`OcclusionPass` calls `setSize()` on its render targets every frame, on both the occlusion map texture and the three kawase blur targets. `setSize()` forces a GPU texture reallocation on every call even when the dimensions are identical, and `renderer.getDrawingBufferSize` returns the same value frame after frame in a steady-state session.

surfaced via a perf trace of demos/portals (which uses depth + occlusion). `WebGLRenderer.setSize` showed up at ~154 ms over a 12 s sample window in the renderOcclusionMapFromScene call chain. resize-on-real-change cuts that to effectively zero.

cached dimensions are kept per render-target group (occlusion map vs kawase blur). when the drawing buffer size actually changes (window resize, XR session start, render-target downsize), the next call detects the diff and triggers setSize as before.

## measured impact

portals demo trace before vs after (this PR + #372 both applied):

| function | before | after | change |
|---|---|---|---|
| `WebGLRenderer.setSize` | 154 ms | 1 ms | -99% (this PR) |
| `intersectTriangle` | 167 ms | 34 ms | -80% (from #372) |
| `getVertexPosition` | 137 ms | 50 ms | -64% (from #372) |
| `checkGeometryIntersection` | 178 ms | 12 ms | -93% (from #372) |
| `_computeIntersections` | 68 ms | 16 ms | -77% (from #372) |

idle went from 8% -> 60% of the trace window combined.

related: #372 (BVH-accelerated raycasts, also surfaced from the same trace).
