### PR TITLE
Fix camera cycling when permission not yet granted

### DIFF
--- a/src/camera/XRDeviceCamera.test.ts
+++ b/src/camera/XRDeviceCamera.test.ts
@@ -3,6 +3,7 @@ import {describe, it, expect, vi, beforeEach} from 'vitest';
 
 import {StreamState} from '../video/VideoStream';
 
+import {SimulatorCamera} from '../simulator/SimulatorCamera';
 import {DeviceCameraOptions} from './CameraOptions';
 import {XRDeviceCamera} from './XRDeviceCamera';
 
@@ -280,5 +281,121 @@ describe('XRDeviceCamera', () => {
 
     warnSpy.mockRestore();
     vi.useRealTimers();
+  });
+
+  it('handles switching to a device with empty deviceId gracefully', async () => {
+    const mockEnumerateDevices = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          kind: 'videoinput',
+          deviceId: '',
+          label: '',
+          groupId: 'real-group',
+        },
+        {
+          kind: 'videoinput',
+          deviceId: 'sim-device',
+          label: 'Simulator Camera',
+          groupId: 'simulator',
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          kind: 'videoinput',
+          deviceId: 'real-device-resolved',
+          label: 'Real Camera',
+          groupId: 'real-group',
+        },
+        {
+          kind: 'videoinput',
+          deviceId: 'sim-device',
+          label: 'Simulator Camera',
+          groupId: 'simulator',
+        },
+      ]);
+
+    const mockGetUserMedia = vi.fn().mockResolvedValue({
+      getVideoTracks: () => [
+        {
+          kind: 'video',
+          getSettings: () => ({deviceId: 'real-device-resolved'}),
+          stop: vi.fn(),
+        },
+      ],
+      getTracks: () => [],
+    } as unknown as MediaStream);
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+      value: {
+        enumerateDevices: mockEnumerateDevices,
+        getUserMedia: mockGetUserMedia,
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const videoMock = document.createElement('video') as HTMLVideoElement & {
+      srcObject: MediaStream | null;
+      src: string;
+      play: () => Promise<void>;
+    };
+    Object.defineProperty(videoMock, 'srcObject', {
+      set(_: MediaStream | null) {},
+    });
+    Object.defineProperty(videoMock, 'src', {set(_: string) {}});
+    Object.defineProperty(videoMock, 'videoWidth', {value: 1280});
+    Object.defineProperty(videoMock, 'videoHeight', {value: 720});
+    videoMock.play = vi.fn().mockImplementation(() => {
+      queueMicrotask(() => {
+        videoMock.onloadedmetadata?.call(
+          videoMock,
+          new Event('loadedmetadata')
+        );
+      });
+      return Promise.resolve();
+    });
+    Object.defineProperty(camera, 'video_', {
+      value: videoMock,
+      writable: true,
+      configurable: true,
+    });
+
+    const mockSimulatorCamera: Partial<SimulatorCamera> = {
+      enumerateDevices: vi.fn().mockResolvedValue([
+        {
+          kind: 'videoinput',
+          deviceId: 'sim-device',
+          label: 'Simulator Camera',
+          groupId: 'simulator',
+        },
+      ]),
+      getMedia: vi.fn().mockReturnValue({
+        getVideoTracks: () => [
+          {
+            kind: 'video',
+            getSettings: () => ({deviceId: 'sim-device'}),
+            stop: vi.fn(),
+          },
+        ],
+        getTracks: () => [],
+      }),
+    };
+    camera.simulatorCamera = mockSimulatorCamera as SimulatorCamera;
+
+    await camera.init();
+    expect(camera.getCurrentDevice()?.deviceId).toBe('sim-device');
+
+    await camera.setDeviceId('');
+
+    expect(mockGetUserMedia).toHaveBeenCalledWith({
+      video: {},
+    });
+
+    expect(camera.getAvailableDevices()[0].deviceId).toBe(
+      'real-device-resolved'
+    );
+    expect(camera.getCurrentDeviceIndex()).toBe(0);
+    expect(camera.getCurrentDevice()?.deviceId).toBe('real-device-resolved');
   });
 });

--- a/src/camera/XRDeviceCamera.ts
+++ b/src/camera/XRDeviceCamera.ts
@@ -145,7 +145,7 @@ export class XRDeviceCamera extends VideoStream<XRDeviceCameraDetails> {
       let stream = null;
 
       const deviceIdConstraint = this.videoConstraints_.deviceId;
-      const targetDeviceId =
+      let targetDeviceId =
         typeof deviceIdConstraint === 'string'
           ? deviceIdConstraint
           : Array.isArray(deviceIdConstraint)
@@ -168,6 +168,7 @@ export class XRDeviceCamera extends VideoStream<XRDeviceCameraDetails> {
           deviceId: targetDeviceIdFromLabel,
           ...this.videoConstraints_,
         };
+        targetDeviceId = targetDeviceIdFromLabel;
       }
 
       if (useSimulatorCamera) {
@@ -176,9 +177,14 @@ export class XRDeviceCamera extends VideoStream<XRDeviceCameraDetails> {
           throw new Error('Simulator camera failed to provide a media stream.');
         }
       } else {
+        const constraints = {...this.videoConstraints_};
+        if (targetDeviceId === '') {
+          delete constraints.deviceId;
+        }
         stream = await navigator.mediaDevices.getUserMedia({
-          video: this.videoConstraints_,
+          video: constraints,
         });
+        this.availableDevices_ = await this.getAvailableVideoDevices();
       }
 
       const videoTracks = stream?.getVideoTracks() || [];
@@ -195,6 +201,11 @@ export class XRDeviceCamera extends VideoStream<XRDeviceCameraDetails> {
         this.currentDeviceIndex_ = this.availableDevices_.findIndex(
           (device) => device.deviceId === this.currentTrackSettings_!.deviceId
         );
+        if (targetDeviceId === '') {
+          this.videoConstraints_.deviceId = {
+            exact: this.currentTrackSettings_.deviceId,
+          };
+        }
       } else {
         console.warn('Stream started without deviceId as it was unavailable');
       }


### PR DESCRIPTION
EnumerateDevices returns empty deviceId strings for physical webcams when camera permission is not yet granted. This fix omits empty deviceId constraints from getUserMedia to trigger the permission prompt instead of failing with OverconstrainedError. Once permission is granted, devices are re-enumerated to update device details.

Fix tested through simulator and Galaxy XR.