### PR TITLE
fix face_mirror: camera-not-ready spam + stale depth-mesh cache

### DIFF
--- a/src/camera/CameraUtils.test.ts
+++ b/src/camera/CameraUtils.test.ts
@@ -1,0 +1,73 @@
+import * as THREE from 'three';
+import {describe, it, expect} from 'vitest';
+
+import {XRDeviceCamera} from './XRDeviceCamera';
+import {
+  getCameraParametersSnapshot,
+  isDeviceCameraPoseAvailable,
+} from './CameraUtils';
+
+function makeXrCameras(count: number): THREE.WebXRArrayCamera {
+  return {
+    cameras: new Array(count).fill({}),
+  } as unknown as THREE.WebXRArrayCamera;
+}
+
+function makeDeviceCamera(withSimulatorCamera: boolean): XRDeviceCamera {
+  return {
+    simulatorCamera: withSimulatorCamera
+      ? new THREE.PerspectiveCamera()
+      : undefined,
+  } as unknown as XRDeviceCamera;
+}
+
+describe('isDeviceCameraPoseAvailable', () => {
+  it('is false with no device camera and no XR cameras', () => {
+    expect(isDeviceCameraPoseAvailable(undefined, null)).toBe(false);
+  });
+
+  it('is false when the XR array camera has no cameras yet', () => {
+    expect(isDeviceCameraPoseAvailable(undefined, makeXrCameras(0))).toBe(
+      false
+    );
+  });
+
+  it('is true once the simulator camera is registered', () => {
+    expect(isDeviceCameraPoseAvailable(makeDeviceCamera(true), null)).toBe(
+      true
+    );
+  });
+
+  it('is true once the XR session exposes cameras', () => {
+    expect(isDeviceCameraPoseAvailable(undefined, makeXrCameras(2))).toBe(true);
+  });
+});
+
+describe('getCameraParametersSnapshot', () => {
+  const renderCamera = new THREE.PerspectiveCamera(75, 1.5, 0.1, 100);
+  renderCamera.updateMatrixWorld();
+
+  it('returns null while no camera pose is available', () => {
+    const snapshot = getCameraParametersSnapshot(
+      renderCamera,
+      null,
+      makeDeviceCamera(false),
+      'galaxyxr'
+    );
+    expect(snapshot).toBeNull();
+  });
+
+  it('returns a full snapshot once the simulator camera is available', () => {
+    const snapshot = getCameraParametersSnapshot(
+      renderCamera,
+      null,
+      makeDeviceCamera(true),
+      'galaxyxr'
+    );
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.clipFromView).toBeInstanceOf(THREE.Matrix4);
+    expect(snapshot!.viewFromClip).toBeInstanceOf(THREE.Matrix4);
+    expect(snapshot!.worldFromView).toBeInstanceOf(THREE.Matrix4);
+    expect(snapshot!.worldFromClip).toBeInstanceOf(THREE.Matrix4);
+  });
+});

--- a/src/camera/CameraUtils.ts
+++ b/src/camera/CameraUtils.ts
@@ -110,12 +110,69 @@ export type CameraParametersSnapshot = {
   worldFromClip: THREE.Matrix4;
 };
 
+// Milliseconds the device camera may remain unavailable during startup before
+// we surface a one-time warning. Ordinary warm-up (the simulator registering
+// its camera, or a WebXR session exposing its cameras) resolves well within
+// this window, so a warning indicates a real misconfiguration rather than
+// normal startup ordering.
+const DEVICE_CAMERA_READY_GRACE_MS = 5000;
+let deviceCameraUnavailableSinceMs: number | null = null;
+let warnedDeviceCameraUnavailable = false;
+
+/**
+ * Whether a device-camera pose can currently be resolved. This is false during
+ * the brief startup window before either the simulator camera is registered or
+ * the WebXR session exposes its cameras. While false, camera parameters are
+ * genuinely unavailable, and camera-dependent work should be skipped rather
+ * than run against a camera that does not exist yet.
+ *
+ * @param deviceCamera - The device camera, if configured.
+ * @param xrCameras - The WebXR array camera, or null outside an XR session.
+ * @returns True once a camera pose can be resolved.
+ */
+export function isDeviceCameraPoseAvailable(
+  deviceCamera: XRDeviceCamera | undefined,
+  xrCameras: THREE.WebXRArrayCamera | null
+): boolean {
+  return !!(
+    deviceCamera?.simulatorCamera ||
+    (xrCameras && xrCameras.cameras.length > 0)
+  );
+}
+
+/**
+ * Builds a snapshot of the device camera's view/projection matrices, or returns
+ * `null` while no camera pose is available yet (see
+ * {@link isDeviceCameraPoseAvailable}). Returning `null` lets per-frame callers
+ * skip cleanly during startup instead of throwing on every frame until a
+ * camera appears.
+ */
 export function getCameraParametersSnapshot(
   camera: THREE.PerspectiveCamera,
   xrCameras: THREE.WebXRArrayCamera | null,
   deviceCamera: XRDeviceCamera,
   targetDevice: string
-): CameraParametersSnapshot {
+): CameraParametersSnapshot | null {
+  if (!isDeviceCameraPoseAvailable(deviceCamera, xrCameras)) {
+    const now =
+      typeof performance !== 'undefined' ? performance.now() : Date.now();
+    if (deviceCameraUnavailableSinceMs === null) {
+      deviceCameraUnavailableSinceMs = now;
+    } else if (
+      !warnedDeviceCameraUnavailable &&
+      now - deviceCameraUnavailableSinceMs > DEVICE_CAMERA_READY_GRACE_MS
+    ) {
+      warnedDeviceCameraUnavailable = true;
+      console.warn(
+        '[xrblocks] Device camera is still unavailable after ' +
+          `${DEVICE_CAMERA_READY_GRACE_MS} ms; camera-dependent detection is ` +
+          'being skipped. Check that the camera is permitted and that a ' +
+          'session or simulator is running.'
+      );
+    }
+    return null;
+  }
+  deviceCameraUnavailableSinceMs = null;
   const clipFromView = getDeviceCameraClipFromView(
     camera,
     deviceCamera,

--- a/src/depth/DepthMesh.ts
+++ b/src/depth/DepthMesh.ts
@@ -156,6 +156,12 @@ export class DepthMesh extends MeshScript {
     }
     if (this.downsampledGeometry) {
       this.updateGeometry(depthData, this.downsampledGeometry, depthDataFormat);
+      // The downsampled geometry's positions just changed, so bump its
+      // version. Consumers that cache work keyed on the position attribute's
+      // version (e.g. FaceRecognizer's depth-mesh snapshot + BVH) rely on this
+      // to invalidate; without it they reuse a stale clone from the first
+      // detection and every raycast misses.
+      this.downsampledGeometry.attributes.position.needsUpdate = true;
     }
 
     this.minDepthPrev = this.minDepth;

--- a/src/world/faces/FaceRecognizer.ts
+++ b/src/world/faces/FaceRecognizer.ts
@@ -90,6 +90,10 @@ export class FaceRecognizer extends Script {
       this.deviceCamera,
       this.targetDevice
     );
+    if (!cameraParametersSnapshot) {
+      // Device camera not ready yet (warming up); skip until it is available.
+      return [];
+    }
 
     const context = this.getBackendContext();
     const activeBackend = this.options.faces.backendConfig.activeBackend;

--- a/src/world/humans/HumanRecognizer.ts
+++ b/src/world/humans/HumanRecognizer.ts
@@ -73,6 +73,10 @@ export class HumanRecognizer extends Script {
       this.deviceCamera,
       this.targetDevice
     );
+    if (!cameraParametersSnapshot) {
+      // Device camera not ready yet (warming up); skip until it is available.
+      return [];
+    }
 
     const context = this.getBackendContext();
     const activeBackend = this.options.humans.backendConfig.activeBackend;

--- a/src/world/objects/ObjectDetector.ts
+++ b/src/world/objects/ObjectDetector.ts
@@ -129,6 +129,10 @@ export class ObjectDetector extends Script {
       this.deviceCamera,
       this.targetDevice
     );
+    if (!cameraParametersSnapshot) {
+      // Device camera not ready yet (warming up); skip until it is available.
+      return [];
+    }
 
     const context = this.getDetectorContext();
     const activeBackend = this.options.objects.backendConfig.activeBackend;


### PR DESCRIPTION
two separate things were breaking face_mirror in the simulator, both predating #365 (matches the report that the demo was broken even before that refactor). split into two commits.

first, the camera detectors (faces / humans / objects) run detection from frame 1, but the device-camera pose isn't ready until the simulator registers its camera or a WebXR session exposes its cameras. `getCameraParametersSnapshot` threw `No XR cameras available` during that window, so the console filled with ~10 errors on every startup. it now returns null while no pose is available and the detectors skip the cycle, same as they already do when the depth mesh isn't ready. a one-time warning still fires if the camera never shows up past a grace period so a real misconfig isn't silently swallowed.

second, the face wireframe only rendered while you moved the camera. `DepthMesh.update` writes fresh positions into the downsampled geometry but only bumped `needsUpdate` on the full-res geometry, so the downsampled geometry's position version never changed. `FaceRecognizer` caches a cloned depth mesh + BVH keyed on that version (added in f468793), so the cache never invalidated: the clone built over the initial empty geometry got reused forever, every per-landmark raycast missed, and all 478 landmarks collapsed onto the camera origin (so the wireframe sat on the camera, invisible). moving recreated the geometry object and forced a one-off rebuild, which is why it only flickered in on motion. one line: bump the downsampled geometry's `needsUpdate` too so the cache invalidates.
