### PR TITLE
core: request world-sensing features as optional instead of required

### DIFF
--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -332,14 +332,13 @@ export class Core {
     }
 
     const webXRRequiredFeatures: string[] = options.webxrRequiredFeatures;
+    const webXROptionalFeatures: string[] = options.webxrOptionalFeatures;
     // Use camera-access when the browser supports it.
     if (options.deviceCamera?.enabled) {
-      if (!this.webXRSettings.optionalFeatures) {
-        this.webXRSettings.optionalFeatures = [];
-      }
-      (this.webXRSettings.optionalFeatures as string[]).push('camera-access');
+      webXROptionalFeatures.push('camera-access');
     }
     this.webXRSettings.requiredFeatures = webXRRequiredFeatures;
+    this.webXRSettings.optionalFeatures = webXROptionalFeatures;
     // Sets up depth.
     if (options.depth.enabled) {
       webXRRequiredFeatures.push('depth-sensing');
@@ -369,16 +368,19 @@ export class Core {
         this.registry.register(this.gestureRecognition);
       }
     }
+    // World-sensing and lighting features are requested as optional so that
+    // browsers lacking one of them still enter the immersive session instead
+    // of rejecting it outright; the subsystems no-op when the data is absent.
     if (options.world.planes.enabled) {
-      webXRRequiredFeatures.push('plane-detection');
+      webXROptionalFeatures.push('plane-detection');
     }
     if (options.world.meshes.enabled) {
-      webXRRequiredFeatures.push('mesh-detection');
+      webXROptionalFeatures.push('mesh-detection');
     }
 
     // Sets up lighting.
     if (options.lighting.enabled) {
-      webXRRequiredFeatures.push('light-estimation');
+      webXROptionalFeatures.push('light-estimation');
       this.lighting = new Lighting();
       this.lighting.init(
         options.lighting,

--- a/src/core/Options.ts
+++ b/src/core/Options.ts
@@ -107,6 +107,11 @@ export class Options {
    */
   webxrRequiredFeatures: string[] = [];
 
+  /**
+   * Any additional optional features when initializing webxr.
+   */
+  webxrOptionalFeatures: string[] = [];
+
   // "local-floor" sets the scene origin at the user's feet,
   // "local" sets the scene origin near their head.
   referenceSpaceType: XRReferenceSpaceType = 'local-floor';


### PR DESCRIPTION
## Problem

When `options.world.planes`, `options.world.meshes`, or `options.lighting` are enabled, `Core` pushes `plane-detection` / `mesh-detection` / `light-estimation` into `requiredFeatures` of the immersive session request.

On browsers that do not support one of these features (e.g. `light-estimation` on standalone headset browsers, or `plane-detection` behind a flag on some devices), `requestSession('immersive-ar')` is rejected entirely — the Enter XR button silently does nothing, even though the app could run fine without the feature.

## Change

Request these three world-sensing features via `optionalFeatures` instead, following the existing pattern used for `camera-access` a few lines above.

No behavior change on devices that support the features. On devices that don't, the session now starts and the subsystems degrade gracefully — they already handle absent data:

- `PlaneDetector.update()` bails out when `frame.detectedPlanes` is missing
- `MeshDetector` bails out when the frame mesh collection is missing
- `Lighting` (`XREstimatedLight`) simply never receives `estimationstart`

`depth-sensing`, `local-floor`, and `hand-tracking` intentionally stay required — apps enabling them typically cannot run meaningfully without them.

## Testing

- `npm run build` and `tsc --noEmit` are clean
- `npm test` matches `main` (the 13 pre-existing failures in the gamepad-bindings suite are unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)