### PR TITLE
JSDOM Headless Testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,16 +58,16 @@ XR Blocks is a **singleton engine driven by a script lifecycle**:
 
 ### Repository layout
 
-| Path          | Purpose                                                                                                             |
-| ------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `src/`        | SDK source — one folder per subsystem (overview: [`src/SKILL.md`](src/SKILL.md))                                    |
-| `src/addons/` | Opt-in modules built separately: `uiblocks`, `netblocks`, `glasses`, `simulator`, `volumes`, `virtualkeyboard`, ... |
-| `samples/`    | Focused feature examples (served by the docs site)                                                                  |
-| `demos/`      | Richer showcase apps (Ballpit, XR-Emoji, XR-Object, Gemini Icebreakers, ...)                                        |
-| `templates/`  | Minimal starting points (`0_basic`, `1_ui`, `2_hands`, `6_ai`, ...)                                                 |
-| `docs/`       | Docusaurus manual + samples/templates pages                                                                         |
-| `skills/`     | Agent skill registry (`xb-*`) — focused, task-oriented guides                                                       |
-| `build/`      | **Generated** bundle output — do not edit                                                                           |
+| Path          | Purpose                                                                                                                        |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `src/`        | SDK source — one folder per subsystem (overview: [`src/SKILL.md`](src/SKILL.md))                                               |
+| `src/addons/` | Opt-in modules built separately: `testing`, `uiblocks`, `netblocks`, `glasses`, `simulator`, `volumes`, `virtualkeyboard`, ... |
+| `samples/`    | Focused feature examples (served by the docs site)                                                                             |
+| `demos/`      | Richer showcase apps (Ballpit, XR-Emoji, XR-Object, Gemini Icebreakers, ...)                                                   |
+| `templates/`  | Minimal starting points (`0_basic`, `1_ui`, `2_hands`, `6_ai`, ...)                                                            |
+| `docs/`       | Docusaurus manual + samples/templates pages                                                                                    |
+| `skills/`     | Agent skill registry (`xb-*`) — focused, task-oriented guides                                                                  |
+| `build/`      | **Generated** bundle output — do not edit                                                                                      |
 
 ### `src/` subsystems
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -98,4 +98,4 @@ Open a sample/template/demo under that URL; add `?formFactor=desktop` to force t
 
 For "how do I do X", use the focused skills in [`skills/`](skills/): `xb-core`, `xb-ui`,
 `xb-uiblocks`, `xb-modelviewer`, `xb-hands`, `xb-gestures`, `xb-depth`, `xb-world`, `xb-ai`,
-`xb-physics`, `xb-simulator`, `xb-netblocks`, `xb-sound`.
+`xb-physics`, `xb-simulator`, `xb-netblocks`, `xb-sound`, `xb-testing`.

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -76,6 +76,7 @@ const externalPackages = [
   '@preact/signals-core',
   'rapier3d',
   'three-mesh-bvh',
+  'vitest',
 ];
 
 const xrblocksPackages = [

--- a/skills/README.md
+++ b/skills/README.md
@@ -33,6 +33,7 @@ The `xb-` prefix matches the `xb` import alias.
 | [`xb-netblocks`](xb-netblocks/SKILL.md)     | Add multiplayer presence, shared objects, voice                   |
 | [`xb-lipsync`](xb-lipsync/SKILL.md)         | Drive audio-driven avatar mouths from any `MediaStream`           |
 | [`xb-sound`](xb-sound/SKILL.md)             | Play spatial audio, record, recognize/synthesize speech           |
+| [`xb-testing`](xb-testing/SKILL.md)         | Write sequential functional, integration, or simulator tests      |
 
 Deep references some skills link to live next to the code:
 [`../src/SKILL.md`](../src/SKILL.md), [`../src/addons/uiblocks/SKILL.md`](../src/addons/uiblocks/SKILL.md),

--- a/skills/xb-testing/SKILL.md
+++ b/skills/xb-testing/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: xb-testing
+description: >-
+  Write sequential asynchronous functional, integration, or simulator tests for xrblocks apps using
+  the testing addon. Use this when you need to mock WebGL/WebAudio in headless environments (like JSDOM / Vitest),
+  simulate user locomotion, trigger controller pointing, raycasts, and select/squeeze hand inputs.
+  Covers `TestRunner` and `TestRunnerConfig`.
+---
+
+# xb-testing: functional & simulator testing
+
+The testing addon (`import { TestRunner } from 'xrblocks/addons/testing'`) provides a headless functional test framework designed to test scripts, locomotion, interaction, and engine lifecycle sequentially under environments like Vitest/JSDOM.
+
+## Bootstrapping a test
+
+Use `TestRunner.create` to spin up a core instance with a spied canvas/WebGL context:
+
+```ts
+import {describe, it, expect} from 'vitest';
+import {TestRunner} from 'xrblocks/addons/testing';
+import {MyScript} from './MyScript';
+
+describe('My Functional Test', () => {
+  it('verifies script interaction', async () => {
+    const script = new MyScript();
+
+    // Create the runner and load scripts
+    const runner = await TestRunner.create({
+      scripts: [script],
+    });
+
+    // Step the frame loop forward (in milliseconds)
+    await runner.step(100);
+
+    // Check script states
+    expect(script.someValue).toBe(true);
+
+    // Always clean up to prevent memory/state leaks
+    await runner.destroy();
+  });
+});
+```
+
+## Locomotion (movement)
+
+Simulate user camera translation (in strafe, rise, forward offsets relative to camera orientation):
+
+```ts
+// Move user forward by 1 meter
+await runner.move([0, 0, -1], {durationMs: 200});
+
+// Verify camera position changed
+expect(runner.camera.position.z).toBeLessThan(0);
+```
+
+## Pointer & click interactions
+
+Simulate hands or controllers pointing at objects and performing selections (pinches/clicks):
+
+```ts
+// Point right hand (index 1) directly at the target object
+await runner.pointTo(1, targetMesh);
+
+// Perform a pinch/click with the right hand
+await runner.click(1);
+
+// Step time to allow the select start and select end callbacks to fire
+await runner.step(250);
+
+expect(targetMesh.clicked).toBe(true);
+```
+
+## Error handling
+
+Any error or exception thrown during script lifecycle (`init`, `update`, `onSelectEnd`, etc.) is caught by the test runner. Call `step()` or check for errors explicitly:
+
+```ts
+// Script crash verification
+const crasher = new CrashingScript();
+const runner = await TestRunner.create({scripts: [crasher]});
+
+// Advancing the frame loop throws the exception caught in the script
+await expect(runner.step(16.67)).rejects.toThrow(
+  'Script crash inside update loop'
+);
+```
+
+## Notes
+
+- **Auto-mocking:** `TestRunner` automatically stubs `AudioContext`, `AudioListener` parameter curves, and `WebGLRenderer` capabilities transparently.
+- **Teardown:** Always call `await runner.destroy()` in your tests to reset the core singleton, otherwise subsequent tests will share state and leak listeners.

--- a/skills/xb-testing/SKILL.md
+++ b/skills/xb-testing/SKILL.md
@@ -64,7 +64,7 @@ await runner.pointTo(1, targetMesh);
 // Perform a pinch/click with the right hand
 await runner.click(1);
 
-// Step time to allow the select start and select end callbacks to fire
+// Step time in ms to allow the select start and select end callbacks to fire
 await runner.step(250);
 
 expect(targetMesh.clicked).toBe(true);

--- a/src/SKILL.md
+++ b/src/SKILL.md
@@ -191,22 +191,22 @@ gradients, and shadows, use the **uiblocks addon** instead — see
 
 ## Directory map (read deeper on demand)
 
-| Path                                                                                 | What lives there                                                                                                                           |
-| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| [`core/`](core)                                                                      | `Core` singleton, `Script`, `Options`, `User`, DI `Registry`, `XRButton`, WebXR session mgmt                                               |
-| [`input/`](input)                                                                    | controllers, hands, gaze, mouse, gamepad; `gestures/`; `strokes/`                                                                          |
-| [`world/`](world)                                                                    | `World` + `planes/`, `mesh/`, `objects/` (Gemini & MediaPipe backends), `sounds/`                                                          |
-| [`depth/`](depth)                                                                    | depth sensing, depth mesh, `occlusion/` shaders & passes                                                                                   |
-| [`ai/`](ai)                                                                          | `AI` facade over `Gemini` + `OpenAI` (query / live / image gen)                                                                            |
-| [`agent/`](agent)                                                                    | agent framework: tools, memory, context (WIP — see `agent/README.md`)                                                                      |
-| [`ui/`](ui)                                                                          | core spatial UI: `SpatialPanel`, `Grid`/`Row`/`Col`, views, `ModelViewer`, `Reticle`                                                       |
-| [`ux/`](ux)                                                                          | `DragManager`, reusable interaction behaviors                                                                                              |
-| [`simulator/`](simulator)                                                            | desktop XR simulator (virtual user/hands/depth/planes, control modes)                                                                      |
-| [`sound/`](sound)                                                                    | spatial audio, speech recognizer/synthesizer (see `sound/README.md`)                                                                       |
-| [`physics/`](physics)                                                                | Rapier3D integration                                                                                                                       |
-| [`lighting/`](lighting), [`camera/`](camera), [`video/`](video), [`stereo/`](stereo) | light estimation, device camera, video streams, stereo utils                                                                               |
-| [`utils/`](utils)                                                                    | `ModelLoader`, dependency injection, helpers                                                                                               |
-| [`addons/`](addons)                                                                  | opt-in modules, each often with its own README/skills: `uiblocks`, `netblocks`, `glasses`, `volumes`, `virtualkeyboard`, simulator UI, ... |
+| Path                                                                                 | What lives there                                                                                                                                      |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`core/`](core)                                                                      | `Core` singleton, `Script`, `Options`, `User`, DI `Registry`, `XRButton`, WebXR session mgmt                                                          |
+| [`input/`](input)                                                                    | controllers, hands, gaze, mouse, gamepad; `gestures/`; `strokes/`                                                                                     |
+| [`world/`](world)                                                                    | `World` + `planes/`, `mesh/`, `objects/` (Gemini & MediaPipe backends), `sounds/`                                                                     |
+| [`depth/`](depth)                                                                    | depth sensing, depth mesh, `occlusion/` shaders & passes                                                                                              |
+| [`ai/`](ai)                                                                          | `AI` facade over `Gemini` + `OpenAI` (query / live / image gen)                                                                                       |
+| [`agent/`](agent)                                                                    | agent framework: tools, memory, context (WIP — see `agent/README.md`)                                                                                 |
+| [`ui/`](ui)                                                                          | core spatial UI: `SpatialPanel`, `Grid`/`Row`/`Col`, views, `ModelViewer`, `Reticle`                                                                  |
+| [`ux/`](ux)                                                                          | `DragManager`, reusable interaction behaviors                                                                                                         |
+| [`simulator/`](simulator)                                                            | desktop XR simulator (virtual user/hands/depth/planes, control modes)                                                                                 |
+| [`sound/`](sound)                                                                    | spatial audio, speech recognizer/synthesizer (see `sound/README.md`)                                                                                  |
+| [`physics/`](physics)                                                                | Rapier3D integration                                                                                                                                  |
+| [`lighting/`](lighting), [`camera/`](camera), [`video/`](video), [`stereo/`](stereo) | light estimation, device camera, video streams, stereo utils                                                                                          |
+| [`utils/`](utils)                                                                    | `ModelLoader`, dependency injection, helpers                                                                                                          |
+| [`addons/`](addons)                                                                  | opt-in modules, each often with its own README/skills: `uiblocks`, `netblocks`, `testing`, `glasses`, `volumes`, `virtualkeyboard`, simulator UI, ... |
 
 ## Two UI systems — pick deliberately
 

--- a/src/addons/embodied-control/EmbodiedControl.ts
+++ b/src/addons/embodied-control/EmbodiedControl.ts
@@ -52,7 +52,10 @@ export class EmbodiedControl extends Script {
     if (!this.executor) {
       throw new Error('EmbodiedControl is not initialized.');
     }
-    return this.executor.step(step);
+    return this.executor.step({
+      ...step,
+      control: step.control || {},
+    });
   }
 
   applyControl(control: XRCompoundControl) {

--- a/src/addons/embodied-control/EmbodiedControlExecutor.ts
+++ b/src/addons/embodied-control/EmbodiedControlExecutor.ts
@@ -39,9 +39,6 @@ function mergeOptions(
 ): EmbodiedControlExecutorOptions {
   return {
     tickMs: options.tickMs ?? DEFAULT_EMBODIED_CONTROL_OPTIONS.tickMs,
-    defaultDurationMs:
-      options.defaultDurationMs ??
-      DEFAULT_EMBODIED_CONTROL_OPTIONS.defaultDurationMs,
     includeScreenshot:
       options.includeScreenshot ??
       DEFAULT_EMBODIED_CONTROL_OPTIONS.includeScreenshot,
@@ -109,8 +106,8 @@ export class EmbodiedControlExecutor {
     this.activeStep = true;
 
     try {
-      const durationMs = step.durationMs ?? this.options.defaultDurationMs;
       const tickMs = this.options.tickMs;
+      const durationMs = step.durationMs ?? tickMs;
       const stepCount = Math.max(1, Math.ceil(durationMs / tickMs));
       let elapsedMs = 0;
       const initialCameraQuaternion =
@@ -126,7 +123,7 @@ export class EmbodiedControlExecutor {
         const fraction = durationMs > 0 ? currentTickMs / durationMs : 1;
 
         this.applyControlFraction(
-          step.control,
+          step.control || {},
           fraction,
           initialCameraQuaternion
         );

--- a/src/addons/embodied-control/EmbodiedControlTypes.ts
+++ b/src/addons/embodied-control/EmbodiedControlTypes.ts
@@ -33,7 +33,7 @@ export type XRCompoundControl = {
 export type EmbodiedControlStep = {
   id?: string;
   durationMs?: number;
-  control: XRCompoundControl;
+  control?: XRCompoundControl;
 };
 
 export type HandObservation = {
@@ -70,8 +70,6 @@ export type EmbodiedControlOptions = {
   realTime?: boolean;
   /** Simulated frame length used while executing a step. */
   tickMs?: number;
-  /** Step duration used when a step omits durationMs. */
-  defaultDurationMs?: number;
   /** Capture a screenshot in each completed observation. */
   includeScreenshot?: boolean;
   /** Clamp hand joint rotations through simulator biomechanical constraints. */
@@ -82,7 +80,6 @@ export type EmbodiedControlExecutorOptions = Required<
   Pick<
     EmbodiedControlOptions,
     | 'tickMs'
-    | 'defaultDurationMs'
     | 'includeScreenshot'
     | 'applyHandRotationConstraints'
     | 'realTime'
@@ -94,7 +91,6 @@ export const DEFAULT_EMBODIED_CONTROL_OPTIONS: Required<EmbodiedControlOptions> 
     autoPause: true,
     realTime: false,
     tickMs: 16.67,
-    defaultDurationMs: 250,
     includeScreenshot: true,
     applyHandRotationConstraints: true,
   };

--- a/src/addons/embodied-control/EmbodiedControlTypes.ts
+++ b/src/addons/embodied-control/EmbodiedControlTypes.ts
@@ -79,10 +79,7 @@ export type EmbodiedControlOptions = {
 export type EmbodiedControlExecutorOptions = Required<
   Pick<
     EmbodiedControlOptions,
-    | 'tickMs'
-    | 'includeScreenshot'
-    | 'applyHandRotationConstraints'
-    | 'realTime'
+    'tickMs' | 'includeScreenshot' | 'applyHandRotationConstraints' | 'realTime'
   >
 >;
 

--- a/src/addons/testing/TestRunner.ts
+++ b/src/addons/testing/TestRunner.ts
@@ -86,6 +86,7 @@ export class TestRunner {
 
     options.enableSimulator = true;
     options.xrButton.alwaysAutostartSimulator = true;
+    options.gestures.updateIntervalMs = 0; // Disable real-time throttle for headless tests.
 
     options.simulator.environments = [
       {

--- a/src/addons/testing/TestRunner.ts
+++ b/src/addons/testing/TestRunner.ts
@@ -10,7 +10,6 @@ import {
 import {
   EmbodiedControl,
   type EmbodiedControlOptions,
-  DEFAULT_EMBODIED_CONTROL_OPTIONS,
 } from '../embodied-control';
 export interface TestRunnerConfig {
   /** Scripts to load into the test scene. */
@@ -26,6 +25,7 @@ export class TestRunner {
   readonly embodiedControl: EmbodiedControl;
   readonly scene: THREE.Scene;
   readonly camera: THREE.Camera;
+  readonly actions: EmbodiedControl;
 
   private caughtErrors: Error[] = [];
   private boundExceptionListener: (event: {
@@ -58,6 +58,26 @@ export class TestRunner {
       ScriptsManagerEventType.EXCEPTION,
       this.boundExceptionListener
     );
+
+    // Set up the dynamic actions proxy.
+    this.actions = new Proxy(this.embodiedControl, {
+      get: (target, prop) => {
+        const val = (target as unknown as Record<string | symbol, unknown>)[
+          prop
+        ];
+        if (typeof val === 'function') {
+          const fn = val as (...args: unknown[]) => unknown;
+          return async (...args: unknown[]) => {
+            const result = fn.apply(target, args);
+            if (result instanceof Promise) {
+              await result;
+            }
+            this.checkErrors();
+          };
+        }
+        return val;
+      },
+    }) as unknown as EmbodiedControl;
   }
 
   static async create(config: TestRunnerConfig = {}): Promise<TestRunner> {
@@ -122,131 +142,6 @@ export class TestRunner {
     const runner = new TestRunner(core, embodiedControl);
     runner.checkErrors();
     return runner;
-  }
-
-  /**
-   * Steps the frame loop forward by the specified duration.
-   */
-  async step(
-    durationMs = DEFAULT_EMBODIED_CONTROL_OPTIONS.tickMs
-  ): Promise<void> {
-    return this.runAction(
-      this.embodiedControl.step({
-        control: {},
-        durationMs,
-      })
-    );
-  }
-
-  /**
-   * Simulates camera movement.
-   * @param direction - [strafe, rise, forward] relative to camera orientation.
-   */
-  async move(
-    direction: [number, number, number],
-    options?: {durationMs?: number}
-  ): Promise<void> {
-    return this.runAction(
-      this.embodiedControl.step({
-        control: {locomotion: {move: direction}},
-        durationMs: options?.durationMs,
-      })
-    );
-  }
-
-  /**
-   * Simulates camera rotation in degrees [pitch, yaw, roll].
-   */
-  async rotate(
-    degrees: [number, number, number],
-    options?: {durationMs?: number}
-  ): Promise<void> {
-    return this.runAction(
-      this.embodiedControl.step({
-        control: {locomotion: {rotate: degrees}},
-        durationMs: options?.durationMs,
-      })
-    );
-  }
-
-  /**
-   * Snaps or rotates the camera to look at the target.
-   */
-  async lookAt(
-    target: THREE.Object3D | THREE.Vector3 | [number, number, number],
-    options?: {velocity?: number}
-  ): Promise<void> {
-    return this.runAction(this.embodiedControl.lookAtTarget(target, options));
-  }
-
-  /**
-   * Teleports the camera to the target position.
-   */
-  async teleportTo(
-    target: THREE.Object3D | THREE.Vector3 | [number, number, number],
-    options?: {
-      distance?: number;
-      faceTarget?: boolean;
-      snapToGround?: boolean;
-    }
-  ): Promise<void> {
-    return this.runAction(this.embodiedControl.teleportTo(target, options));
-  }
-
-  /**
-   * Programmatically clicks/pinches with a specific hand.
-   */
-  async click(handIndex = 1, options?: {durationMs?: number}): Promise<void> {
-    return this.runAction(this.embodiedControl.click(handIndex, options));
-  }
-
-  /**
-   * Initiates/continues a pinch on the specified hand.
-   */
-  async pinch(
-    handIndex: 0 | 1,
-    active: boolean,
-    options?: {durationMs?: number}
-  ): Promise<void> {
-    const handControl = active ? {selectStart: true} : {selectEnd: true};
-    return this.runAction(
-      this.embodiedControl.step({
-        control:
-          handIndex === 0 ? {leftHand: handControl} : {rightHand: handControl},
-        durationMs: options?.durationMs,
-      })
-    );
-  }
-
-  /**
-   * Moves a hand to reach a target.
-   */
-  async reachTo(
-    handIndex: 0 | 1,
-    target: THREE.Vector3 | [number, number, number] | THREE.Object3D,
-    options?: {velocity?: number}
-  ): Promise<void> {
-    return this.runAction(
-      this.embodiedControl.reachTo(handIndex, target, options)
-    );
-  }
-
-  /**
-   * Points a hand at a target.
-   */
-  async pointTo(
-    handIndex: 0 | 1,
-    target: THREE.Object3D | THREE.Vector3 | [number, number, number],
-    options?: {velocity?: number}
-  ): Promise<void> {
-    return this.runAction(
-      this.embodiedControl.pointTo(handIndex, target, options)
-    );
-  }
-
-  private async runAction(action: Promise<unknown>): Promise<void> {
-    await action;
-    this.checkErrors();
   }
 
   /**

--- a/src/addons/testing/TestRunner.ts
+++ b/src/addons/testing/TestRunner.ts
@@ -1,0 +1,347 @@
+import './setup';
+import * as THREE from 'three';
+import {
+  Core,
+  Options,
+  Script,
+  ScriptsManagerEventType,
+  type Constructor,
+} from 'xrblocks';
+import {
+  EmbodiedControl,
+  type EmbodiedControlOptions,
+  DEFAULT_EMBODIED_CONTROL_OPTIONS,
+} from '../embodied-control';
+export interface TestRunnerConfig {
+  /** Scripts to load into the test scene. */
+  scripts?: Script[];
+  /** Core configuration option overrides. */
+  options?: Options;
+  /** Options passed to the underlying EmbodiedControl addon. */
+  embodiedOptions?: EmbodiedControlOptions;
+}
+
+export class TestRunner {
+  readonly core: Core;
+  readonly embodiedControl: EmbodiedControl;
+  readonly scene: THREE.Scene;
+  readonly camera: THREE.Camera;
+
+  private caughtErrors: Error[] = [];
+  private boundExceptionListener: (event: {
+    error: Error;
+    scriptName: string;
+    context: string;
+  }) => void;
+
+  private constructor(core: Core, embodiedControl: EmbodiedControl) {
+    this.core = core;
+    this.embodiedControl = embodiedControl;
+    this.scene = core.scene;
+    this.camera = core.camera;
+
+    this.boundExceptionListener = (event: {
+      error: Error;
+      scriptName: string;
+      context: string;
+    }) => {
+      const error =
+        event.error ||
+        new Error(
+          `Exception in script: ${event.scriptName} (${event.context})`
+        );
+      this.caughtErrors.push(error);
+    };
+
+    // Hook error handling
+    core.scriptsManager.addEventListener(
+      ScriptsManagerEventType.EXCEPTION,
+      this.boundExceptionListener
+    );
+  }
+
+  static async create(config: TestRunnerConfig = {}): Promise<TestRunner> {
+    const core = Core.instance || new Core();
+    const options = config.options || new Options();
+
+    options.enableSimulator = true;
+    options.xrButton.alwaysAutostartSimulator = true;
+
+    options.simulator.environments = [
+      {
+        name: 'Empty Test Environment',
+        scenePath: null,
+        scenePlanesPath: null,
+      },
+    ];
+    options.simulator.activeEnvironmentIndex = 0;
+
+    core.options = options;
+
+    if (config.scripts) {
+      for (const script of config.scripts) {
+        core.scene.add(script);
+      }
+    }
+
+    const embodiedOptions: EmbodiedControlOptions = {
+      autoPause: true,
+      realTime: false,
+      includeScreenshot: false, // No screenshot rendering in headless
+      ...config.embodiedOptions,
+    };
+    const embodiedControl = new EmbodiedControl(embodiedOptions);
+    core.scene.add(embodiedControl);
+
+    await core.init(options);
+
+    while (!core.simulatorRunning) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    // Automatically re-trigger hand bone loading under JSDOM to populate virtual hand skeletons.
+    if (core.simulator?.hands) {
+      core.simulator.hands.leftHandBones = [];
+      core.simulator.hands.rightHandBones = [];
+      core.simulator.hands.loadMeshes();
+    }
+
+    for (let i = 0; i < Math.min(2, core.input.controllers.length); i++) {
+      const controller = core.input.controllers[i];
+      controller.userData.connected = true;
+      if (i === 0) {
+        core.input.leftController = controller;
+      } else if (i === 1) {
+        core.input.rightController = controller;
+      }
+    }
+
+    core.camera.updateMatrixWorld(true);
+    core.camera.matrixWorldInverse.copy(core.camera.matrixWorld).invert();
+
+    const runner = new TestRunner(core, embodiedControl);
+    runner.checkErrors();
+    return runner;
+  }
+
+  /**
+   * Steps the frame loop forward by the specified duration.
+   */
+  async step(
+    durationMs = DEFAULT_EMBODIED_CONTROL_OPTIONS.tickMs
+  ): Promise<void> {
+    return this.runAction(
+      this.embodiedControl.step({
+        control: {},
+        durationMs,
+      })
+    );
+  }
+
+  /**
+   * Simulates camera movement.
+   * @param direction - [strafe, rise, forward] relative to camera orientation.
+   */
+  async move(
+    direction: [number, number, number],
+    options?: {durationMs?: number}
+  ): Promise<void> {
+    return this.runAction(
+      this.embodiedControl.step({
+        control: {locomotion: {move: direction}},
+        durationMs: options?.durationMs,
+      })
+    );
+  }
+
+  /**
+   * Simulates camera rotation in degrees [pitch, yaw, roll].
+   */
+  async rotate(
+    degrees: [number, number, number],
+    options?: {durationMs?: number}
+  ): Promise<void> {
+    return this.runAction(
+      this.embodiedControl.step({
+        control: {locomotion: {rotate: degrees}},
+        durationMs: options?.durationMs,
+      })
+    );
+  }
+
+  /**
+   * Snaps or rotates the camera to look at the target.
+   */
+  async lookAt(
+    target: THREE.Object3D | THREE.Vector3 | [number, number, number],
+    options?: {velocity?: number}
+  ): Promise<void> {
+    return this.runAction(this.embodiedControl.lookAtTarget(target, options));
+  }
+
+  /**
+   * Teleports the camera to the target position.
+   */
+  async teleportTo(
+    target: THREE.Object3D | THREE.Vector3 | [number, number, number],
+    options?: {
+      distance?: number;
+      faceTarget?: boolean;
+      snapToGround?: boolean;
+    }
+  ): Promise<void> {
+    return this.runAction(this.embodiedControl.teleportTo(target, options));
+  }
+
+  /**
+   * Programmatically clicks/pinches with a specific hand.
+   */
+  async click(handIndex = 1, options?: {durationMs?: number}): Promise<void> {
+    return this.runAction(this.embodiedControl.click(handIndex, options));
+  }
+
+  /**
+   * Initiates/continues a pinch on the specified hand.
+   */
+  async pinch(
+    handIndex: 0 | 1,
+    active: boolean,
+    options?: {durationMs?: number}
+  ): Promise<void> {
+    const handControl = active ? {selectStart: true} : {selectEnd: true};
+    return this.runAction(
+      this.embodiedControl.step({
+        control:
+          handIndex === 0 ? {leftHand: handControl} : {rightHand: handControl},
+        durationMs: options?.durationMs,
+      })
+    );
+  }
+
+  /**
+   * Moves a hand to reach a target.
+   */
+  async reachTo(
+    handIndex: 0 | 1,
+    target: THREE.Vector3 | [number, number, number] | THREE.Object3D,
+    options?: {velocity?: number}
+  ): Promise<void> {
+    return this.runAction(
+      this.embodiedControl.reachTo(handIndex, target, options)
+    );
+  }
+
+  /**
+   * Points a hand at a target.
+   */
+  async pointTo(
+    handIndex: 0 | 1,
+    target: THREE.Object3D | THREE.Vector3 | [number, number, number],
+    options?: {velocity?: number}
+  ): Promise<void> {
+    return this.runAction(
+      this.embodiedControl.pointTo(handIndex, target, options)
+    );
+  }
+
+  private async runAction(action: Promise<unknown>): Promise<void> {
+    await action;
+    this.checkErrors();
+  }
+
+  /**
+   * Retrieves a loaded script instance from the dependency injection registry.
+   */
+  getScript<T extends Script>(klass: Constructor<T>): T {
+    const script = this.core.registry.get(klass);
+    if (!script) {
+      throw new Error(
+        `Script or subsystem for ${klass.name} not found in Core registry.`
+      );
+    }
+    return script;
+  }
+
+  /**
+   * Destroys the test runner, cleans up the scene, window events, and resets mocks.
+   */
+  async destroy(): Promise<void> {
+    this.checkErrors();
+
+    // Remove exception listener
+    this.core.scriptsManager.removeEventListener(
+      ScriptsManagerEventType.EXCEPTION,
+      this.boundExceptionListener
+    );
+
+    const coreInternal = this.core as unknown as {
+      onWindowResize?: EventListenerOrEventListenerObject;
+    };
+    if (coreInternal.onWindowResize) {
+      window.removeEventListener('resize', coreInternal.onWindowResize);
+    }
+
+    this.core.scene.clear();
+    await this.core.scriptsManager.syncScriptsWithScene(this.core.scene);
+    this.core.scene.add(this.core.xrSystemsGroup);
+
+    // Clear Input lists and maps to prevent duplicate controller registration across tests.
+    const input = this.core.input;
+    input.controllers.length = 0;
+    input.controllerGrips.length = 0;
+    input.hands.length = 0;
+    input.leftController = undefined;
+    input.rightController = undefined;
+    input.intersectionsForController.clear();
+    input.activeControllers.clear();
+    input.listeners.clear();
+
+    const depth = this.core.depth;
+    depth.view.length = 0;
+    depth.cpuDepthData.length = 0;
+    depth.gpuDepthData.length = 0;
+    depth.depthArray.length = 0;
+
+    const coreWritable = this.core as unknown as {
+      effects?: unknown;
+      renderer?: unknown;
+    };
+    coreWritable.effects = undefined;
+
+    const registryInternal = this.core.registry as unknown as {
+      instances: Map<unknown, unknown>;
+    };
+    registryInternal.instances.clear();
+    this.core.registry.register(this.core.registry);
+    this.core.registry.register(this.core, Core);
+    this.core.registry.register(this.core.scene, THREE.Scene);
+    this.core.registry.register(this.core.camera, THREE.Camera);
+    this.core.registry.register(this.core.timer, THREE.Timer);
+    this.core.registry.register(this.core.input);
+    this.core.registry.register(this.core.user);
+    this.core.registry.register(this.core.ui);
+    this.core.registry.register(this.core.sound);
+    this.core.registry.register(this.core.dragManager);
+    this.core.registry.register(this.core.simulator);
+    this.core.registry.register(this.core.scriptsManager);
+    this.core.registry.register(this.core.depth);
+    this.core.registry.register(this.core.world);
+    this.core.registry.register(this.core.xrSystemsGroup);
+
+    if (this.core.renderer) {
+      this.core.renderer.dispose();
+      this.core.renderer.domElement.remove();
+      coreWritable.renderer = undefined;
+    }
+  }
+
+  private checkErrors() {
+    if (this.caughtErrors.length > 0) {
+      const combined = this.caughtErrors
+        .map((e) => e.stack || e.message)
+        .join('\n\n');
+      this.caughtErrors = [];
+      throw new Error(`Test failed due to script exceptions:\n${combined}`);
+    }
+  }
+}

--- a/src/addons/testing/example.test.ts
+++ b/src/addons/testing/example.test.ts
@@ -1,15 +1,7 @@
 import {describe, it, expect} from 'vitest';
 import {TestRunner} from './TestRunner';
 import * as THREE from 'three';
-import {
-  Script,
-  type SelectEvent,
-  TextButton,
-  Options,
-  core,
-  HeuristicGestureRecognizer,
-  WebXRHandPoseEstimator,
-} from 'xrblocks';
+import {Script, type SelectEvent, TextButton, Options, core} from 'xrblocks';
 
 class SimpleRotationScript extends Script {
   speed = 1.0;
@@ -133,7 +125,7 @@ describe('TestRunner functional examples', () => {
     button.onTriggered = () => {
       game.spawnItem();
     };
-    button.position.set(0, 1.2, -1.2); // Positioned in front of camera
+    button.position.set(0, core.user.height, -core.user.height);
 
     const runner = await TestRunner.create({
       scripts: [game, button],
@@ -156,23 +148,39 @@ describe('TestRunner functional examples', () => {
   it('should run Example 5: End-to-End Heuristic Gesture Recognition', async () => {
     class TestGestureScript extends Script {
       pinchDetected = false;
-      confidence = 0;
+      private _onGestureStart?: (event: Event) => void;
+      private _onGestureEnd?: (event: Event) => void;
 
-      private recognizer = new HeuristicGestureRecognizer();
-      private estimator = new WebXRHandPoseEstimator(core.user);
+      override init() {
+        const gestures = core.gestureRecognition;
+        if (!gestures) return;
 
-      override update() {
-        const context = this.estimator.getHandContext(1);
-        if (!context) return;
+        this._onGestureStart = (event: Event) => {
+          const detail = (event as CustomEvent).detail;
+          if (detail && detail.name === 'pinch') {
+            this.pinchDetected = true;
+          }
+        };
+        this._onGestureEnd = (event: Event) => {
+          const detail = (event as CustomEvent).detail;
+          if (detail && detail.name === 'pinch') {
+            this.pinchDetected = false;
+          }
+        };
 
-        const scores = this.recognizer.recognize(context);
-        const pinch = scores['pinch'];
-        if (pinch) {
-          this.pinchDetected = pinch.confidence > 0.6;
-          this.confidence = pinch.confidence;
-        } else {
-          this.pinchDetected = false;
-          this.confidence = 0;
+        gestures.addEventListener('gesturestart', this._onGestureStart);
+        gestures.addEventListener('gestureend', this._onGestureEnd);
+      }
+
+      override dispose() {
+        const gestures = core.gestureRecognition;
+        if (gestures) {
+          if (this._onGestureStart) {
+            gestures.removeEventListener('gesturestart', this._onGestureStart);
+          }
+          if (this._onGestureEnd) {
+            gestures.removeEventListener('gestureend', this._onGestureEnd);
+          }
         }
       }
     }
@@ -180,6 +188,7 @@ describe('TestRunner functional examples', () => {
     const script = new TestGestureScript();
     const options = new Options();
     options.hands.enabled = true;
+    options.enableGestures(); // Boot the gesture recognition subsystem!
 
     const runner = await TestRunner.create({
       scripts: [script],
@@ -193,7 +202,6 @@ describe('TestRunner functional examples', () => {
       durationMs: 400,
     });
     expect(script.pinchDetected).toBe(true);
-    expect(script.confidence).toBeGreaterThan(0.6);
 
     await runner.actions.step({
       control: {rightHand: {selectEnd: true}},

--- a/src/addons/testing/example.test.ts
+++ b/src/addons/testing/example.test.ts
@@ -34,11 +34,11 @@ class GrabbableScript extends Script {
   grabbedByHand: number | null = null;
 
   override onObjectSelectStart(event: SelectEvent) {
-    // Determine which controller triggered the selection
+    // Determine which controller triggered the selection.
     const controller = event.target as unknown as {userData: {id: number}};
     const index = controller.userData.id;
     this.grabbedByHand = index;
-    return true; // Mark as handled
+    return true;
   }
 
   override onObjectSelectEnd(_event: SelectEvent) {
@@ -68,8 +68,7 @@ describe('TestRunner functional examples', () => {
 
     expect(script.rotation.y).toBe(0);
 
-    // Step 1 frame (~16ms)
-    await runner.step(16.67);
+    await runner.actions.step({durationMs: 16.67});
     expect(script.rotation.y).toBeGreaterThan(0);
 
     await runner.destroy();
@@ -84,13 +83,12 @@ describe('TestRunner functional examples', () => {
       scripts: [hoverScript],
     });
 
-    // Initially pointing down/away, not hovered
-    await runner.step(100);
+    // Initially pointing down/away, not hovered.
+    await runner.actions.step({durationMs: 100});
     expect(hoverScript.isHovered).toBe(false);
 
-    // Point right hand (index 1) directly at the target object
-    await runner.pointTo(1, hoverScript);
-    await runner.step(100);
+    await runner.actions.pointTo(1, hoverScript);
+    await runner.actions.step({durationMs: 100});
 
     expect(hoverScript.isHovered).toBe(true);
 
@@ -106,16 +104,19 @@ describe('TestRunner functional examples', () => {
       scripts: [grabbable],
     });
 
-    // Point and pinch (grab) with the right hand (index 1)
-    await runner.pointTo(1, grabbable);
-    await runner.pinch(1, true);
-    await runner.step(100);
+    await runner.actions.pointTo(1, grabbable);
+    await runner.actions.step({
+      control: {rightHand: {selectStart: true}},
+      durationMs: 100,
+    });
 
     expect(grabbable.grabbedByHand).toBe(1);
 
     // Release pinch
-    await runner.pinch(1, false);
-    await runner.step(100);
+    await runner.actions.step({
+      control: {rightHand: {selectEnd: true}},
+      durationMs: 100,
+    });
 
     expect(grabbable.grabbedByHand).toBeNull();
 
@@ -125,7 +126,7 @@ describe('TestRunner functional examples', () => {
   it('should run Example 4: UI Button Clicking & Game Logic', async () => {
     const game = new GameController();
 
-    // Create button that triggers spawning on game controller
+    // Create button that triggers spawning on game controller.
     const button = new TextButton({
       text: 'Spawn Item',
     });
@@ -140,13 +141,11 @@ describe('TestRunner functional examples', () => {
 
     expect(game.score).toBe(0);
 
-    // Point right hand (index 1) at button and click it
-    await runner.pointTo(1, button);
+    // Point right hand (index 1) at button and click it.
+    await runner.actions.pointTo(1, button);
     expect(game.score).toBe(0);
-    await runner.click(1); // Click does pinch and release over time
-
-    // Step virtual time to process click frames
-    await runner.step(250);
+    await runner.actions.click(1);
+    await runner.actions.step({durationMs: 250});
 
     expect(game.score).toBe(1);
     expect(game.spawnedItems.size).toBe(1);
@@ -163,7 +162,7 @@ describe('TestRunner functional examples', () => {
       private estimator = new WebXRHandPoseEstimator(core.user);
 
       override update() {
-        const context = this.estimator.getHandContext(1); // 1 is right hand
+        const context = this.estimator.getHandContext(1);
         if (!context) return;
 
         const scores = this.recognizer.recognize(context);
@@ -189,17 +188,17 @@ describe('TestRunner functional examples', () => {
 
     expect(script.pinchDetected).toBe(false);
 
-    // Trigger a pinch using simulated embodied motions
-    await runner.pinch(1, true);
-    await runner.step(400); // Wait for the simulator hand to lerp and trigger the gesture
-
-    // Expect the pinch to be detected by the gesture logger
+    await runner.actions.step({
+      control: {rightHand: {selectStart: true}},
+      durationMs: 400,
+    });
     expect(script.pinchDetected).toBe(true);
     expect(script.confidence).toBeGreaterThan(0.6);
 
-    // Release pinch
-    await runner.pinch(1, false);
-    await runner.step(250);
+    await runner.actions.step({
+      control: {rightHand: {selectEnd: true}},
+      durationMs: 250,
+    });
 
     expect(script.pinchDetected).toBe(false);
 

--- a/src/addons/testing/example.test.ts
+++ b/src/addons/testing/example.test.ts
@@ -1,0 +1,208 @@
+import {describe, it, expect} from 'vitest';
+import {TestRunner} from './TestRunner';
+import * as THREE from 'three';
+import {
+  Script,
+  type SelectEvent,
+  TextButton,
+  Options,
+  core,
+  HeuristicGestureRecognizer,
+  WebXRHandPoseEstimator,
+} from 'xrblocks';
+
+class SimpleRotationScript extends Script {
+  speed = 1.0;
+  override update() {
+    this.rotation.y += this.speed * 0.01;
+  }
+}
+
+class HoverScript extends Script {
+  isHovered = false;
+
+  override onHoverEnter(_controller: THREE.Object3D) {
+    this.isHovered = true;
+  }
+
+  override onHoverExit(_controller: THREE.Object3D) {
+    this.isHovered = false;
+  }
+}
+
+class GrabbableScript extends Script {
+  grabbedByHand: number | null = null;
+
+  override onObjectSelectStart(event: SelectEvent) {
+    // Determine which controller triggered the selection
+    const controller = event.target as unknown as {userData: {id: number}};
+    const index = controller.userData.id;
+    this.grabbedByHand = index;
+    return true; // Mark as handled
+  }
+
+  override onObjectSelectEnd(_event: SelectEvent) {
+    this.grabbedByHand = null;
+    return true;
+  }
+}
+
+class GameController extends Script {
+  score = 0;
+  spawnedItems = new Set<THREE.Object3D>();
+
+  spawnItem() {
+    const item = new THREE.Object3D();
+    this.spawnedItems.add(item);
+    this.add(item);
+    this.score++;
+  }
+}
+
+describe('TestRunner functional examples', () => {
+  it('should run Example 1: State and Lifecycle Testing', async () => {
+    const script = new SimpleRotationScript();
+    const runner = await TestRunner.create({
+      scripts: [script],
+    });
+
+    expect(script.rotation.y).toBe(0);
+
+    // Step 1 frame (~16ms)
+    await runner.step(16.67);
+    expect(script.rotation.y).toBeGreaterThan(0);
+
+    await runner.destroy();
+  });
+
+  it('should run Example 2: Raycasting & Hover Check', async () => {
+    const hoverScript = new HoverScript();
+    hoverScript.add(new THREE.Mesh(new THREE.BoxGeometry(0.5, 0.5, 0.5)));
+    hoverScript.position.set(1, 0, -2); // 1m right, 2m in front of user
+
+    const runner = await TestRunner.create({
+      scripts: [hoverScript],
+    });
+
+    // Initially pointing down/away, not hovered
+    await runner.step(100);
+    expect(hoverScript.isHovered).toBe(false);
+
+    // Point right hand (index 1) directly at the target object
+    await runner.pointTo(1, hoverScript);
+    await runner.step(100);
+
+    expect(hoverScript.isHovered).toBe(true);
+
+    await runner.destroy();
+  });
+
+  it('should run Example 3: Correct Hand & Grab Verification', async () => {
+    const grabbable = new GrabbableScript();
+    grabbable.add(new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.2, 0.2)));
+    grabbable.position.set(0, 0, -1); // 1 meter in front of user
+
+    const runner = await TestRunner.create({
+      scripts: [grabbable],
+    });
+
+    // Point and pinch (grab) with the right hand (index 1)
+    await runner.pointTo(1, grabbable);
+    await runner.pinch(1, true);
+    await runner.step(100);
+
+    expect(grabbable.grabbedByHand).toBe(1);
+
+    // Release pinch
+    await runner.pinch(1, false);
+    await runner.step(100);
+
+    expect(grabbable.grabbedByHand).toBeNull();
+
+    await runner.destroy();
+  });
+
+  it('should run Example 4: UI Button Clicking & Game Logic', async () => {
+    const game = new GameController();
+
+    // Create button that triggers spawning on game controller
+    const button = new TextButton({
+      text: 'Spawn Item',
+    });
+    button.onTriggered = () => {
+      game.spawnItem();
+    };
+    button.position.set(0, 1.2, -1.2); // Positioned in front of camera
+
+    const runner = await TestRunner.create({
+      scripts: [game, button],
+    });
+
+    expect(game.score).toBe(0);
+
+    // Point right hand (index 1) at button and click it
+    await runner.pointTo(1, button);
+    expect(game.score).toBe(0);
+    await runner.click(1); // Click does pinch and release over time
+
+    // Step virtual time to process click frames
+    await runner.step(250);
+
+    expect(game.score).toBe(1);
+    expect(game.spawnedItems.size).toBe(1);
+
+    await runner.destroy();
+  });
+
+  it('should run Example 5: End-to-End Heuristic Gesture Recognition', async () => {
+    class TestGestureScript extends Script {
+      pinchDetected = false;
+      confidence = 0;
+
+      private recognizer = new HeuristicGestureRecognizer();
+      private estimator = new WebXRHandPoseEstimator(core.user);
+
+      override update() {
+        const context = this.estimator.getHandContext(1); // 1 is right hand
+        if (!context) return;
+
+        const scores = this.recognizer.recognize(context);
+        const pinch = scores['pinch'];
+        if (pinch) {
+          this.pinchDetected = pinch.confidence > 0.6;
+          this.confidence = pinch.confidence;
+        } else {
+          this.pinchDetected = false;
+          this.confidence = 0;
+        }
+      }
+    }
+
+    const script = new TestGestureScript();
+    const options = new Options();
+    options.hands.enabled = true;
+
+    const runner = await TestRunner.create({
+      scripts: [script],
+      options,
+    });
+
+    expect(script.pinchDetected).toBe(false);
+
+    // Trigger a pinch using simulated embodied motions
+    await runner.pinch(1, true);
+    await runner.step(400); // Wait for the simulator hand to lerp and trigger the gesture
+
+    // Expect the pinch to be detected by the gesture logger
+    expect(script.pinchDetected).toBe(true);
+    expect(script.confidence).toBeGreaterThan(0.6);
+
+    // Release pinch
+    await runner.pinch(1, false);
+    await runner.step(250);
+
+    expect(script.pinchDetected).toBe(false);
+
+    await runner.destroy();
+  });
+});

--- a/src/addons/testing/index.ts
+++ b/src/addons/testing/index.ts
@@ -1,0 +1,2 @@
+import './setup';
+export {TestRunner, type TestRunnerConfig} from './TestRunner';

--- a/src/addons/testing/setup.ts
+++ b/src/addons/testing/setup.ts
@@ -1,8 +1,16 @@
+/*
+Mock THREE and WebGL/WebAudio API for JSDOM/Vitest environments. 
+Runs globally before XRBlocks instantiates.
+
+Stubs WebGL/WebAudio APIs, mocks GLTFLoader to return
+hands with bones immediately under the root scene.
+*/
+
 import {vi} from 'vitest';
 import * as THREE from 'three';
 import {GLTFLoader, type GLTF} from 'three/addons/loaders/GLTFLoader.js';
 
-// 1. Stub AudioContext globally
+// Stub AudioContext globally.
 const globalRecord = globalThis as unknown as Record<string, unknown>;
 if (typeof globalRecord.AudioContext === 'undefined') {
   const mockAudioParam = {
@@ -41,7 +49,7 @@ if (typeof globalRecord.AudioContext === 'undefined') {
   };
 }
 
-// 2. Mock three WebGLRenderer for JSDOM headless testing
+// Mock three WebGLRenderer for JSDOM headless testing.
 vi.mock('three', async (importOriginal) => {
   const original = await importOriginal<typeof import('three')>();
 
@@ -99,7 +107,7 @@ vi.mock('three', async (importOriginal) => {
   };
 });
 
-// 3. Mock GLTFLoader to return a mock hand hierarchy with bones immediately under JSDOM
+// Mock GLTFLoader to return a mock hand hierarchy with bones immediately under JSDOM.
 const isWebGLSupported = () => {
   try {
     const canvas = document.createElement('canvas');

--- a/src/addons/testing/setup.ts
+++ b/src/addons/testing/setup.ts
@@ -1,0 +1,134 @@
+import {vi} from 'vitest';
+import * as THREE from 'three';
+import {GLTFLoader, type GLTF} from 'three/addons/loaders/GLTFLoader.js';
+
+// 1. Stub AudioContext globally
+const globalRecord = globalThis as unknown as Record<string, unknown>;
+if (typeof globalRecord.AudioContext === 'undefined') {
+  const mockAudioParam = {
+    value: 0,
+    setValueAtTime: () => {},
+    linearRampToValueAtTime: () => {},
+    setTargetAtTime: () => {},
+    cancelScheduledValues: () => {},
+    defaultValue: 0,
+    minValue: 0,
+    maxValue: 0,
+  };
+
+  const mockAudioListener = {
+    positionX: mockAudioParam,
+    positionY: mockAudioParam,
+    positionZ: mockAudioParam,
+    forwardX: mockAudioParam,
+    forwardY: mockAudioParam,
+    forwardZ: mockAudioParam,
+    upX: mockAudioParam,
+    upY: mockAudioParam,
+    upZ: mockAudioParam,
+    setPosition: () => {},
+    setOrientation: () => {},
+  };
+
+  globalRecord.AudioContext = function () {
+    return {
+      createGain: () => ({
+        connect: () => {},
+      }),
+      destination: {},
+      listener: mockAudioListener,
+    };
+  };
+}
+
+// 2. Mock three WebGLRenderer for JSDOM headless testing
+vi.mock('three', async (importOriginal) => {
+  const original = await importOriginal<typeof import('three')>();
+
+  const MockWebGLRenderer = function () {
+    const self = Object.create(original.WebGLRenderer.prototype);
+    self.constructor = MockWebGLRenderer;
+
+    self.domElement = document.createElement('canvas');
+    const controllers = [new original.Group(), new original.Group()];
+    const controllerGrips = [new original.Group(), new original.Group()];
+    const hands = [new original.Group(), new original.Group()];
+    hands.forEach((hand) => {
+      (hand as unknown as {joints: unknown}).joints = {};
+    });
+
+    self.xr = {
+      enabled: false,
+      isPresenting: false,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      getDepthSensingMesh: () => null,
+      setReferenceSpaceType: () => {},
+      setAnimationLoop: () => {},
+      getController: (i: number) => controllers[i],
+      getControllerGrip: (i: number) => controllerGrips[i],
+      getHand: (i: number) => hands[i],
+      getCamera: () => ({cameras: []}),
+      cameraAutoUpdate: true,
+    };
+    self.shadowMap = {enabled: false};
+    self.capabilities = {isWebGL2: false};
+    self.autoClearColor = true;
+    self.localClippingEnabled = false;
+
+    self.setPixelRatio = () => {};
+    self.setSize = () => {};
+    self.setRenderTarget = () => {};
+    self.setAnimationLoop = () => {};
+    self.clear = () => {};
+    self.render = () => {};
+    self.setTransparentSort = () => {};
+    self.clearDepth = () => {};
+    self.dispose = () => {};
+    self.getRenderTarget = () => null;
+    self.readRenderTargetPixelsAsync = () => Promise.resolve();
+
+    return self;
+  };
+
+  MockWebGLRenderer.prototype = original.WebGLRenderer.prototype;
+
+  return {
+    ...original,
+    WebGLRenderer: MockWebGLRenderer,
+  };
+});
+
+// 3. Mock GLTFLoader to return a mock hand hierarchy with bones immediately under JSDOM
+const isWebGLSupported = () => {
+  try {
+    const canvas = document.createElement('canvas');
+    return !!(
+      canvas.getContext('webgl') || canvas.getContext('experimental-webgl')
+    );
+  } catch {
+    return false;
+  }
+};
+
+if (!isWebGLSupported()) {
+  const {HAND_JOINT_NAMES} = await import('xrblocks');
+
+  vi.spyOn(GLTFLoader.prototype, 'load').mockImplementation((_url, onLoad) => {
+    const mockHandScene = new THREE.Group();
+    for (const jointName of HAND_JOINT_NAMES) {
+      const bone = new THREE.Group();
+      bone.name = jointName;
+      mockHandScene.add(bone);
+    }
+    if (onLoad) {
+      onLoad({
+        scene: mockHandScene,
+        scenes: [mockHandScene],
+        animations: [],
+        cameras: [],
+        asset: {},
+      } as unknown as GLTF);
+    }
+  });
+}

--- a/src/addons/tsconfig.lib.json
+++ b/src/addons/tsconfig.lib.json
@@ -14,6 +14,6 @@
     }
   },
   "include": ["**/*.ts"],
-  "exclude": ["**/cli/**/*.ts"],
+  "exclude": ["**/cli/**/*.ts", "**/*.test.ts", "**/*.test.js"],
   "references": [{"path": "../../"}]
 }

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -519,6 +519,9 @@ export class Core {
     // Traverse the scene to find all scripts.
     this.scriptsManager.syncScriptsWithScene(this.scene);
 
+    // Force matrix updates since there is no active renderer render loop in headless/test environments.
+    this.scene.updateMatrixWorld(true);
+
     // Updates reticles and UIs.
     this.scriptsManager.resetUX();
     this.input.update();

--- a/src/utils/CreateLoadingSpinner.ts
+++ b/src/utils/CreateLoadingSpinner.ts
@@ -45,6 +45,7 @@ class LoadingSpinner extends HTMLElement {
     shadowRoot.innerHTML = LoadingSpinner.innerHTML;
   }
 }
+// Prevents errors in headless environments where the spinner isn't actually used.
 if (!customElements.get('xb-blocks-loading-spinner')) {
   customElements.define('xb-blocks-loading-spinner', LoadingSpinner);
 }

--- a/src/utils/CreateLoadingSpinner.ts
+++ b/src/utils/CreateLoadingSpinner.ts
@@ -45,7 +45,9 @@ class LoadingSpinner extends HTMLElement {
     shadowRoot.innerHTML = LoadingSpinner.innerHTML;
   }
 }
-customElements.define('xb-blocks-loading-spinner', LoadingSpinner);
+if (!customElements.get('xb-blocks-loading-spinner')) {
+  customElements.define('xb-blocks-loading-spinner', LoadingSpinner);
+}
 
 // Creates a new Loading spinner and attaches it to document.body.
 export function createLoadingSpinner() {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,13 @@
 import {defineConfig} from 'vitest/config';
+import {resolve} from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      'xrblocks/addons': resolve(__dirname, './src/addons'),
+      xrblocks: resolve(__dirname, './src/xrblocks.ts'),
+    },
+  },
   test: {
     include: ['src/**/*.test.ts'],
     environment: 'jsdom',


### PR DESCRIPTION
New addon to allow for more functional tests in ```addons/testing```. Includes
- New ```TestRunner.ts``` which instantiates all the mock systems needed to startup a test JSDOM run.
- Mock renderers instantiated on setup to override XRBlocks browser dependencies
- embodied-actions as the endpoint to run action tests
- Documentation on loading to make it a bit smoother for agents to run tests
- ```addons/testing/examples.test.ts``` shows how tests can be used and extend beyond just logic tests right now.