### PR TITLE
objects_3d: make the control panel draggable

### DIFF
--- a/demos/objects_3d/index.html
+++ b/demos/objects_3d/index.html
@@ -27,9 +27,9 @@
           "webgl-sdf-generator": "https://esm.sh/webgl-sdf-generator@1.1.1/es2022/webgl-sdf-generator.mjs",
           "lit": "https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js",
           "lit/": "https://esm.run/lit@3/",
-          "@pmndrs/uikit": "https://cdn.jsdelivr.net/npm/@pmndrs/uikit@1.0.56/dist/index.min.js",
-          "@pmndrs/uikit-pub-sub": "https://cdn.jsdelivr.net/npm/@pmndrs/uikit-pub-sub@1.0.56/dist/index.min.js",
-          "@pmndrs/msdfonts": "https://cdn.jsdelivr.net/npm/@pmndrs/msdfonts@1.0.56/dist/index.min.js",
+          "@pmndrs/uikit": "https://cdn.jsdelivr.net/npm/@pmndrs/uikit@1.0.64/dist/index.min.js",
+          "@pmndrs/uikit-pub-sub": "https://cdn.jsdelivr.net/npm/@pmndrs/uikit-pub-sub@1.0.64/dist/index.min.js",
+          "@pmndrs/msdfonts": "https://cdn.jsdelivr.net/npm/@pmndrs/msdfonts@1.0.64/dist/index.min.js",
           "@preact/signals-core": "https://cdn.jsdelivr.net/npm/@preact/signals-core@1.12.1/dist/signals-core.mjs",
           "yoga-layout/load": "https://cdn.jsdelivr.net/npm/yoga-layout@3.2.1/dist/src/load.js",
           "uiblocks": "../../build/addons/uiblocks/src/index.js",
@@ -249,7 +249,7 @@
       import * as THREE from 'three';
       import * as xb from 'xrblocks';
       import {
-        HeadLeashBehavior,
+        ManipulationBehavior,
         UICore,
         UIIcon,
         UIPanel,
@@ -2191,15 +2191,9 @@
           this.uiCore = new UICore(this);
           const card = this.uiCore.createCard({
             name: 'Objects3dControlCard',
+            position: new THREE.Vector3(0, 1.4, -1.0),
             sizeX: 0.62,
             sizeY: 0.42,
-            behaviors: [
-              new HeadLeashBehavior({
-                offset: new THREE.Vector3(0, -0.25, -0.9),
-                posLerp: 0.1,
-                rotLerp: 0.1,
-              }),
-            ],
           });
           const panel = new UIPanel({
             width: '100%',
@@ -2287,6 +2281,9 @@
           panel.add(buttonRow);
           panel.add(pickerRow);
           card.add(panel);
+          card.addBehavior(
+            new ManipulationBehavior({draggable: true, faceCamera: true})
+          );
         }
 
         // Detect / clear: icon + caption stacked so XR users get the same
@@ -2307,6 +2304,7 @@
             alignItems: 'center',
             justifyContent: 'center',
             gap: 8,
+            renderOrder: 10,
             onHoverEnter: () => btn.setFillColor(hover),
             onHoverExit: () => btn.setFillColor(idle),
             onClick: () => {
@@ -2316,13 +2314,20 @@
             },
           });
           btn.add(
-            new UIIcon(iconName, {color: 'white', width: 22, height: 22})
+            new UIIcon(iconName, {
+              color: 'white',
+              width: 22,
+              height: 22,
+              renderOrder: 12,
+            })
           );
           btn.add(
             new UIText(label, {
               fontSize: 14,
               color: '#ffffff',
               fontWeight: 'bold',
+              depthTest: false,
+              renderOrder: 100,
             })
           );
           return btn;
@@ -2373,6 +2378,7 @@
             alignItems: 'center',
             justifyContent: 'center',
             gap: 2,
+            renderOrder: 10,
             onHoverEnter: () => btn.setFillColor(hover),
             onHoverExit: () => btn.setFillColor(idle),
             onClick: () => {
@@ -2386,6 +2392,8 @@
               fontSize: 10,
               color: '#888888',
               textAlign: 'center',
+              depthTest: false,
+              renderOrder: 100,
             })
           );
           btn.add(
@@ -2394,6 +2402,8 @@
               color: '#ffffff',
               fontWeight: 'bold',
               textAlign: 'center',
+              depthTest: false,
+              renderOrder: 100,
             })
           );
           return btn;


### PR DESCRIPTION
the objects_3d control panel was head-leashed, so it followed your gaze around and you couldn't set it down anywhere. swapped HeadLeashBehavior for a draggable ManipulationBehavior so you can grab it and place it.

doing that surfaced two uiblocks rendering issues. the importmap was still pinned to `@pmndrs/uikit` 1.0.56 while the uiblocks addon is built against 1.0.64, so the button icons and labels didn't render at all. bumped the three `@pmndrs/*` pins to 1.0.64.

with that fixed the labels showed up but the deeply-nested button text was hidden behind its own backplate (the shared glyph mesh sits at the card plane while each button fill stacks a little forward, so the fill draws over the label), and the transparent fills sort by camera distance with depthWrite off so the button backgrounds blended inconsistently and flickered light/dark with the viewing angle. pinned the labels on top (depthTest off + higher renderOrder) and gave the button fills and icons a deterministic renderOrder, so it reads right from every angle now.

stacks on #363, rebase once that lands.
