### PR TITLE
ci: split tests into their own workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Build Check
+name: Test
 
 on:
   push:
@@ -6,17 +6,15 @@ on:
       - 'build'
     paths:
       - 'src/**'
-      - 'demos/**/*.ts'
-      - 'samples/**/*.ts'
       - 'package.json'
       - 'package-lock.json'
       - 'tsconfig*.json'
-      - 'rollup.config.js'
-      - '.github/workflows/build-check.yml'
+      - 'vitest.config.ts'
+      - '.github/workflows/test.yml'
   pull_request:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:
@@ -40,5 +38,5 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: Build project
-        run: npm run build
+      - name: Run tests
+        run: npm run test


### PR DESCRIPTION
tests already run in ci but they're buried in build-check.yml as a `Run tests` step after the build. so if the build fails the tests never run, and a test failure just shows up under the "Build Check" check with no separate signal.

pulled them into their own `test.yml` ("Test"). same node 24 + npm cache setup as the others, runs `npm run test`. build-check now just builds, and i moved the `vitest.config.ts` path trigger over to the test workflow where it belongs.

`pull_request:` has no path filter so Test runs on every PR push, same as the existing workflows.
