### PR TITLE
feat: Support multiple concurrent clients in HumanRecognizer

### DIFF
--- a/demos/human_pose_detector/PoseDisplay.js
+++ b/demos/human_pose_detector/PoseDisplay.js
@@ -9,12 +9,15 @@ export class PoseDisplay extends xb.Script {
     this.camera = camera;
     this.world = world;
     this.uiCore = new UICore(this);
-    this.detecting = false;
 
     this.initHudText();
 
     this.initJointMarkers();
     this.initConnections();
+
+    if (this.world.humans) {
+      this.world.humans.start(this);
+    }
 
     console.log('PoseDisplay: human pose detector initialized.');
   }
@@ -191,22 +194,8 @@ export class PoseDisplay extends xb.Script {
       this.hudCard.quaternion.copy(quaternion);
     }
 
-    // Continuously query human detector backend
-    if (this.world.humans && !this.detecting) {
-      this.detecting = true;
-      this.world.humans
-        .runDetection()
-        .then((poses) => {
-          this.detecting = false;
-          this.displayPoses(poses);
-        })
-        .catch((err) => {
-          this.detecting = false;
-          const errMsg = err.message || String(err);
-          this.statusText.setText('Detection Error');
-          this.statusDetailsText.setText('[Exception]:\n' + errMsg);
-          console.error('Pose detection failed:', err);
-        });
+    if (this.world.humans) {
+      this.displayPoses(this.world.humans.poses);
     }
   }
 
@@ -298,6 +287,9 @@ export class PoseDisplay extends xb.Script {
   }
 
   dispose() {
+    if (this.world.humans) {
+      this.world.humans.stop(this);
+    }
     if (this.markerGeometry) {
       this.markerGeometry.dispose();
     }

--- a/src/world/humans/HumanRecognizer.test.ts
+++ b/src/world/humans/HumanRecognizer.test.ts
@@ -1,0 +1,148 @@
+import * as THREE from 'three';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {HumanRecognizer} from './HumanRecognizer';
+import {WorldOptions} from '../WorldOptions';
+import {XRDeviceCamera} from '../../camera/XRDeviceCamera';
+import {Depth} from '../../depth/Depth';
+import {DetectedBodyPose} from './DetectedBodyPose';
+
+vi.mock('../../camera/CameraUtils', () => ({
+  getCameraParametersSnapshot: vi.fn().mockReturnValue({}),
+}));
+
+interface PrivateRecognizer {
+  currentDetectionPromise: Promise<DetectedBodyPose[]> | null;
+  getOrCreateBackend: (
+    activeBackend: string,
+    context: unknown
+  ) => Promise<unknown>;
+}
+
+describe('HumanRecognizer Multi-Client API', () => {
+  let recognizer: HumanRecognizer;
+  let mockBackend: {run: ReturnType<typeof vi.fn>};
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    const options = new WorldOptions();
+    options.humans.enable();
+    const deviceCamera = {} as unknown as XRDeviceCamera;
+    const depth = {
+      depthMesh: new THREE.Mesh(),
+      options: {
+        depthMesh: {
+          updateFullResolutionGeometry: false,
+        },
+      },
+    } as unknown as Depth;
+    const camera = new THREE.PerspectiveCamera();
+    const renderer = {
+      xr: {
+        getCamera: () => new THREE.PerspectiveCamera(),
+      },
+    } as unknown as THREE.WebGLRenderer;
+
+    recognizer = new HumanRecognizer();
+    recognizer.init({
+      options,
+      deviceCamera,
+      depth,
+      camera,
+      renderer,
+    });
+
+    mockBackend = {
+      run: vi.fn().mockResolvedValue([{uuid: 'pose-1'}]),
+    };
+    vi.spyOn(
+      recognizer as unknown as PrivateRecognizer,
+      'getOrCreateBackend'
+    ).mockResolvedValue(mockBackend);
+  });
+
+  it('should start continuous detection for clients and cache results to poses', async () => {
+    const client = {};
+    recognizer.start(client);
+
+    // Continuous detection runs immediately on first client start
+    const promise = (recognizer as unknown as PrivateRecognizer)
+      .currentDetectionPromise;
+    expect(promise).not.toBeNull();
+
+    const results = await promise;
+    expect(results).toEqual([{uuid: 'pose-1'}]);
+    expect(recognizer.poses).toEqual([{uuid: 'pose-1'}]);
+    expect(
+      (recognizer as unknown as PrivateRecognizer).currentDetectionPromise
+    ).toBeNull();
+
+    // Subsequent updates trigger new detections
+    recognizer.update();
+    const promise2 = (recognizer as unknown as PrivateRecognizer)
+      .currentDetectionPromise;
+    expect(promise2).not.toBeNull();
+    await promise2;
+  });
+
+  it('should stop continuous detection when all clients stop', async () => {
+    const client1 = {};
+    const client2 = {};
+
+    recognizer.start(client1);
+    recognizer.start(client2);
+
+    const promise = (recognizer as unknown as PrivateRecognizer)
+      .currentDetectionPromise;
+    expect(promise).not.toBeNull();
+    await promise;
+
+    // Stop one client, continuous detection should still be active
+    recognizer.stop(client1);
+    recognizer.update();
+    expect(
+      (recognizer as unknown as PrivateRecognizer).currentDetectionPromise
+    ).not.toBeNull();
+    await (recognizer as unknown as PrivateRecognizer).currentDetectionPromise;
+
+    // Stop final client, continuous detection should not be triggered on update
+    recognizer.stop(client2);
+    recognizer.update();
+    expect(
+      (recognizer as unknown as PrivateRecognizer).currentDetectionPromise
+    ).toBeNull();
+  });
+
+  it('should return the ongoing promise for concurrent runDetection calls when started', async () => {
+    const client = {};
+    recognizer.start(client);
+
+    const continuousPromise = (recognizer as unknown as PrivateRecognizer)
+      .currentDetectionPromise;
+    expect(continuousPromise).not.toBeNull();
+
+    const runPromise = recognizer.runDetection();
+    expect(runPromise).toBe(continuousPromise);
+
+    await runPromise;
+  });
+
+  it('should support one-off runs when not started, and reuse the ongoing promise', async () => {
+    // No clients started
+    const promise1 = recognizer.runDetection();
+    expect(promise1).not.toBeNull();
+    expect(
+      (recognizer as unknown as PrivateRecognizer).currentDetectionPromise
+    ).toBe(promise1);
+
+    // A concurrent call should return the exact same promise
+    const promise2 = recognizer.runDetection();
+    expect(promise2).toBe(promise1);
+
+    const results = await promise1;
+    expect(results).toEqual([{uuid: 'pose-1'}]);
+    expect(
+      (recognizer as unknown as PrivateRecognizer).currentDetectionPromise
+    ).toBeNull();
+  });
+});

--- a/src/world/humans/HumanRecognizer.ts
+++ b/src/world/humans/HumanRecognizer.ts
@@ -22,12 +22,19 @@ export class HumanRecognizer extends Script {
     renderer: THREE.WebGLRenderer,
   };
 
-  private _detectorBackends = new Map<string, Promise<BaseHumanBackend>>();
+  private detectorBackends = new Map<string, Promise<BaseHumanBackend>>();
+  private activeClients = new Set<object>();
+  private currentDetectionPromise: Promise<DetectedBodyPose[]> | null = null;
+
+  /**
+   * The latest detected body poses.
+   */
+  public poses: DetectedBodyPose[] = [];
 
   // Injected dependencies
   private options!: WorldOptions;
   private deviceCamera!: XRDeviceCamera;
-  public depth!: Depth;
+  private depth!: Depth;
   private camera!: THREE.PerspectiveCamera;
   private renderer!: THREE.WebGLRenderer;
 
@@ -54,9 +61,76 @@ export class HumanRecognizer extends Script {
   }
 
   /**
-   * Runs the human body pose detection process based on the configured backend.
+   * Starts continuous pose detection for the given client.
+   * If this is the first client, starts the background detection loop.
+   * @param client - The client object requesting pose detection.
    */
-  async runDetection(): Promise<DetectedBodyPose[]> {
+  start(client: object): void {
+    if (this.activeClients.has(client)) {
+      return;
+    }
+    this.activeClients.add(client);
+    if (this.activeClients.size === 1) {
+      this.runContinuousDetection();
+    }
+  }
+
+  /**
+   * Stops continuous pose detection for the given client.
+   * If this was the last client, stops the background detection loop.
+   * @param client - The client object that no longer needs pose detection.
+   */
+  stop(client: object): void {
+    this.activeClients.delete(client);
+  }
+
+  /**
+   * Called per frame by the engine. If there are active clients,
+   * ensures the continuous pose detection is running.
+   */
+  override update() {
+    if (this.activeClients.size > 0 && !this.currentDetectionPromise) {
+      this.runContinuousDetection();
+    }
+  }
+
+  private runContinuousDetection() {
+    this.currentDetectionPromise = this.runDetectionInternal()
+      .then((results) => {
+        this.poses = results;
+        return results;
+      })
+      .finally(() => {
+        this.currentDetectionPromise = null;
+      });
+  }
+
+  /**
+   * Runs a pose detection or returns the ongoing detection promise.
+   *
+   * - If continuous detection is started (has active clients), returns the promise
+   *   for the next detection result.
+   * - If continuous detection is not started, performs a one-off detection and
+   *   returns the result. If a one-off detection is already in progress, returns
+   *   the promise for that ongoing detection.
+   *
+   * @returns A promise resolving to the next body pose detection result.
+   */
+  runDetection(): Promise<DetectedBodyPose[]> {
+    if (this.currentDetectionPromise) {
+      return this.currentDetectionPromise;
+    }
+    if (this.activeClients.size > 0) {
+      this.runContinuousDetection();
+      return this.currentDetectionPromise!;
+    }
+    this.currentDetectionPromise = this.runDetectionInternal().finally(() => {
+      this.currentDetectionPromise = null;
+    });
+    return this.currentDetectionPromise;
+  }
+
+  private async runDetectionInternal(): Promise<DetectedBodyPose[]> {
     this.clear();
 
     if (!this.depth || !this.depth.depthMesh) {
@@ -112,7 +186,7 @@ export class HumanRecognizer extends Script {
     activeBackend: string,
     context: HumanBackendContext
   ): Promise<BaseHumanBackend> {
-    let backendPromise = this._detectorBackends.get(activeBackend);
+    let backendPromise = this.detectorBackends.get(activeBackend);
 
     if (!backendPromise) {
       backendPromise = (async () => {
@@ -125,7 +199,7 @@ export class HumanRecognizer extends Script {
             );
         }
       })();
-      this._detectorBackends.set(activeBackend, backendPromise);
+      this.detectorBackends.set(activeBackend, backendPromise);
     }
     return backendPromise;
   }


### PR DESCRIPTION
- Update HumanRecognizer API with start(client) and stop(client).
- Cache latest body pose results to .poses.
- Share ongoing detection promise for concurrent runDetection() calls.
- Update human pose detector demo PoseDisplay to use new start/stop/poses API.
- Make depth dependency private in HumanRecognizer and FaceRecognizer.
- Add unit tests for HumanRecognizer.

We're now caching the latest poses within HumanRecognizer.
The new API has:
1. `start(client)` to start continuous detection
2. `stop(client)` to stop continuous detection
3. `poses` to get the latest poses
4. `runDetection()` to run a one-off detection without starting continuous detection