### PR TITLE
docs: add Face Mirror sample page

### DIFF
--- a/docs/docs/samples/28-Face-Mirror.mdx
+++ b/docs/docs/samples/28-Face-Mirror.mdx
@@ -1,0 +1,14 @@
+---
+title: Face Mirror
+hide_title: true
+breadcrumbs: false
+pagination_next: null
+pagination_prev: null
+---
+
+import {SamplesIFrame} from './SamplesIFrame';
+
+<SamplesIFrame
+  demo="face_mirror"
+  link="https://github.com/google/xrblocks/tree/main/demos/face_mirror/"
+></SamplesIFrame>

--- a/docs/docs/samples/28-Face-Mirror.mdx
+++ b/docs/docs/samples/28-Face-Mirror.mdx
@@ -1,5 +1,5 @@
 ---
-title: Face Mirror
+title: Face Landmarks
 hide_title: true
 breadcrumbs: false
 pagination_next: null

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -66,6 +66,7 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       items: [
         'samples/XR-Emoji',
+        'samples/Face-Mirror',
         'samples/Custom-Gestures',
         'samples/RockPaperScissors',
         'samples/Netblocks',


### PR DESCRIPTION
adds the face_mirror demo to the docs site under XR Interaction, next to XR Emoji. same SamplesIFrame page pattern + sidebar entry. no api key, runs MediaPipe on device. demo's already on main.
