### PR TITLE
docs: add 3D Object Boxes sample page

### DIFF
--- a/docs/docs/samples/27-Objects-3D.mdx
+++ b/docs/docs/samples/27-Objects-3D.mdx
@@ -1,5 +1,5 @@
 ---
-title: 3D Object Boxes
+title: 3D Object Detection
 hide_title: true
 breadcrumbs: false
 pagination_next: null

--- a/docs/docs/samples/27-Objects-3D.mdx
+++ b/docs/docs/samples/27-Objects-3D.mdx
@@ -1,0 +1,15 @@
+---
+title: 3D Object Boxes
+hide_title: true
+breadcrumbs: false
+pagination_next: null
+pagination_prev: null
+---
+
+import {SamplesIFrame} from './SamplesIFrame';
+
+<SamplesIFrame
+  requiresApiKey={true}
+  demo="objects_3d"
+  link="https://github.com/google/xrblocks/tree/main/demos/objects_3d/"
+></SamplesIFrame>

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -79,6 +79,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'samples/XR-Poet',
         'samples/Gemini-XRObject',
+        'samples/Objects-3D',
         'samples/Language-Detector',
         'samples/Gemini-Icebreakers',
       ],


### PR DESCRIPTION
adds the objects_3d demo to the docs site so it shows up in the samples nav under AI + XR, next to the other gemini object samples. same SamplesIFrame page pattern as the rest, plus the sidebar entry. demo's already on main so the iframe loads once deployed.
