### PR TITLE
ui: Unify panel corner radius and fix edge dragging

### DIFF
--- a/samples/ui/index.html
+++ b/samples/ui/index.html
@@ -174,7 +174,7 @@
           const panel = new xb.SpatialPanel({
             width: 1.3,
             height: 1.25,
-            backgroundColor: '#00000000',
+            backgroundColor: '#21252baa',
           });
           panel.position.set(
             0,
@@ -183,17 +183,7 @@
           );
           panel.isRoot = true;
           this.add(panel);
-          const grid = panel.addGrid();
-          // Space for orbiter
-          grid.addRow({weight: 0.0});
-          // player row
-          const playerRow = grid.addRow({weight: 1.0});
-          const playerPanel = playerRow.addPanel({
-            width: 1.2,
-            height: 1.2,
-            backgroundColor: '#21252baa',
-          });
-          const playerGrid = playerPanel.addGrid();
+          const playerGrid = panel.addGrid();
           {
             // video row
             playerGrid.addRow({weight: 0.1});
@@ -217,75 +207,7 @@
               .addIconButton({text: 'skip_next', fontSize: 0.4});
             controlsRow.addCol({weight: 0.2});
           }
-          const orbiter = playerGrid.addOrbiter({
-            orbiterScale: 0.1,
-          });
-          orbiter.addExitButton();
           panel.updateLayouts();
-        }
-
-        createSettingsPanel() {
-          // Panel 3: Settings Menu (Top-Right)
-          const settingsPanel = new xb.SpatialPanel({
-            width: 1.0,
-            height: 1.2,
-            backgroundColor: '#282c3488',
-          });
-          settingsPanel.position.set(
-            1.5,
-            xb.user.height,
-            -xb.user.panelDistance + 2.0
-          );
-          settingsPanel.rotation.set(0, -Math.PI / 2.0, 0);
-
-          this.add(settingsPanel);
-          const settingsGrid = settingsPanel.addGrid();
-          settingsGrid.addRow({weight: 0.15}).addText({
-            text: 'Fake Settings',
-            fontSize: 0.1,
-            fontColor: '#61dafb',
-          });
-
-          const addSettingRow = (grid, label, type) => {
-            const row = grid.addRow({weight: 0.2});
-            row.addCol({weight: 0.6}).addText({
-              text: label,
-              anchorX: 'left',
-              textAlign: 'left',
-              fontSize: 0.07,
-            });
-            const controlCol = row.addCol({weight: 0.4});
-            if (type === 'toggle') {
-              const toggleBg = controlCol.addPanel({
-                backgroundColor: '#61dafb',
-                width: 0.3,
-                height: 0.06,
-              });
-              toggleBg.addGrid().addPanel({
-                backgroundColor: '#ffffff',
-                width: 0.05,
-                height: 0.05,
-                x: 0.04,
-              });
-            } else if (type === 'slider') {
-              const sliderBg = controlCol.addPanel({
-                backgroundColor: '#3a3f4b',
-                width: 0.35,
-                height: 0.02,
-              });
-              sliderBg.addGrid().addPanel({
-                backgroundColor: '#61dafb',
-                width: 0.04,
-                height: 0.04,
-                x: 0.05,
-              });
-            }
-          };
-
-          addSettingRow(settingsGrid, 'Enable Hand Tracking', 'toggle');
-          addSettingRow(settingsGrid, 'Show Notifications', 'toggle');
-          addSettingRow(settingsGrid, 'Master Volume', 'slider');
-          addSettingRow(settingsGrid, 'UI Scale', 'slider');
         }
 
         createGalleryPanel() {
@@ -302,7 +224,7 @@
           );
           this.add(galleryPanel);
           const galleryGrid = galleryPanel.addGrid();
-          galleryGrid.addRow({weight: 0.25}).addText({
+          galleryGrid.addRow({weight: 0.2}).addText({
             text: 'Photo Gallery',
             fontSize: 0.07,
             fontColor: '#61dafb',
@@ -310,35 +232,23 @@
           const photoRow1 = galleryGrid.addRow({weight: 0.375});
           photoRow1.addCol({weight: 1 / 3}).addImage({
             src: 'https://placehold.co/150x150/92c5fd/333?text=Img1',
-            paddingX: 0.02,
-            paddingY: 0.02,
           });
           photoRow1.addCol({weight: 1 / 3}).addImage({
             src: 'https://placehold.co/150x150/6ee7b7/333?text=Img2',
-            paddingX: 0.02,
-            paddingY: 0.02,
           });
           photoRow1.addCol({weight: 1 / 3}).addImage({
             src: 'https://placehold.co/150x150/fca5a5/333?text=Img3',
-            paddingX: 0.02,
-            paddingY: 0.02,
           });
           galleryGrid.addRow({weight: 0.05});
           const photoRow2 = galleryGrid.addRow({weight: 0.375});
           photoRow2.addCol({weight: 1 / 3}).addImage({
             src: 'https://placehold.co/150x150/fde047/333?text=Img4',
-            paddingX: 0.02,
-            paddingY: 0.02,
           });
           photoRow2.addCol({weight: 1 / 3}).addImage({
             src: 'https://placehold.co/150x150/c4b5fd/333?text=Img5',
-            paddingX: 0.02,
-            paddingY: 0.02,
           });
           photoRow2.addCol({weight: 1 / 3}).addImage({
             src: 'https://placehold.co/150x150/f9a8d4/333?text=Img6',
-            paddingX: 0.02,
-            paddingY: 0.02,
           });
         }
 
@@ -399,77 +309,6 @@
           });
         }
 
-        createChartPanel() {
-          // Panel 6: Dynamic Chart with Canvas (Bottom-Center)
-          const chartPanel = new xb.SpatialPanel({
-            width: 0.8,
-            height: 0.6,
-            backgroundColor: '#21252b88',
-          });
-          chartPanel.position.set(
-            -1.5,
-            xb.user.height,
-            -xb.user.panelDistance + 2.0
-          );
-          chartPanel.rotation.set(0, Math.PI / 2.0, 0);
-
-          this.add(chartPanel);
-          const chartGrid = chartPanel.addGrid();
-          chartGrid.addRow({weight: 0.15}).addText({
-            text: 'Performance Metrics',
-            fontSize: 0.07,
-            fontColor: '#61dafb',
-          });
-
-          // --- Canvas Chart ---
-          const canvas = document.getElementById('barChartCanvas');
-          const ctx = canvas.getContext('2d');
-          const barData = [0.4, 0.7, 0.5, 0.8, 0.6];
-          const colors = [
-            '#92c5fd',
-            '#6ee7b7',
-            '#fca5a5',
-            '#fde047',
-            '#c4b5fd',
-          ];
-          const padding = 40;
-          const barWidth =
-            (canvas.width - padding * (barData.length + 1)) / barData.length;
-          const maxBarHeight = canvas.height - padding * 2;
-
-          ctx.fillStyle = '#282c34'; // background
-          ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-          barData.forEach((value, index) => {
-            const barHeight = value * maxBarHeight;
-            const x = padding + index * (barWidth + padding);
-            const y = canvas.height - padding - barHeight;
-            ctx.fillStyle = colors[index];
-            ctx.fillRect(x, y, barWidth, barHeight);
-          });
-
-          const canvasTexture = new THREE.CanvasTexture(canvas);
-          canvasTexture.needsUpdate = true;
-          const chartCol = chartGrid.addCol();
-          chartCol.addRow({weight: 0.15});
-          const chartArea = chartCol.addRow({weight: 0.85});
-          const chartMesh = new THREE.Mesh(
-            new THREE.PlaneGeometry(1, 1),
-            new THREE.MeshBasicMaterial({map: canvasTexture})
-          );
-          chartArea.add(chartMesh);
-
-          const tmpRow = chartGrid.addCol();
-          tmpRow.addRow({weight: 0.3});
-          const okButton = tmpRow.addRow().addTextButton({
-            text: 'OK',
-            backgroundColor: '#22aa33',
-            opacity: 0.5,
-            fontColor: '#66ccff',
-            fontSizeDp: 50,
-          });
-        }
-
         init() {
           this.add(new THREE.HemisphereLight(0xffffff, 0x666666, 3));
 
@@ -477,8 +316,6 @@
           this.createProfilePanelFromJSON();
           this.createPlayerPanel();
           this.createGalleryPanel();
-          this.createChartPanel();
-          this.createSettingsPanel();
         }
       }
 

--- a/src/ui/core/Panel.ts
+++ b/src/ui/core/Panel.ts
@@ -76,6 +76,9 @@ export class Panel extends View implements Draggable, Partial<HasDraggingMode> {
    */
   showHighlights = false;
 
+  /** The width of the interactive border, in meters. */
+  borderWidth = 0.1;
+
   /** The background color of the panel, expressed as a CSS color string. */
   backgroundColor = '#c2c2c255';
 
@@ -123,8 +126,6 @@ export class Panel extends View implements Draggable, Partial<HasDraggingMode> {
     const isDraggable = options.draggable ?? this.draggable;
 
     const useBorderlessShader = options.useBorderlessShader ?? !isDraggable;
-    // Draggable panels have a larger geometry for interaction padding.
-    const panelScale = useBorderlessShader ? 1.0 : 1.3;
     // Use SpatialPanelShader for SpatialPanel, while developers can choose
     // useBorderlessShader=false to disable the interactive border.
     const shader = useBorderlessShader ? SquircleShader : SpatialPanelShader;
@@ -147,11 +148,42 @@ export class Panel extends View implements Draggable, Partial<HasDraggingMode> {
       options.useDefaultPosition ?? this.useDefaultPosition;
     this.useBorderlessShader =
       options.useBorderlessShader ?? this.useBorderlessShader;
+    this.borderWidth = options.borderWidth ?? this.borderWidth;
 
-    this.mesh = new PanelMesh(shader, this.backgroundColor, panelScale);
+    this.mesh = new PanelMesh(shader, this.backgroundColor);
+    if (this.mesh.uniforms.uBorderWidth) {
+      this.mesh.uniforms.uBorderWidth.value = this.borderWidth;
+    }
     this.add(this.mesh);
 
     this.updateLayout();
+  }
+
+  /**
+   * Restricts dragging of the panel:
+   * 1. Only drag when intersecting the panel's own mesh directly (blocking child components/buttons).
+   * 2. If the panel has a border (borderWidth \> 0.0), only drag when the intersection is on the edge.
+   */
+  canDrag(intersection: THREE.Intersection): boolean {
+    if (intersection.object !== this.mesh) {
+      return false;
+    }
+    const effectiveBorderWidth = this.useBorderlessShader
+      ? 0.0
+      : this.borderWidth;
+    if (effectiveBorderWidth > 0.0 && intersection.uv) {
+      const uv = intersection.uv;
+      const meshSize = this.mesh.uniforms.uBoxSize.value;
+      const marginU = effectiveBorderWidth / 2.0 / meshSize.x;
+      const marginV = effectiveBorderWidth / 2.0 / meshSize.y;
+      return (
+        uv.x < marginU ||
+        uv.x > 1.0 - marginU ||
+        uv.y < marginV ||
+        uv.y > 1.0 - marginV
+      );
+    }
+    return true;
   }
 
   /**
@@ -321,13 +353,21 @@ export class Panel extends View implements Draggable, Partial<HasDraggingMode> {
    */
   override updateLayout() {
     super.updateLayout();
-    this.mesh.setAspectRatio(this.aspectRatio);
     const parentAspectRatio =
       this.isRoot || !this.parent ? 1.0 : (this.parent as View).aspectRatio;
-    this.mesh.setWidthHeight(
-      this.width * Math.max(parentAspectRatio, 1.0),
-      this.height * Math.max(1.0 / parentAspectRatio, 1.0)
-    );
+    const layoutWidth = this.width * Math.max(parentAspectRatio, 1.0);
+    const layoutHeight = this.height * Math.max(1.0 / parentAspectRatio, 1.0);
+
+    const effectiveBorderWidth = this.useBorderlessShader
+      ? 0.0
+      : this.borderWidth;
+    const meshWidth = layoutWidth + effectiveBorderWidth;
+    const meshHeight = layoutHeight + effectiveBorderWidth;
+
+    const panelScale = Math.min(layoutWidth, layoutHeight);
+    this.mesh.scale.set(meshWidth / panelScale, meshHeight / panelScale, 1.0);
+
+    this.mesh.setWidthHeight(meshWidth, meshHeight);
     this.mesh.renderOrder = this.renderOrder;
   }
 

--- a/src/ui/core/PanelMesh.ts
+++ b/src/ui/core/PanelMesh.ts
@@ -29,9 +29,8 @@ export class PanelMesh extends THREE.Mesh<
    * Creates an instance of PanelMesh.
    * @param shader - Shader for the panel mesh.
    * @param backgroundColor - The background color as a CSS string.
-   * @param panelScale - The initial scale of the plane
    */
-  constructor(shader: Shader, backgroundColor?: string, panelScale = 1.0) {
+  constructor(shader: Shader, backgroundColor?: string) {
     // Each mesh needs its own unique set of uniforms.
     const uniforms = THREE.UniformsUtils.clone(shader.uniforms);
 
@@ -44,7 +43,7 @@ export class PanelMesh extends THREE.Mesh<
       side: THREE.DoubleSide,
     });
 
-    const geometry = new THREE.PlaneGeometry(panelScale, panelScale);
+    const geometry = new THREE.PlaneGeometry(1.0, 1.0);
 
     super(geometry, material);
 

--- a/src/ui/core/PanelOptions.ts
+++ b/src/ui/core/PanelOptions.ts
@@ -14,4 +14,5 @@ export type PanelOptions = ViewOptions & {
   showHighlights?: boolean;
   useDefaultPosition?: boolean;
   useBorderlessShader?: boolean;
+  borderWidth?: number;
 };

--- a/src/ui/shaders/SpatialPanelShader.ts
+++ b/src/ui/shaders/SpatialPanelShader.ts
@@ -108,10 +108,6 @@ export const SpatialPanelShader = {
     }
 
     void main(void) {
-      vec2 size = uBoxSize * 1000.0;
-      float radius = min(size.x, size.y) * (0.05 + uRadius);
-      vec2 half_size = 0.5 * size;
-
       // Distance to the outer edge of the round box in UV space (0-1)
       float distOuterUV = distRoundBox(vTexCoord * uBoxSize - uBoxSize * 0.5, uBoxSize * 0.5, uRadius);
 

--- a/src/ui/shaders/SquircleShader.ts
+++ b/src/ui/shaders/SquircleShader.ts
@@ -106,14 +106,12 @@ export const SquircleShader = {
       #include <alphatest_fragment>
       #include <alphahash_fragment>
       #include <specularmap_fragment>
-      vec2 size = uBoxSize * 1000.0;
 
-      // Calculates the adjusted radius based on box size.
-      float radius = min(size.x, size.y) * (0.05 + uRadius);
-      vec2 half_size = 0.5 * size;
+      // Compute the distance from the rounded box edge in meters.
+      float dist = distRoundBox(vUv * uBoxSize - uBoxSize * 0.5, uBoxSize * 0.5, uRadius);
 
-      // Compute the distance from the rounded box edge.
-      float dist = distRoundBox(vUv * size - half_size, half_size, radius);
+      // Antialiasing delta
+      float aa = fwidth(dist) * 0.8;
 
       // Use lerp for smooth color transition based on distance.
       vec4 colorInside = uBackgroundColor;
@@ -126,7 +124,7 @@ export const SquircleShader = {
       // Transparent black for outside.
       vec4 colorOutside = vec4(0.0, 0.0, 0.0, 0.0);
 
-      vec4 finalColor = mix(colorInside, colorOutside, smoothstep(0.0, 1.0, dist));
+      vec4 finalColor = mix(colorInside, colorOutside, smoothstep(0.0, aa, dist));
 
       // Return premultiplied alpha.
       gl_FragColor = uOpacity * finalColor.a * vec4(finalColor.rgb, 1.0);

--- a/src/ux/DragManager.test.ts
+++ b/src/ux/DragManager.test.ts
@@ -1,0 +1,130 @@
+import {describe, it, expect, beforeEach} from 'vitest';
+import * as THREE from 'three';
+import {DragManager, Draggable, DragMode, HasDraggingMode} from './DragManager';
+import {Panel} from '../ui/core/Panel';
+import {Input} from '../input/Input';
+
+describe('DragManager edge dragging', () => {
+  let input: Input;
+  let camera: THREE.Camera;
+  let dragManager: DragManager;
+
+  beforeEach(() => {
+    input = new Input();
+    camera = new THREE.Camera();
+    dragManager = new DragManager();
+    dragManager.init({input, camera});
+  });
+
+  it('allows dragging panel from edge, but prevents dragging from center or child views', () => {
+    // A standard draggable panel uses useBorderlessShader=false and panelScale=1.3 by default
+    const panel = new Panel({draggable: true});
+
+    // 1. Dragging from the edge of the panel should succeed
+    const edgeIntersection: THREE.Intersection = {
+      distance: 1,
+      point: new THREE.Vector3(0, 0, 0),
+      object: panel.mesh,
+      uv: new THREE.Vector2(0.02, 0.5), // on the left edge (outside margins)
+    };
+    const controller = new THREE.Object3D();
+
+    let result = dragManager.beginDragging(edgeIntersection, controller);
+    expect(result).toBe(true);
+    dragManager.onSelectEnd();
+
+    // 2. Dragging from the center of the panel background should fail
+    const centerIntersection: THREE.Intersection = {
+      distance: 1,
+      point: new THREE.Vector3(0, 0, 0),
+      object: panel.mesh,
+      uv: new THREE.Vector2(0.5, 0.5), // center (inside [0.1154, 0.8846])
+    };
+    result = dragManager.beginDragging(centerIntersection, controller);
+    expect(result).toBe(false);
+
+    // 3. Dragging from a child view / button should fail
+    const childMesh = new THREE.Mesh(new THREE.PlaneGeometry(0.1, 0.1));
+    panel.add(childMesh); // add as a child to the panel
+
+    const childIntersection: THREE.Intersection = {
+      distance: 1,
+      point: new THREE.Vector3(0, 0, 0),
+      object: childMesh,
+      uv: new THREE.Vector2(0.5, 0.5),
+    };
+    result = dragManager.beginDragging(childIntersection, controller);
+    expect(result).toBe(false);
+  });
+
+  it('allows dragging from anywhere on borderless draggable panels', () => {
+    const borderlessPanel = new Panel({
+      draggable: true,
+      useBorderlessShader: true, // sets panelScale=1.0
+    });
+
+    const centerIntersection: THREE.Intersection = {
+      distance: 1,
+      point: new THREE.Vector3(0, 0, 0),
+      object: borderlessPanel.mesh,
+      uv: new THREE.Vector2(0.5, 0.5),
+    };
+    const controller = new THREE.Object3D();
+
+    const result = dragManager.beginDragging(centerIntersection, controller);
+    expect(result).toBe(true);
+  });
+
+  it('does not affect dragging on non-panel objects', () => {
+    // Create a generic draggable object
+    const genericDraggable = new THREE.Object3D() as Draggable;
+    genericDraggable.draggable = true;
+    (genericDraggable as unknown as HasDraggingMode).draggingMode =
+      DragMode.TRANSLATING;
+
+    const childMesh = new THREE.Mesh(new THREE.PlaneGeometry(1, 1));
+    genericDraggable.add(childMesh);
+
+    const intersection: THREE.Intersection = {
+      distance: 1,
+      point: new THREE.Vector3(0, 0, 0),
+      object: childMesh,
+    };
+    const controller = new THREE.Object3D();
+
+    const result = dragManager.beginDragging(intersection, controller);
+    expect(result).toBe(true);
+  });
+
+  it('respects custom borderWidth values', () => {
+    // Custom border width = 0.2m
+    const panel = new Panel({draggable: true, borderWidth: 0.2});
+
+    // layoutWidth = 1.024, layoutHeight = 0.720
+    // meshWidth = 1.224, meshHeight = 0.920
+    // UV margin in X: (0.2 / 2) / 1.224 ≈ 0.0817
+
+    // uv.x = 0.06 is within the 0.0817 margin, so it should drag
+    const edgeIntersection: THREE.Intersection = {
+      distance: 1,
+      point: new THREE.Vector3(0, 0, 0),
+      object: panel.mesh,
+      uv: new THREE.Vector2(0.06, 0.5),
+    };
+    const controller = new THREE.Object3D();
+
+    let result = dragManager.beginDragging(edgeIntersection, controller);
+    expect(result).toBe(true);
+    dragManager.onSelectEnd();
+
+    // uv.x = 0.10 is outside the 0.0817 margin, so it should fail to drag
+    const innerIntersection: THREE.Intersection = {
+      distance: 1,
+      point: new THREE.Vector3(0, 0, 0),
+      object: panel.mesh,
+      uv: new THREE.Vector2(0.1, 0.5),
+    };
+    result = dragManager.beginDragging(innerIntersection, controller);
+    expect(result).toBe(false);
+  });
+});

--- a/src/ux/DragManager.ts
+++ b/src/ux/DragManager.ts
@@ -15,6 +15,8 @@ export interface Draggable extends THREE.Object3D {
   // Whether to continuously face the camera as the user drags.
   // If unspecified, defaults to false.
   dragFacingCamera?: boolean;
+  // Dynamic check to determine if dragging should begin on this object.
+  canDrag?: (intersection: THREE.Intersection) => boolean;
 }
 
 export enum DragMode {
@@ -87,6 +89,9 @@ export class DragManager extends Script {
       draggingMode == null ||
       draggingMode == DragManager.DO_NOT_DRAG
     ) {
+      return false;
+    }
+    if (draggableObject.canDrag && !draggableObject.canDrag(intersection)) {
       return false;
     }
     if (this.mode != DragManager.IDLE) {


### PR DESCRIPTION
- Added `canDrag(intersection)` optional hook on the `Draggable` interface.
- Integrated `canDrag` in `DragManager.beginDragging` to prevent dragging from panel center, child elements, or non-border regions.
- Replaced percentage-based `panelScale` with absolute `borderWidth` (in meters) configurable via `PanelOptions`.
- Implemented `Panel.canDrag` using physical borders in UV space.
- Modified `PanelMesh` to use a unit square `PlaneGeometry(1, 1)` and scaled it dynamically in `Panel.updateLayout`.
- Updated `SquircleShader` to use absolute physical dimensions and `fwidth` for resolution-independent antialiasing, unifying corner radius with `SpatialPanelShader`.
- Fixed child panel relative sizes and weights in `samples/ui/index.html` to prevent overflow of parent borders.
- Added comprehensive unit tests in `src/ux/DragManager.test.ts` for all dragging edge cases.

<img width="2734" height="1966" alt="image" src="https://github.com/user-attachments/assets/89c1e662-0062-48d6-ab8b-a532b89b0e8e" />
