### PR TITLE
video: set willReadFrequently on the snapshot canvas

### DIFF
--- a/src/video/VideoStream.ts
+++ b/src/video/VideoStream.ts
@@ -230,7 +230,7 @@ export class VideoStream<
         this.canvas_.width = width;
         this.canvas_.height = height;
         this.context_ = this.canvas_.getContext('2d', {
-          willCaptureFrequently: this.willCaptureFrequently_,
+          willReadFrequently: this.willCaptureFrequently_,
         }) as CanvasRenderingContext2D;
       }
 


### PR DESCRIPTION
the snapshot canvas requested `willCaptureFrequently`, which isn't a canvas 2d context attribute, so it was silently ignored and chrome kept warning that repeated `getImageData` would be faster with `willReadFrequently`.

just fixes the key to `willReadFrequently`. the device camera already passes `willCaptureFrequently: true`, so frequent snapshot readbacks now actually get the hint.

(same 1-liner is also in #416 since the agent_hands room scan tripped the warning; this pulls it out as the standalone sdk fix, #416 dedupes on rebase.)
