### PR TITLE
Simulator Hand Reach Limit

### DIFF
--- a/skills/xb-simulator/SKILL.md
+++ b/skills/xb-simulator/SKILL.md
@@ -50,6 +50,20 @@ options.simulator.defaultMode = xb.SimulatorMode.POSE; // pose hands (great for 
 controllers — see [`src/simulator/SimulatorOptions.ts`](../../src/simulator/SimulatorOptions.ts)
 and `src/simulator/controlModes/`.
 
+## Reach limits
+
+You can limit how far each virtual hand controller can travel from the user's shoulder origin (in meters) and restrict their movement to an angular cone (in radians) facing forward from the camera:
+
+```js
+options.simulator.reachDistance.enabled = true;
+options.simulator.reachDistance.radius = 0.75; // meters from shoulder origin
+options.simulator.reachDistance.leftHandOrigin = {x: -0.2, y: -0.2, z: 0};
+options.simulator.reachDistance.rightHandOrigin = {x: 0.2, y: -0.2, z: 0};
+
+options.simulator.reachAngle.enabled = true;
+options.simulator.reachAngle.angle = Math.PI; // radians (default Math.PI is a front hemisphere)
+```
+
 ## Lifecycle
 
 `onSimulatorStarted()` fires when the simulator boots — a common pattern is to mirror your XR

--- a/src/simulator/Simulator.ts
+++ b/src/simulator/Simulator.ts
@@ -9,7 +9,6 @@ import {Options} from '../core/Options';
 import {Script} from '../core/Script';
 import {Depth} from '../depth/Depth';
 import {Input} from '../input/Input';
-import {Handedness} from '../input/Hands';
 
 import {SimulatorCamera} from './SimulatorCamera';
 import {AVERAGE_IPD_METERS, SimulatorRenderMode} from './SimulatorConstants';
@@ -306,25 +305,5 @@ export class Simulator extends Script {
     }
     this.renderer.render(this.simulatorScene, camera);
     this.renderer.clearDepth();
-  }
-
-  isReachable(
-    object: THREE.Object3D | THREE.Vector3,
-    handIndex?: Handedness
-  ): boolean {
-    if (!this.options?.reachDistance?.enabled) {
-      return true;
-    }
-    const pos = object instanceof THREE.Vector3 ? object : object.position;
-    const radius = this.options.reachDistance.radius;
-    const leftDist = pos.distanceTo(this.hands.leftController.position);
-    const rightDist = pos.distanceTo(this.hands.rightController.position);
-
-    if (handIndex === Handedness.LEFT) {
-      return leftDist <= radius;
-    } else if (handIndex === Handedness.RIGHT) {
-      return rightDist <= radius;
-    }
-    return leftDist <= radius || rightDist <= radius;
   }
 }

--- a/src/simulator/Simulator.ts
+++ b/src/simulator/Simulator.ts
@@ -9,6 +9,7 @@ import {Options} from '../core/Options';
 import {Script} from '../core/Script';
 import {Depth} from '../depth/Depth';
 import {Input} from '../input/Input';
+import {Handedness} from '../input/Hands';
 
 import {SimulatorCamera} from './SimulatorCamera';
 import {AVERAGE_IPD_METERS, SimulatorRenderMode} from './SimulatorConstants';
@@ -305,5 +306,25 @@ export class Simulator extends Script {
     }
     this.renderer.render(this.simulatorScene, camera);
     this.renderer.clearDepth();
+  }
+
+  isReachable(
+    object: THREE.Object3D | THREE.Vector3,
+    handIndex?: Handedness
+  ): boolean {
+    if (!this.options?.reachDistance?.enabled) {
+      return true;
+    }
+    const pos = object instanceof THREE.Vector3 ? object : object.position;
+    const radius = this.options.reachDistance.radius;
+    const leftDist = pos.distanceTo(this.hands.leftController.position);
+    const rightDist = pos.distanceTo(this.hands.rightController.position);
+
+    if (handIndex === Handedness.LEFT) {
+      return leftDist <= radius;
+    } else if (handIndex === Handedness.RIGHT) {
+      return rightDist <= radius;
+    }
+    return leftDist <= radius || rightDist <= radius;
   }
 }

--- a/src/simulator/SimulatorControls.ts
+++ b/src/simulator/SimulatorControls.ts
@@ -123,6 +123,7 @@ export class SimulatorControls {
         input,
         timer,
         domElement: renderer.domElement,
+        simulatorOptions,
       });
     }
     this.renderer = renderer;

--- a/src/simulator/SimulatorHands.ts
+++ b/src/simulator/SimulatorHands.ts
@@ -100,6 +100,8 @@ export class SimulatorHands {
   rightHandBones: THREE.Object3D[] = [];
   leftHandPose? = SimulatorHandPose.RELAXED;
   rightHandPose? = SimulatorHandPose.RELAXED;
+  leftHandAtMaxRange = false;
+  rightHandAtMaxRange = false;
   leftHandCurrentRotations = cloneHandPoseRotations(
     SIMULATOR_HAND_POSE_ROTATIONS[SimulatorHandPose.RELAXED]
   );

--- a/src/simulator/SimulatorOptions.ts
+++ b/src/simulator/SimulatorOptions.ts
@@ -92,6 +92,10 @@ export class SimulatorOptions {
     leftHandOrigin: {x: -0.2, y: -0.2, z: 0},
     rightHandOrigin: {x: 0.2, y: -0.2, z: 0},
   };
+  reachAngle = {
+    enabled: false,
+    angle: 180,
+  };
 
   constructor(options?: DeepReadonly<DeepPartial<SimulatorOptions>>) {
     deepMerge(this, options);

--- a/src/simulator/SimulatorOptions.ts
+++ b/src/simulator/SimulatorOptions.ts
@@ -86,6 +86,12 @@ export class SimulatorOptions {
   renderToRenderTexture = true;
   // Blending mode when rendering the virtual scene.
   blendingMode: 'normal' | 'screen' = 'normal';
+  reachDistance = {
+    enabled: false,
+    radius: 0.75,
+    leftHandOrigin: {x: -0.2, y: -0.2, z: 0},
+    rightHandOrigin: {x: 0.2, y: -0.2, z: 0},
+  };
 
   constructor(options?: DeepReadonly<DeepPartial<SimulatorOptions>>) {
     deepMerge(this, options);

--- a/src/simulator/SimulatorOptions.ts
+++ b/src/simulator/SimulatorOptions.ts
@@ -94,7 +94,7 @@ export class SimulatorOptions {
   };
   reachAngle = {
     enabled: false,
-    angle: 180,
+    angle: 180, // Degrees around camera vector direction.
   };
 
   constructor(options?: DeepReadonly<DeepPartial<SimulatorOptions>>) {

--- a/src/simulator/SimulatorOptions.ts
+++ b/src/simulator/SimulatorOptions.ts
@@ -86,15 +86,21 @@ export class SimulatorOptions {
   renderToRenderTexture = true;
   // Blending mode when rendering the virtual scene.
   blendingMode: 'normal' | 'screen' = 'normal';
+  /** Limits how far each hand controller can travel from the user's shoulder origin. */
   reachDistance = {
     enabled: false,
+    /** The maximum distance in meters a controller can move from its origin point. */
     radius: 0.75,
+    /** The shoulder/chest origin point for the left hand in local camera space. */
     leftHandOrigin: {x: -0.2, y: -0.2, z: 0},
+    /** The shoulder/chest origin point for the right hand in local camera space. */
     rightHandOrigin: {x: 0.2, y: -0.2, z: 0},
   };
+  /** Limits the angular cone in front of the user within which controllers can move. */
   reachAngle = {
     enabled: false,
-    angle: 180, // Degrees around camera vector direction.
+    /** The maximum full cone angle in radians around the camera's forward direction (default is Math.PI, a front hemisphere). */
+    angle: Math.PI,
   };
 
   constructor(options?: DeepReadonly<DeepPartial<SimulatorOptions>>) {

--- a/src/simulator/controlModes/SimulatorControlMode.ts
+++ b/src/simulator/controlModes/SimulatorControlMode.ts
@@ -198,10 +198,19 @@ export class SimulatorControlMode {
         vector3.set(originObj.x, originObj.y, originObj.z);
         const localPos =
           this.simulatorControllerState.localControllerPositions[i];
-        if (localPos.distanceTo(vector3) > radius) {
+        const dist = localPos.distanceTo(vector3);
+        if (i === 0) {
+          this.hands.leftHandAtMaxRange = dist >= radius;
+        } else {
+          this.hands.rightHandAtMaxRange = dist >= radius;
+        }
+        if (dist > radius) {
           localPos.sub(vector3).clampLength(0, radius).add(vector3);
         }
       }
+    } else {
+      this.hands.leftHandAtMaxRange = false;
+      this.hands.rightHandAtMaxRange = false;
     }
     this.camera.updateMatrixWorld();
     for (let i = 0; i < 2 && i < this.input.controllers.length; i++) {

--- a/src/simulator/controlModes/SimulatorControlMode.ts
+++ b/src/simulator/controlModes/SimulatorControlMode.ts
@@ -7,6 +7,7 @@ import {SimulatorRenderMode} from '../SimulatorConstants';
 import {SimulatorControllerState} from '../SimulatorControllerState';
 import {SimulatorHands} from '../SimulatorHands.js';
 import {SimulatorHandPose} from '../handPoses/HandPoses';
+import {SimulatorOptions} from '../SimulatorOptions';
 
 const {A_CODE, D_CODE, E_CODE, Q_CODE, S_CODE, W_CODE} = Keycodes;
 const vector3 = new THREE.Vector3();
@@ -18,6 +19,7 @@ export class SimulatorControlMode {
   input!: Input;
   timer!: THREE.Timer;
   domElement?: HTMLCanvasElement;
+  simulatorOptions?: SimulatorOptions;
 
   /**
    * Create a SimulatorControlMode
@@ -39,16 +41,19 @@ export class SimulatorControlMode {
     input,
     timer,
     domElement,
+    simulatorOptions,
   }: {
     camera: THREE.Camera;
     input: Input;
     timer: THREE.Timer;
     domElement?: HTMLCanvasElement;
+    simulatorOptions?: SimulatorOptions;
   }) {
     this.camera = camera;
     this.input = input;
     this.timer = timer;
     this.domElement = domElement;
+    this.simulatorOptions = simulatorOptions;
     input.gamepadController.init({camera});
   }
 
@@ -185,6 +190,19 @@ export class SimulatorControlMode {
   }
 
   updateControllerPositions() {
+    if (this.simulatorOptions?.reachDistance.enabled) {
+      const {radius, leftHandOrigin, rightHandOrigin} =
+        this.simulatorOptions.reachDistance;
+      for (let i = 0; i < 2; i++) {
+        const originObj = i === 0 ? leftHandOrigin : rightHandOrigin;
+        vector3.set(originObj.x, originObj.y, originObj.z);
+        const localPos =
+          this.simulatorControllerState.localControllerPositions[i];
+        if (localPos.distanceTo(vector3) > radius) {
+          localPos.sub(vector3).clampLength(0, radius).add(vector3);
+        }
+      }
+    }
     this.camera.updateMatrixWorld();
     for (let i = 0; i < 2 && i < this.input.controllers.length; i++) {
       const controller = this.input.controllers[i];

--- a/src/simulator/controlModes/SimulatorControlMode.ts
+++ b/src/simulator/controlModes/SimulatorControlMode.ts
@@ -11,6 +11,9 @@ import {SimulatorOptions} from '../SimulatorOptions';
 
 const {A_CODE, D_CODE, E_CODE, Q_CODE, S_CODE, W_CODE} = Keycodes;
 const vector3 = new THREE.Vector3();
+const forwardVec = new THREE.Vector3(0, 0, -1);
+const offsetVec = new THREE.Vector3();
+const axisVec = new THREE.Vector3();
 const euler = new THREE.Euler();
 const HAND_POSES = Object.values(SimulatorHandPose);
 
@@ -190,23 +193,42 @@ export class SimulatorControlMode {
   }
 
   updateControllerPositions() {
-    if (this.simulatorOptions?.reachDistance.enabled) {
+    const distanceEnabled = !!this.simulatorOptions?.reachDistance.enabled;
+    const angleEnabled = !!this.simulatorOptions?.reachAngle.enabled;
+    if (distanceEnabled || angleEnabled) {
       const {radius, leftHandOrigin, rightHandOrigin} =
-        this.simulatorOptions.reachDistance;
+        this.simulatorOptions!.reachDistance;
+      const angle = this.simulatorOptions!.reachAngle.angle;
+      const maxAngleRad = THREE.MathUtils.degToRad(angle / 2);
       for (let i = 0; i < 2; i++) {
         const originObj = i === 0 ? leftHandOrigin : rightHandOrigin;
         vector3.set(originObj.x, originObj.y, originObj.z);
         const localPos =
           this.simulatorControllerState.localControllerPositions[i];
-        const dist = localPos.distanceTo(vector3);
+        offsetVec.copy(localPos).sub(vector3);
+        const dist = offsetVec.length();
+        const angleToForward = offsetVec.angleTo(forwardVec);
+        const atAngleLimit = angleEnabled && angleToForward >= maxAngleRad;
+        const atRadiusLimit = distanceEnabled && dist >= radius;
+        const atMax = atRadiusLimit || atAngleLimit;
         if (i === 0) {
-          this.hands.leftHandAtMaxRange = dist >= radius;
+          this.hands.leftHandAtMaxRange = atMax;
         } else {
-          this.hands.rightHandAtMaxRange = dist >= radius;
+          this.hands.rightHandAtMaxRange = atMax;
         }
-        if (dist > radius) {
-          localPos.sub(vector3).clampLength(0, radius).add(vector3);
+        if (angleEnabled && angleToForward > maxAngleRad) {
+          axisVec.copy(offsetVec).cross(forwardVec);
+          if (axisVec.lengthSq() < 1e-6) {
+            axisVec.set(0, 1, 0);
+          } else {
+            axisVec.normalize();
+          }
+          offsetVec.applyAxisAngle(axisVec, angleToForward - maxAngleRad);
         }
+        if (distanceEnabled && offsetVec.length() > radius) {
+          offsetVec.clampLength(0, radius);
+        }
+        localPos.copy(vector3).add(offsetVec);
       }
     } else {
       this.hands.leftHandAtMaxRange = false;

--- a/src/simulator/controlModes/SimulatorControlMode.ts
+++ b/src/simulator/controlModes/SimulatorControlMode.ts
@@ -227,7 +227,10 @@ export class SimulatorControlMode {
     if (angleOpt.enabled) {
       const maxAngle = THREE.MathUtils.degToRad(angleOpt.angle * 0.5);
       const curAngle = currentOffsetVec.angleTo(forwardVec);
-      if (curAngle >= maxAngle && newOffsetVec.angleTo(forwardVec) >= curAngle) {
+      if (
+        curAngle >= maxAngle &&
+        newOffsetVec.angleTo(forwardVec) >= curAngle
+      ) {
         delta.set(0, 0, 0);
       }
     }
@@ -252,7 +255,8 @@ export class SimulatorControlMode {
         const dist = offsetVec.length();
         const angle = offsetVec.angleTo(forwardVec);
         const atMax =
-          (distEnabled && dist >= radius) || (angleEnabled && angle >= maxAngle);
+          (distEnabled && dist >= radius) ||
+          (angleEnabled && angle >= maxAngle);
         if (i === 0) {
           this.hands.leftHandAtMaxRange = atMax;
         } else {

--- a/src/simulator/controlModes/SimulatorControlMode.ts
+++ b/src/simulator/controlModes/SimulatorControlMode.ts
@@ -11,9 +11,12 @@ import {SimulatorOptions} from '../SimulatorOptions';
 
 const {A_CODE, D_CODE, E_CODE, Q_CODE, S_CODE, W_CODE} = Keycodes;
 const vector3 = new THREE.Vector3();
+const originVec = new THREE.Vector3();
 const forwardVec = new THREE.Vector3(0, 0, -1);
 const offsetVec = new THREE.Vector3();
 const axisVec = new THREE.Vector3();
+const currentOffsetVec = new THREE.Vector3();
+const newOffsetVec = new THREE.Vector3();
 const euler = new THREE.Euler();
 const HAND_POSES = Object.values(SimulatorHandPose);
 
@@ -192,43 +195,83 @@ export class SimulatorControlMode {
     }
   }
 
+  private getHandOrigin(idx: number, target: THREE.Vector3): boolean {
+    const distOpt = this.simulatorOptions?.reachDistance;
+    const angleOpt = this.simulatorOptions?.reachAngle;
+    if (!distOpt?.enabled && !angleOpt?.enabled) return false;
+    const originObj =
+      idx === 0 ? distOpt!.leftHandOrigin : distOpt!.rightHandOrigin;
+    target.set(originObj.x, originObj.y, originObj.z);
+    return true;
+  }
+
+  limitMovementAtReachEdge(
+    idx: number,
+    localPos: THREE.Vector3,
+    delta: THREE.Vector3
+  ) {
+    if (!this.getHandOrigin(idx, originVec)) return;
+    const distOpt = this.simulatorOptions!.reachDistance;
+    const angleOpt = this.simulatorOptions!.reachAngle;
+    currentOffsetVec.copy(localPos).sub(originVec);
+    newOffsetVec.copy(currentOffsetVec).add(delta);
+
+    if (distOpt.enabled) {
+      const curDistSq = currentOffsetVec.lengthSq();
+      const radSq = distOpt.radius * distOpt.radius;
+      if (curDistSq >= radSq && newOffsetVec.lengthSq() >= curDistSq) {
+        delta.set(0, 0, 0);
+        return;
+      }
+    }
+    if (angleOpt.enabled) {
+      const maxAngle = THREE.MathUtils.degToRad(angleOpt.angle * 0.5);
+      const curAngle = currentOffsetVec.angleTo(forwardVec);
+      if (curAngle >= maxAngle && newOffsetVec.angleTo(forwardVec) >= curAngle) {
+        delta.set(0, 0, 0);
+      }
+    }
+  }
+
   updateControllerPositions() {
-    const distanceEnabled = !!this.simulatorOptions?.reachDistance.enabled;
-    const angleEnabled = !!this.simulatorOptions?.reachAngle.enabled;
-    if (distanceEnabled || angleEnabled) {
-      const {radius, leftHandOrigin, rightHandOrigin} =
-        this.simulatorOptions!.reachDistance;
-      const angle = this.simulatorOptions!.reachAngle.angle;
-      const maxAngleRad = THREE.MathUtils.degToRad(angle / 2);
+    const distOpt = this.simulatorOptions?.reachDistance;
+    const angleOpt = this.simulatorOptions?.reachAngle;
+    const distEnabled = !!distOpt?.enabled;
+    const angleEnabled = !!angleOpt?.enabled;
+
+    if (distEnabled || angleEnabled) {
+      const radius = distOpt!.radius;
+      const maxAngle = THREE.MathUtils.degToRad(angleOpt!.angle * 0.5);
+
       for (let i = 0; i < 2; i++) {
-        const originObj = i === 0 ? leftHandOrigin : rightHandOrigin;
-        vector3.set(originObj.x, originObj.y, originObj.z);
+        this.getHandOrigin(i, originVec);
         const localPos =
           this.simulatorControllerState.localControllerPositions[i];
-        offsetVec.copy(localPos).sub(vector3);
+        offsetVec.copy(localPos).sub(originVec);
+
         const dist = offsetVec.length();
-        const angleToForward = offsetVec.angleTo(forwardVec);
-        const atAngleLimit = angleEnabled && angleToForward >= maxAngleRad;
-        const atRadiusLimit = distanceEnabled && dist >= radius;
-        const atMax = atRadiusLimit || atAngleLimit;
+        const angle = offsetVec.angleTo(forwardVec);
+        const atMax =
+          (distEnabled && dist >= radius) || (angleEnabled && angle >= maxAngle);
         if (i === 0) {
           this.hands.leftHandAtMaxRange = atMax;
         } else {
           this.hands.rightHandAtMaxRange = atMax;
         }
-        if (angleEnabled && angleToForward > maxAngleRad) {
+
+        if (angleEnabled && angle > maxAngle) {
           axisVec.copy(offsetVec).cross(forwardVec);
           if (axisVec.lengthSq() < 1e-6) {
             axisVec.set(0, 1, 0);
           } else {
             axisVec.normalize();
           }
-          offsetVec.applyAxisAngle(axisVec, angleToForward - maxAngleRad);
+          offsetVec.applyAxisAngle(axisVec, angle - maxAngle);
         }
-        if (distanceEnabled && offsetVec.length() > radius) {
+        if (distEnabled && offsetVec.lengthSq() > radius * radius) {
           offsetVec.clampLength(0, radius);
         }
-        localPos.copy(vector3).add(offsetVec);
+        localPos.copy(originVec).add(offsetVec);
       }
     } else {
       this.hands.leftHandAtMaxRange = false;

--- a/src/simulator/controlModes/SimulatorControlMode.ts
+++ b/src/simulator/controlModes/SimulatorControlMode.ts
@@ -225,7 +225,7 @@ export class SimulatorControlMode {
       }
     }
     if (angleOpt.enabled) {
-      const maxAngle = THREE.MathUtils.degToRad(angleOpt.angle * 0.5);
+      const maxAngle = angleOpt.angle * 0.5;
       const curAngle = currentOffsetVec.angleTo(forwardVec);
       if (
         curAngle >= maxAngle &&
@@ -244,7 +244,7 @@ export class SimulatorControlMode {
 
     if (distEnabled || angleEnabled) {
       const radius = distOpt!.radius;
-      const maxAngle = THREE.MathUtils.degToRad(angleOpt!.angle * 0.5);
+      const maxAngle = angleOpt!.angle * 0.5;
 
       for (let i = 0; i < 2; i++) {
         this.getHandOrigin(i, originVec);

--- a/src/simulator/controlModes/SimulatorControllerMode.ts
+++ b/src/simulator/controlModes/SimulatorControllerMode.ts
@@ -6,6 +6,9 @@ import {SimulatorControlMode} from './SimulatorControlMode';
 
 const vector3 = new THREE.Vector3();
 const originVec = new THREE.Vector3();
+const forwardVec = new THREE.Vector3(0, 0, -1);
+const currentOffsetVec = new THREE.Vector3();
+const newOffsetVec = new THREE.Vector3();
 const {A_CODE, D_CODE, E_CODE, Q_CODE, S_CODE, SPACE_CODE, T_CODE, W_CODE} =
   Keycodes;
 
@@ -42,14 +45,26 @@ export class SimulatorControllerMode extends SimulatorControlMode {
         Number(downKeys.has(S_CODE)) - Number(downKeys.has(W_CODE))
       )
       .multiplyScalar(deltaTime);
-    if (this.simulatorOptions?.reachDistance.enabled) {
+    const distanceEnabled = !!this.simulatorOptions?.reachDistance.enabled;
+    const angleEnabled = !!this.simulatorOptions?.reachAngle.enabled;
+    if (distanceEnabled || angleEnabled) {
       const {radius, leftHandOrigin, rightHandOrigin} =
-        this.simulatorOptions.reachDistance;
+        this.simulatorOptions!.reachDistance;
+      const angle = this.simulatorOptions!.reachAngle.angle;
       const originObj = idx === 0 ? leftHandOrigin : rightHandOrigin;
       originVec.set(originObj.x, originObj.y, originObj.z);
-      const currentDist = localPos.distanceTo(originVec);
-      const newDist = localPos.clone().add(vector3).distanceTo(originVec);
-      if (currentDist >= radius && newDist >= currentDist) {
+      currentOffsetVec.copy(localPos).sub(originVec);
+      newOffsetVec.copy(currentOffsetVec).add(vector3);
+      const currentDist = currentOffsetVec.length();
+      const newDist = newOffsetVec.length();
+      const currentAngle = currentOffsetVec.angleTo(forwardVec);
+      const newAngle = newOffsetVec.angleTo(forwardVec);
+      const maxAngleRad = THREE.MathUtils.degToRad(angle / 2);
+      const atRadiusEdge =
+        distanceEnabled && currentDist >= radius && newDist >= currentDist;
+      const atAngleEdge =
+        angleEnabled && currentAngle >= maxAngleRad && newAngle >= currentAngle;
+      if (atRadiusEdge || atAngleEdge) {
         vector3.set(0, 0, 0);
       }
     }
@@ -64,14 +79,28 @@ export class SimulatorControllerMode extends SimulatorControlMode {
       const downVal = gp.getButtonValue(gp.bindings.getBinding('moveDown'));
       const upVal = gp.getButtonValue(gp.bindings.getBinding('moveUp'));
       vector3.set(lx, upVal - downVal, ly).multiplyScalar(deltaTime);
-      if (this.simulatorOptions?.reachDistance.enabled) {
+      const distanceEnabled = !!this.simulatorOptions?.reachDistance.enabled;
+      const angleEnabled = !!this.simulatorOptions?.reachAngle.enabled;
+      if (distanceEnabled || angleEnabled) {
         const {radius, leftHandOrigin, rightHandOrigin} =
-          this.simulatorOptions.reachDistance;
+          this.simulatorOptions!.reachDistance;
+        const angle = this.simulatorOptions!.reachAngle.angle;
         const originObj = idx === 0 ? leftHandOrigin : rightHandOrigin;
         originVec.set(originObj.x, originObj.y, originObj.z);
-        const currentDist = localPos.distanceTo(originVec);
-        const newDist = localPos.clone().add(vector3).distanceTo(originVec);
-        if (currentDist >= radius && newDist >= currentDist) {
+        currentOffsetVec.copy(localPos).sub(originVec);
+        newOffsetVec.copy(currentOffsetVec).add(vector3);
+        const currentDist = currentOffsetVec.length();
+        const newDist = newOffsetVec.length();
+        const currentAngle = currentOffsetVec.angleTo(forwardVec);
+        const newAngle = newOffsetVec.angleTo(forwardVec);
+        const maxAngleRad = THREE.MathUtils.degToRad(angle / 2);
+        const atRadiusEdge =
+          distanceEnabled && currentDist >= radius && newDist >= currentDist;
+        const atAngleEdge =
+          angleEnabled &&
+          currentAngle >= maxAngleRad &&
+          newAngle >= currentAngle;
+        if (atRadiusEdge || atAngleEdge) {
           vector3.set(0, 0, 0);
         }
       }

--- a/src/simulator/controlModes/SimulatorControllerMode.ts
+++ b/src/simulator/controlModes/SimulatorControllerMode.ts
@@ -5,6 +5,7 @@ import {Keycodes} from '../../utils/Keycodes';
 import {SimulatorControlMode} from './SimulatorControlMode';
 
 const vector3 = new THREE.Vector3();
+const originVec = new THREE.Vector3();
 const {A_CODE, D_CODE, E_CODE, Q_CODE, S_CODE, SPACE_CODE, T_CODE, W_CODE} =
   Keycodes;
 
@@ -31,10 +32,9 @@ export class SimulatorControllerMode extends SimulatorControlMode {
   updateControllerPositions() {
     const deltaTime = this.timer.getDelta();
     const downKeys = this.downKeys;
+    const idx = this.simulatorControllerState.currentControllerIndex;
     const localPos =
-      this.simulatorControllerState.localControllerPositions[
-        this.simulatorControllerState.currentControllerIndex
-      ];
+      this.simulatorControllerState.localControllerPositions[idx];
     vector3
       .set(
         Number(downKeys.has(D_CODE)) - Number(downKeys.has(A_CODE)),
@@ -42,6 +42,17 @@ export class SimulatorControllerMode extends SimulatorControlMode {
         Number(downKeys.has(S_CODE)) - Number(downKeys.has(W_CODE))
       )
       .multiplyScalar(deltaTime);
+    if (this.simulatorOptions?.reachDistance.enabled) {
+      const {radius, leftHandOrigin, rightHandOrigin} =
+        this.simulatorOptions.reachDistance;
+      const originObj = idx === 0 ? leftHandOrigin : rightHandOrigin;
+      originVec.set(originObj.x, originObj.y, originObj.z);
+      const currentDist = localPos.distanceTo(originVec);
+      const newDist = localPos.clone().add(vector3).distanceTo(originVec);
+      if (currentDist >= radius && newDist >= currentDist) {
+        vector3.set(0, 0, 0);
+      }
+    }
     localPos.add(vector3);
 
     // Gamepad: left stick moves hand on XZ; configurable buttons on Y.
@@ -53,6 +64,17 @@ export class SimulatorControllerMode extends SimulatorControlMode {
       const downVal = gp.getButtonValue(gp.bindings.getBinding('moveDown'));
       const upVal = gp.getButtonValue(gp.bindings.getBinding('moveUp'));
       vector3.set(lx, upVal - downVal, ly).multiplyScalar(deltaTime);
+      if (this.simulatorOptions?.reachDistance.enabled) {
+        const {radius, leftHandOrigin, rightHandOrigin} =
+          this.simulatorOptions.reachDistance;
+        const originObj = idx === 0 ? leftHandOrigin : rightHandOrigin;
+        originVec.set(originObj.x, originObj.y, originObj.z);
+        const currentDist = localPos.distanceTo(originVec);
+        const newDist = localPos.clone().add(vector3).distanceTo(originVec);
+        if (currentDist >= radius && newDist >= currentDist) {
+          vector3.set(0, 0, 0);
+        }
+      }
       localPos.add(vector3);
     }
 

--- a/src/simulator/controlModes/SimulatorControllerMode.ts
+++ b/src/simulator/controlModes/SimulatorControllerMode.ts
@@ -5,10 +5,6 @@ import {Keycodes} from '../../utils/Keycodes';
 import {SimulatorControlMode} from './SimulatorControlMode';
 
 const vector3 = new THREE.Vector3();
-const originVec = new THREE.Vector3();
-const forwardVec = new THREE.Vector3(0, 0, -1);
-const currentOffsetVec = new THREE.Vector3();
-const newOffsetVec = new THREE.Vector3();
 const {A_CODE, D_CODE, E_CODE, Q_CODE, S_CODE, SPACE_CODE, T_CODE, W_CODE} =
   Keycodes;
 
@@ -45,29 +41,7 @@ export class SimulatorControllerMode extends SimulatorControlMode {
         Number(downKeys.has(S_CODE)) - Number(downKeys.has(W_CODE))
       )
       .multiplyScalar(deltaTime);
-    const distanceEnabled = !!this.simulatorOptions?.reachDistance.enabled;
-    const angleEnabled = !!this.simulatorOptions?.reachAngle.enabled;
-    if (distanceEnabled || angleEnabled) {
-      const {radius, leftHandOrigin, rightHandOrigin} =
-        this.simulatorOptions!.reachDistance;
-      const angle = this.simulatorOptions!.reachAngle.angle;
-      const originObj = idx === 0 ? leftHandOrigin : rightHandOrigin;
-      originVec.set(originObj.x, originObj.y, originObj.z);
-      currentOffsetVec.copy(localPos).sub(originVec);
-      newOffsetVec.copy(currentOffsetVec).add(vector3);
-      const currentDist = currentOffsetVec.length();
-      const newDist = newOffsetVec.length();
-      const currentAngle = currentOffsetVec.angleTo(forwardVec);
-      const newAngle = newOffsetVec.angleTo(forwardVec);
-      const maxAngleRad = THREE.MathUtils.degToRad(angle / 2);
-      const atRadiusEdge =
-        distanceEnabled && currentDist >= radius && newDist >= currentDist;
-      const atAngleEdge =
-        angleEnabled && currentAngle >= maxAngleRad && newAngle >= currentAngle;
-      if (atRadiusEdge || atAngleEdge) {
-        vector3.set(0, 0, 0);
-      }
-    }
+    this.limitMovementAtReachEdge(idx, localPos, vector3);
     localPos.add(vector3);
 
     // Gamepad: left stick moves hand on XZ; configurable buttons on Y.
@@ -79,31 +53,7 @@ export class SimulatorControllerMode extends SimulatorControlMode {
       const downVal = gp.getButtonValue(gp.bindings.getBinding('moveDown'));
       const upVal = gp.getButtonValue(gp.bindings.getBinding('moveUp'));
       vector3.set(lx, upVal - downVal, ly).multiplyScalar(deltaTime);
-      const distanceEnabled = !!this.simulatorOptions?.reachDistance.enabled;
-      const angleEnabled = !!this.simulatorOptions?.reachAngle.enabled;
-      if (distanceEnabled || angleEnabled) {
-        const {radius, leftHandOrigin, rightHandOrigin} =
-          this.simulatorOptions!.reachDistance;
-        const angle = this.simulatorOptions!.reachAngle.angle;
-        const originObj = idx === 0 ? leftHandOrigin : rightHandOrigin;
-        originVec.set(originObj.x, originObj.y, originObj.z);
-        currentOffsetVec.copy(localPos).sub(originVec);
-        newOffsetVec.copy(currentOffsetVec).add(vector3);
-        const currentDist = currentOffsetVec.length();
-        const newDist = newOffsetVec.length();
-        const currentAngle = currentOffsetVec.angleTo(forwardVec);
-        const newAngle = newOffsetVec.angleTo(forwardVec);
-        const maxAngleRad = THREE.MathUtils.degToRad(angle / 2);
-        const atRadiusEdge =
-          distanceEnabled && currentDist >= radius && newDist >= currentDist;
-        const atAngleEdge =
-          angleEnabled &&
-          currentAngle >= maxAngleRad &&
-          newAngle >= currentAngle;
-        if (atRadiusEdge || atAngleEdge) {
-          vector3.set(0, 0, 0);
-        }
-      }
+      this.limitMovementAtReachEdge(idx, localPos, vector3);
       localPos.add(vector3);
     }
 


### PR DESCRIPTION
Added new configuration opens for the simulator to limit the hand reach length and the radius of reach.

- New origin points for the hands to simulate shoulders
- checks if hands in range and stops movement if not
- Reach angle checks angle in direction of camera to limit angle of movement
  - defaults to 180 degrees for a realistic shoulder angle range
