### PR TITLE
Added NavMesh Support to Simulator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,9 @@ XR Blocks is a **singleton engine driven by a script lifecycle**:
 - **Dependency injection over globals**: prefer `static dependencies = {...}` on a `Script`
   (resolved via `core.registry`) to reaching into singletons, so subsystems stay testable.
 - Keep PR diffs focused and add/adjust colocated tests for new branches.
+- Simulator navmesh navigation is opt-in. Use `options.simulator.navigation.enabled = true`
+  and an environment `navMeshPath` pointing to a pregenerated glTF/GLB walkable floor
+  surface; the simulator constrains the Simulator User, not hands/controllers.
 
 ## Adding a Feature / Subsystem
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,9 +100,10 @@ XR Blocks is a **singleton engine driven by a script lifecycle**:
 - **Dependency injection over globals**: prefer `static dependencies = {...}` on a `Script`
   (resolved via `core.registry`) to reaching into singletons, so subsystems stay testable.
 - Keep PR diffs focused and add/adjust colocated tests for new branches.
-- Simulator navmesh constraints are opt-in. Use `options.simulator.navMesh.enabled = true`
-  and an environment `navMeshPath` pointing to a pregenerated glTF/GLB walkable floor
-  surface; the simulator constrains the Simulator User, not hands/controllers.
+- Simulator navmesh constraints are opt-in. Use `options.simulator.navMesh.enabled = true`;
+  the default Living Room environment includes a pregenerated glTF/GLB `navMeshPath`.
+  Custom environments can provide their own walkable floor surface; the simulator
+  constrains the Simulator User, not hands/controllers.
 
 ## Adding a Feature / Subsystem
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ XR Blocks is a **singleton engine driven by a script lifecycle**:
 - **Dependency injection over globals**: prefer `static dependencies = {...}` on a `Script`
   (resolved via `core.registry`) to reaching into singletons, so subsystems stay testable.
 - Keep PR diffs focused and add/adjust colocated tests for new branches.
-- Simulator navmesh navigation is opt-in. Use `options.simulator.navigation.enabled = true`
+- Simulator navmesh constraints are opt-in. Use `options.simulator.navMesh.enabled = true`
   and an environment `navMeshPath` pointing to a pregenerated glTF/GLB walkable floor
   surface; the simulator constrains the Simulator User, not hands/controllers.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,6 +25,26 @@ and the full in-tree overview is [`src/SKILL.md`](src/SKILL.md).
 - **Units & colors.** World/position values are meters; UI sizes use meters or "layout
   pixels"/`fontSize`. Colors are hex strings (`'#ffffff'`) or `THREE.Color`.
 
+## Language
+
+**Simulator User**:
+The simulated person whose viewpoint is represented by the simulator camera. Navigation
+constraints apply to the Simulator User, not to simulated hands or controllers.
+_Avoid_: Camera-only actor, embodied action target
+
+**Simulator Navmesh**:
+A pregenerated walkable navigation surface for a simulator environment. When enabled, it
+constrains Simulator User navigation by clamping attempted movement to valid walkable space
+and represents the walkable floor surface used for grounding. It is authored in the same
+local coordinate space as the simulator scene and receives the same environment placement
+transform.
+_Avoid_: Movement bounds, collision mesh
+
+**`navMeshPath`**:
+The simulator environment field containing the URL/path of the pregenerated Simulator
+Navmesh sidecar asset.
+_Avoid_: navigationMeshPath, navmeshUrl, navMesh
+
 ## Core Pattern
 
 ```js

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ immersive applications with features like:
 - **Automation-Friendly Simulator:** Use `options.enableAutomationMode()` or
   `?xrAutomation=1` to start a desktop simulator preset for external remote runs.
 - **Constrained Simulator Navigation:** Opt into simulator navmesh grounding with
-  `options.simulator.navMesh.enabled = true` and an environment `navMeshPath`
-  pointing at a pregenerated glTF/GLB navmesh authored in the same local
+  `options.simulator.navMesh.enabled = true`. The default Living Room
+  environment includes a pregenerated glTF/GLB `navMeshPath`; custom
+  environments can provide their own navmesh authored in the same local
   coordinate space as the simulator scene.
 
 We welcome all contributors to foster an AI + XR community! Read our

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ immersive applications with features like:
   Chrome browsers.
 - **Automation-Friendly Simulator:** Use `options.enableAutomationMode()` or
   `?xrAutomation=1` to start a desktop simulator preset for external remote runs.
+- **Constrained Simulator Navigation:** Opt into simulator navmesh grounding with
+  `options.simulator.navigation.enabled = true` and an environment `navMeshPath`
+  pointing at a pregenerated glTF/GLB navmesh authored in the same local
+  coordinate space as the simulator scene.
 
 We welcome all contributors to foster an AI + XR community! Read our
 [blog post](https://research.google/blog/xr-blocks-accelerating-ai-xr-innovation/)
@@ -84,6 +88,7 @@ code below:
         "imports": {
           "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
           "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
+          "three-pathfinding": "https://cdn.jsdelivr.net/npm/three-pathfinding@1.3.0/dist/three-pathfinding.module.js",
           "xrblocks": "https://cdn.jsdelivr.net/gh/google/xrblocks@build/xrblocks.js",
           "xrblocks/addons/": "https://cdn.jsdelivr.net/gh/google/xrblocks@build/addons/"
         }

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ immersive applications with features like:
 - **Automation-Friendly Simulator:** Use `options.enableAutomationMode()` or
   `?xrAutomation=1` to start a desktop simulator preset for external remote runs.
 - **Constrained Simulator Navigation:** Opt into simulator navmesh grounding with
-  `options.simulator.navigation.enabled = true` and an environment `navMeshPath`
+  `options.simulator.navMesh.enabled = true` and an environment `navMeshPath`
   pointing at a pregenerated glTF/GLB navmesh authored in the same local
   coordinate space as the simulator scene.
 

--- a/demos/navmesh_simulator/index.html
+++ b/demos/navmesh_simulator/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Simulator Navmesh</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, user-scalable=no"
+    />
+    <meta
+      http-equiv="Cache-Control"
+      content="no-cache, no-store, must-revalidate"
+    />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <link type="text/css" rel="stylesheet" href="../../samples/main.css" />
+    <script>
+      window.litDisableBundleWarning = true;
+    </script>
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
+          "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
+          "three-mesh-bvh": "https://cdn.jsdelivr.net/npm/three-mesh-bvh@0.9.10/build/index.module.js",
+          "three-pathfinding": "https://cdn.jsdelivr.net/npm/three-pathfinding@1.3.0/dist/three-pathfinding.module.js",
+          "lit": "https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js",
+          "lit/": "https://esm.run/lit@3/",
+          "xrblocks": "../../build/xrblocks.js",
+          "xrblocks/addons/": "../../build/addons/"
+        }
+      }
+    </script>
+  </head>
+
+  <body>
+    <script type="module" src="main.js"></script>
+  </body>
+</html>

--- a/demos/navmesh_simulator/main.js
+++ b/demos/navmesh_simulator/main.js
@@ -11,39 +11,13 @@ const PATH_Y_OFFSET = 0.04;
 const NAVIGATION_SPEED_METERS_PER_SECOND = 1.2;
 const WAYPOINT_THRESHOLD_METERS = 0.08;
 
-const triangleA = new THREE.Vector3();
-const triangleB = new THREE.Vector3();
-const triangleC = new THREE.Vector3();
-const triangleAB = new THREE.Vector3();
-const triangleAC = new THREE.Vector3();
 const pathStart = new THREE.Vector3();
 const currentFootPosition = new THREE.Vector3();
 const desiredCameraPosition = new THREE.Vector3();
 const waypointDelta = new THREE.Vector3();
 const remainingPathStart = new THREE.Vector3();
 
-function triangleArea(a, b, c) {
-  triangleAB.subVectors(b, a);
-  triangleAC.subVectors(c, a);
-  return triangleAB.cross(triangleAC).length() * 0.5;
-}
-
-function sampleTriangle(a, b, c) {
-  let u = Math.random();
-  let v = Math.random();
-  if (u + v > 1) {
-    u = 1 - u;
-    v = 1 - v;
-  }
-  return new THREE.Vector3()
-    .copy(a)
-    .addScaledVector(triangleAB.subVectors(b, a), u)
-    .addScaledVector(triangleAC.subVectors(c, a), v);
-}
-
 class NavMeshWireframe extends xb.Script {
-  triangles = [];
-  totalArea = 0;
   pathLine = null;
   targetMarker = null;
   pathButton = null;
@@ -76,7 +50,6 @@ class NavMeshWireframe extends xb.Script {
       if (!object.isMesh || !object.geometry) return;
       const geometry = object.geometry.clone();
       geometry.applyMatrix4(object.matrixWorld);
-      this.addNavMeshTriangles(geometry);
       const edges = new THREE.EdgesGeometry(geometry, 1);
       const wireframe = new THREE.LineSegments(
         edges,
@@ -96,31 +69,6 @@ class NavMeshWireframe extends xb.Script {
 
   update() {
     this.updateNavigation();
-  }
-
-  addNavMeshTriangles(geometry) {
-    const positions = geometry.attributes.position;
-    const index = geometry.index;
-    const triangleCount = index ? index.count / 3 : positions.count / 3;
-
-    for (let i = 0; i < triangleCount; i++) {
-      const aIndex = index ? index.getX(i * 3) : i * 3;
-      const bIndex = index ? index.getX(i * 3 + 1) : i * 3 + 1;
-      const cIndex = index ? index.getX(i * 3 + 2) : i * 3 + 2;
-      triangleA.fromBufferAttribute(positions, aIndex);
-      triangleB.fromBufferAttribute(positions, bIndex);
-      triangleC.fromBufferAttribute(positions, cIndex);
-
-      const area = triangleArea(triangleA, triangleB, triangleC);
-      if (area <= 0) continue;
-      this.totalArea += area;
-      this.triangles.push({
-        a: triangleA.clone(),
-        b: triangleB.clone(),
-        c: triangleC.clone(),
-        cumulativeArea: this.totalArea,
-      });
-    }
   }
 
   createPathButton() {
@@ -144,14 +92,10 @@ class NavMeshWireframe extends xb.Script {
   }
 
   showRandomPath() {
-    const target = this.sampleNavMeshPoint();
-    if (!target) return;
-
-    const path = xb.core.simulator.navigation.findPathTo(
-      xb.core.camera.position,
-      target
+    const result = xb.core.simulator.navigation.findRandomPathFrom(
+      xb.core.camera.position
     );
-    if (!path) {
+    if (!result) {
       this.pathButton.textContent = 'No Path';
       window.setTimeout(() => {
         this.pathButton.textContent = 'Random Path';
@@ -161,19 +105,10 @@ class NavMeshWireframe extends xb.Script {
 
     pathStart.copy(xb.core.camera.position);
     pathStart.y -= xb.core.options.simulator.navigation.eyeHeight;
-    this.routePoints = [...path, target];
+    this.routePoints = [...result.path, result.target];
     this.routeIndex = 0;
     this.pathButton.textContent = 'Navigating...';
     this.drawPath([pathStart, ...this.routePoints]);
-  }
-
-  sampleNavMeshPoint() {
-    if (this.triangles.length === 0) return null;
-    const targetArea = Math.random() * this.totalArea;
-    const triangle =
-      this.triangles.find((item) => item.cumulativeArea >= targetArea) ??
-      this.triangles[this.triangles.length - 1];
-    return sampleTriangle(triangle.a, triangle.b, triangle.c);
   }
 
   drawPath(points) {

--- a/demos/navmesh_simulator/main.js
+++ b/demos/navmesh_simulator/main.js
@@ -1,0 +1,276 @@
+import 'xrblocks/addons/simulator/SimulatorAddons.js';
+
+import * as THREE from 'three';
+import {GLTFLoader} from 'three/addons/loaders/GLTFLoader.js';
+import * as xb from 'xrblocks';
+
+const NAVMESH_PATH = './navmesh.glb';
+const EYE_HEIGHT = 1.5;
+const START_FOOT_POSITION = {x: 20, y: 0, z: 20};
+const PATH_Y_OFFSET = 0.04;
+const NAVIGATION_SPEED_METERS_PER_SECOND = 1.2;
+const WAYPOINT_THRESHOLD_METERS = 0.08;
+
+const triangleA = new THREE.Vector3();
+const triangleB = new THREE.Vector3();
+const triangleC = new THREE.Vector3();
+const triangleAB = new THREE.Vector3();
+const triangleAC = new THREE.Vector3();
+const pathStart = new THREE.Vector3();
+const currentFootPosition = new THREE.Vector3();
+const desiredCameraPosition = new THREE.Vector3();
+const waypointDelta = new THREE.Vector3();
+const remainingPathStart = new THREE.Vector3();
+
+function triangleArea(a, b, c) {
+  triangleAB.subVectors(b, a);
+  triangleAC.subVectors(c, a);
+  return triangleAB.cross(triangleAC).length() * 0.5;
+}
+
+function sampleTriangle(a, b, c) {
+  let u = Math.random();
+  let v = Math.random();
+  if (u + v > 1) {
+    u = 1 - u;
+    v = 1 - v;
+  }
+  return new THREE.Vector3()
+    .copy(a)
+    .addScaledVector(triangleAB.subVectors(b, a), u)
+    .addScaledVector(triangleAC.subVectors(c, a), v);
+}
+
+class NavMeshWireframe extends xb.Script {
+  triangles = [];
+  totalArea = 0;
+  pathLine = null;
+  targetMarker = null;
+  pathButton = null;
+  routePoints = [];
+  routeIndex = 0;
+
+  async init() {
+    this.add(new THREE.HemisphereLight(0xffffff, 0x666666, 3));
+
+    const loader = new GLTFLoader();
+    let gltf;
+    try {
+      gltf = await loader.loadAsync(NAVMESH_PATH);
+    } catch (error) {
+      console.warn(
+        `Failed to load navmesh wireframe at ${NAVMESH_PATH}.`,
+        error
+      );
+      return;
+    }
+    const group = new THREE.Group();
+
+    gltf.scene.position.set(
+      xb.core.options.simulator.initialScenePosition.x,
+      xb.core.options.simulator.initialScenePosition.y,
+      xb.core.options.simulator.initialScenePosition.z
+    );
+    gltf.scene.updateMatrixWorld(true);
+    gltf.scene.traverse((object) => {
+      if (!object.isMesh || !object.geometry) return;
+      const geometry = object.geometry.clone();
+      geometry.applyMatrix4(object.matrixWorld);
+      this.addNavMeshTriangles(geometry);
+      const edges = new THREE.EdgesGeometry(geometry, 1);
+      const wireframe = new THREE.LineSegments(
+        edges,
+        new THREE.LineBasicMaterial({
+          color: 0x00e5ff,
+          transparent: true,
+          opacity: 0.9,
+          depthTest: false,
+        })
+      );
+      wireframe.renderOrder = 1000;
+      group.add(wireframe);
+    });
+    this.add(group);
+    this.createPathButton();
+  }
+
+  update() {
+    this.updateNavigation();
+  }
+
+  addNavMeshTriangles(geometry) {
+    const positions = geometry.attributes.position;
+    const index = geometry.index;
+    const triangleCount = index ? index.count / 3 : positions.count / 3;
+
+    for (let i = 0; i < triangleCount; i++) {
+      const aIndex = index ? index.getX(i * 3) : i * 3;
+      const bIndex = index ? index.getX(i * 3 + 1) : i * 3 + 1;
+      const cIndex = index ? index.getX(i * 3 + 2) : i * 3 + 2;
+      triangleA.fromBufferAttribute(positions, aIndex);
+      triangleB.fromBufferAttribute(positions, bIndex);
+      triangleC.fromBufferAttribute(positions, cIndex);
+
+      const area = triangleArea(triangleA, triangleB, triangleC);
+      if (area <= 0) continue;
+      this.totalArea += area;
+      this.triangles.push({
+        a: triangleA.clone(),
+        b: triangleB.clone(),
+        c: triangleC.clone(),
+        cumulativeArea: this.totalArea,
+      });
+    }
+  }
+
+  createPathButton() {
+    this.pathButton = document.createElement('button');
+    this.pathButton.textContent = 'Random Path';
+    this.pathButton.style.position = 'fixed';
+    this.pathButton.style.left = '12px';
+    this.pathButton.style.bottom = '12px';
+    this.pathButton.style.zIndex = '10000';
+    this.pathButton.style.padding = '8px 12px';
+    this.pathButton.style.border = '1px solid rgba(255, 255, 255, 0.35)';
+    this.pathButton.style.borderRadius = '4px';
+    this.pathButton.style.background = 'rgba(8, 12, 18, 0.82)';
+    this.pathButton.style.color = '#ffffff';
+    this.pathButton.style.font = '13px system-ui, sans-serif';
+    this.pathButton.style.cursor = 'pointer';
+    this.pathButton.addEventListener('click', () => {
+      this.showRandomPath();
+    });
+    document.body.append(this.pathButton);
+  }
+
+  showRandomPath() {
+    const target = this.sampleNavMeshPoint();
+    if (!target) return;
+
+    const path = xb.core.simulator.navigation.findPathTo(
+      xb.core.camera.position,
+      target
+    );
+    if (!path) {
+      this.pathButton.textContent = 'No Path';
+      window.setTimeout(() => {
+        this.pathButton.textContent = 'Random Path';
+      }, 1200);
+      return;
+    }
+
+    pathStart.copy(xb.core.camera.position);
+    pathStart.y -= xb.core.options.simulator.navigation.eyeHeight;
+    this.routePoints = [...path, target];
+    this.routeIndex = 0;
+    this.pathButton.textContent = 'Navigating...';
+    this.drawPath([pathStart, ...this.routePoints]);
+  }
+
+  sampleNavMeshPoint() {
+    if (this.triangles.length === 0) return null;
+    const targetArea = Math.random() * this.totalArea;
+    const triangle =
+      this.triangles.find((item) => item.cumulativeArea >= targetArea) ??
+      this.triangles[this.triangles.length - 1];
+    return sampleTriangle(triangle.a, triangle.b, triangle.c);
+  }
+
+  drawPath(points) {
+    if (this.pathLine) {
+      this.remove(this.pathLine);
+      this.pathLine.geometry.dispose();
+      this.pathLine.material.dispose();
+    }
+    if (this.targetMarker) {
+      this.remove(this.targetMarker);
+      this.targetMarker.geometry.dispose();
+      this.targetMarker.material.dispose();
+    }
+
+    const liftedPoints = points.map((point) =>
+      point.clone().add(new THREE.Vector3(0, PATH_Y_OFFSET, 0))
+    );
+    const geometry = new THREE.BufferGeometry().setFromPoints(liftedPoints);
+    this.pathLine = new THREE.Line(
+      geometry,
+      new THREE.LineBasicMaterial({
+        color: 0xffd23f,
+        depthTest: false,
+      })
+    );
+    this.pathLine.renderOrder = 1001;
+    this.add(this.pathLine);
+
+    const targetPoint = liftedPoints[liftedPoints.length - 1];
+    this.targetMarker = new THREE.Mesh(
+      new THREE.SphereGeometry(0.06, 16, 8),
+      new THREE.MeshBasicMaterial({
+        color: 0xff5c7a,
+        depthTest: false,
+      })
+    );
+    this.targetMarker.position.copy(targetPoint);
+    this.targetMarker.renderOrder = 1002;
+    this.add(this.targetMarker);
+  }
+
+  updateNavigation() {
+    if (this.routeIndex >= this.routePoints.length) return;
+
+    const eyeHeight = xb.core.options.simulator.navigation.eyeHeight;
+    const target = this.routePoints[this.routeIndex];
+    currentFootPosition.copy(xb.core.camera.position);
+    currentFootPosition.y -= eyeHeight;
+    waypointDelta.subVectors(target, currentFootPosition);
+
+    const distance = waypointDelta.length();
+    if (distance <= WAYPOINT_THRESHOLD_METERS) {
+      this.routeIndex++;
+      if (this.routeIndex >= this.routePoints.length) {
+        this.pathButton.textContent = 'Random Path';
+      }
+      return;
+    }
+
+    const step = Math.min(
+      distance,
+      NAVIGATION_SPEED_METERS_PER_SECOND * xb.getDeltaTime()
+    );
+    waypointDelta.multiplyScalar(step / distance);
+    desiredCameraPosition.copy(xb.core.camera.position).add(waypointDelta);
+    desiredCameraPosition.y =
+      currentFootPosition.y + waypointDelta.y + eyeHeight;
+    xb.core.simulator.navigation.applyUserMovement(
+      xb.core.camera,
+      desiredCameraPosition
+    );
+
+    remainingPathStart.copy(xb.core.camera.position);
+    remainingPathStart.y -= eyeHeight;
+    this.drawPath([
+      remainingPathStart,
+      ...this.routePoints.slice(this.routeIndex),
+    ]);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const options = new xb.Options();
+  options.formFactor = 'desktop';
+  options.setAppTitle('Simulator Navmesh');
+  options.simulator.defaultMode = xb.SimulatorMode.POINTER_LOCK;
+  options.simulator.navigation.enabled = true;
+  options.simulator.navigation.eyeHeight = EYE_HEIGHT;
+  options.simulator.initialCameraPosition = {
+    x: START_FOOT_POSITION.x,
+    y: START_FOOT_POSITION.y + EYE_HEIGHT,
+    z: START_FOOT_POSITION.z,
+  };
+  options.simulator.environments[
+    options.simulator.activeEnvironmentIndex
+  ].navMeshPath = NAVMESH_PATH;
+
+  xb.add(new NavMeshWireframe());
+  xb.init(options);
+});

--- a/demos/navmesh_simulator/main.js
+++ b/demos/navmesh_simulator/main.js
@@ -4,9 +4,8 @@ import * as THREE from 'three';
 import {GLTFLoader} from 'three/addons/loaders/GLTFLoader.js';
 import * as xb from 'xrblocks';
 
-const NAVMESH_PATH = './navmesh.glb';
 const EYE_HEIGHT = 1.5;
-const START_FOOT_POSITION = {x: 20, y: 0, z: 20};
+const START_FOOT_POSITION = {x: 0.49, y: 0.3, z: 2.31};
 const PATH_Y_OFFSET = 0.04;
 const NAVIGATION_SPEED_METERS_PER_SECOND = 1.2;
 const WAYPOINT_THRESHOLD_METERS = 0.08;
@@ -27,13 +26,22 @@ class NavMeshWireframe extends xb.Script {
   async init() {
     this.add(new THREE.HemisphereLight(0xffffff, 0x666666, 3));
 
+    const simulatorOptions = xb.core.options.simulator;
+    const activeEnvironment =
+      simulatorOptions.environments[simulatorOptions.activeEnvironmentIndex];
+    const navMeshPath = activeEnvironment?.navMeshPath;
+    if (!navMeshPath) {
+      console.warn('No navmesh path configured for the active environment.');
+      return;
+    }
+
     const loader = new GLTFLoader();
     let gltf;
     try {
-      gltf = await loader.loadAsync(NAVMESH_PATH);
+      gltf = await loader.loadAsync(navMeshPath);
     } catch (error) {
       console.warn(
-        `Failed to load navmesh wireframe at ${NAVMESH_PATH}.`,
+        `Failed to load navmesh wireframe at ${navMeshPath}.`,
         error
       );
       return;
@@ -41,9 +49,9 @@ class NavMeshWireframe extends xb.Script {
     const group = new THREE.Group();
 
     gltf.scene.position.set(
-      xb.core.options.simulator.initialScenePosition.x,
-      xb.core.options.simulator.initialScenePosition.y,
-      xb.core.options.simulator.initialScenePosition.z
+      simulatorOptions.initialScenePosition.x,
+      simulatorOptions.initialScenePosition.y,
+      simulatorOptions.initialScenePosition.z
     );
     gltf.scene.updateMatrixWorld(true);
     gltf.scene.traverse((object) => {
@@ -203,9 +211,6 @@ document.addEventListener('DOMContentLoaded', () => {
     y: START_FOOT_POSITION.y + EYE_HEIGHT,
     z: START_FOOT_POSITION.z,
   };
-  options.simulator.environments[
-    options.simulator.activeEnvironmentIndex
-  ].navMeshPath = NAVMESH_PATH;
 
   xb.add(new NavMeshWireframe());
   xb.init(options);

--- a/demos/navmesh_simulator/main.js
+++ b/demos/navmesh_simulator/main.js
@@ -92,7 +92,7 @@ class NavMeshWireframe extends xb.Script {
   }
 
   showRandomPath() {
-    const result = xb.core.simulator.navigation.findRandomPathFrom(
+    const result = xb.core.simulator.navMesh.findRandomPathFrom(
       xb.core.camera.position
     );
     if (!result) {
@@ -104,8 +104,9 @@ class NavMeshWireframe extends xb.Script {
     }
 
     pathStart.copy(xb.core.camera.position);
-    pathStart.y -= xb.core.options.simulator.navigation.eyeHeight;
-    this.routePoints = [...result.path, result.target];
+    pathStart.y -= xb.core.options.simulator.navMesh.eyeHeight;
+    this.routePoints =
+      result.path.length > 0 ? [...result.path] : [result.target];
     this.routeIndex = 0;
     this.pathButton.textContent = 'Navigating...';
     this.drawPath([pathStart, ...this.routePoints]);
@@ -153,7 +154,7 @@ class NavMeshWireframe extends xb.Script {
   updateNavigation() {
     if (this.routeIndex >= this.routePoints.length) return;
 
-    const eyeHeight = xb.core.options.simulator.navigation.eyeHeight;
+    const eyeHeight = xb.core.options.simulator.navMesh.eyeHeight;
     const target = this.routePoints[this.routeIndex];
     currentFootPosition.copy(xb.core.camera.position);
     currentFootPosition.y -= eyeHeight;
@@ -176,7 +177,7 @@ class NavMeshWireframe extends xb.Script {
     desiredCameraPosition.copy(xb.core.camera.position).add(waypointDelta);
     desiredCameraPosition.y =
       currentFootPosition.y + waypointDelta.y + eyeHeight;
-    xb.core.simulator.navigation.applyUserMovement(
+    xb.core.simulator.navMesh.applyUserMovement(
       xb.core.camera,
       desiredCameraPosition
     );
@@ -195,8 +196,8 @@ document.addEventListener('DOMContentLoaded', () => {
   options.formFactor = 'desktop';
   options.setAppTitle('Simulator Navmesh');
   options.simulator.defaultMode = xb.SimulatorMode.POINTER_LOCK;
-  options.simulator.navigation.enabled = true;
-  options.simulator.navigation.eyeHeight = EYE_HEIGHT;
+  options.simulator.navMesh.enabled = true;
+  options.simulator.navMesh.eyeHeight = EYE_HEIGHT;
   options.simulator.initialCameraPosition = {
     x: START_FOOT_POSITION.x,
     y: START_FOOT_POSITION.y + EYE_HEIGHT,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "xrblocks",
       "version": "0.17.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "three-pathfinding": "^1.3.0"
+      },
       "bin": {
         "xrblocks-remote-control": "src/addons/remote-control/server/relay.js"
       },
@@ -5619,6 +5622,15 @@
       "license": "MIT",
       "peerDependencies": {
         "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/three-pathfinding": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/three-pathfinding/-/three-pathfinding-1.3.0.tgz",
+      "integrity": "sha512-LKxMI3/YqdMYvt6AdE2vB6s5ueDFczt/DWoxhtPNgRsH6E0D8LMYQxz+eIrmKo0MQpDvMVzXYUMBk+b86+k97w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": "0.x.x"
       }
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -88,5 +88,8 @@
     "rollup-plugin-dts": {
       "typescript": "$typescript"
     }
+  },
+  "dependencies": {
+    "three-pathfinding": "^1.3.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -52,6 +52,7 @@ ${apache2License}
     "webgl-sdf-generator": "https://esm.sh/webgl-sdf-generator@1.1.1/es2022/webgl-sdf-generator.mjs",
     "lit": "https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js",
     "lit/": "https://esm.run/lit@3/",
+    "three-pathfinding": "https://cdn.jsdelivr.net/npm/three-pathfinding@1.3.0/dist/three-pathfinding.module.js",
     2. If the app focus on standalone objects, spawn it in front of the user in
     WebXR and rescale to reasonable physical size. Wrap them with xb.ModelViewer
     and make sure users can drag the platform to move it around in XR.
@@ -76,6 +77,7 @@ const externalPackages = [
   '@preact/signals-core',
   'rapier3d',
   'three-mesh-bvh',
+  'three-pathfinding',
   'vitest',
 ];
 

--- a/src/SKILL.md
+++ b/src/SKILL.md
@@ -121,14 +121,15 @@ camera input, hides simulator control panels, and can also be activated from the
 URL with `?xrAutomation=1`.
 
 Simulator navmesh constraints are opt-in. Set
-`options.simulator.navMesh.enabled = true` and provide a glTF/GLB
-`navMeshPath` on the active simulator environment. The navmesh represents the
-walkable floor surface; XR Blocks uses it to ground/constrain the Simulator User
-only, not simulated hands/controllers. Author it in the same local coordinates as
-the simulator scene; XR Blocks applies the same environment placement transform
-to both. `SimulatorNavMesh` also exposes high-level helpers for reachable
-location/object checks and random reachable path generation, without exposing
-`three-pathfinding` groups or nodes. CDN/importmap apps that enable this need
+`options.simulator.navMesh.enabled = true`; the default Living Room environment
+already includes a glTF/GLB `navMeshPath`. Custom environments can provide their
+own navmesh. The navmesh represents the walkable floor surface; XR Blocks uses it
+to ground/constrain the Simulator User only, not simulated hands/controllers.
+Author it in the same local coordinates as the simulator scene; XR Blocks
+applies the same environment placement transform to both. `SimulatorNavMesh`
+also exposes high-level helpers for reachable location/object checks and random
+reachable path generation, without exposing `three-pathfinding` groups or nodes.
+CDN/importmap apps that enable this need
 `"three-pathfinding": "https://cdn.jsdelivr.net/npm/three-pathfinding@1.3.0/dist/three-pathfinding.module.js"`.
 
 ## Script lifecycle hooks

--- a/src/SKILL.md
+++ b/src/SKILL.md
@@ -120,6 +120,17 @@ For automation or external remote runs, use `options.enableAutomationMode()` bef
 camera input, hides simulator control panels, and can also be activated from the
 URL with `?xrAutomation=1`.
 
+Simulator navmesh constraints are opt-in. Set
+`options.simulator.navMesh.enabled = true` and provide a glTF/GLB
+`navMeshPath` on the active simulator environment. The navmesh represents the
+walkable floor surface; XR Blocks uses it to ground/constrain the Simulator User
+only, not simulated hands/controllers. Author it in the same local coordinates as
+the simulator scene; XR Blocks applies the same environment placement transform
+to both. `SimulatorNavMesh` also exposes high-level helpers for reachable
+location/object checks and random reachable path generation, without exposing
+`three-pathfinding` groups or nodes. CDN/importmap apps that enable this need
+`"three-pathfinding": "https://cdn.jsdelivr.net/npm/three-pathfinding@1.3.0/dist/three-pathfinding.module.js"`.
+
 ## Script lifecycle hooks
 
 Override only what you need (all verified against `core/Script.ts` and `core/User.ts`):

--- a/src/addons/embodied-control/EmbodiedControlExecutor.ts
+++ b/src/addons/embodied-control/EmbodiedControlExecutor.ts
@@ -155,7 +155,7 @@ export class EmbodiedControlExecutor {
         .multiplyScalar(fraction)
         .applyQuaternion(initialCameraQuaternion);
       vector.add(camera.position);
-      this.dependencies.simulator.navigation.applyUserMovement(camera, vector);
+      this.dependencies.simulator.navMesh.applyUserMovement(camera, vector);
     }
 
     if (control.rotate) {
@@ -304,14 +304,14 @@ export class EmbodiedControlExecutor {
         );
         targetCameraPosition.addScaledVector(forward, distance);
       }
-      this.dependencies.simulator.navigation.applyUserMovement(
+      this.dependencies.simulator.navMesh.applyUserMovement(
         camera,
         targetCameraPosition
       );
 
       if (
         snapToGround &&
-        !this.dependencies.simulator.navigation.constrained &&
+        !this.dependencies.simulator.navMesh.constrained &&
         world?.planes &&
         user
       ) {

--- a/src/addons/embodied-control/EmbodiedControlExecutor.ts
+++ b/src/addons/embodied-control/EmbodiedControlExecutor.ts
@@ -24,6 +24,7 @@ export type EmbodiedControlExecutorDependencies = {
 };
 
 const vector = new THREE.Vector3();
+const targetCameraPosition = new THREE.Vector3();
 const euler = new THREE.Euler();
 const quaternion = new THREE.Quaternion();
 
@@ -153,7 +154,8 @@ export class EmbodiedControlExecutor {
         .fromArray(control.move)
         .multiplyScalar(fraction)
         .applyQuaternion(initialCameraQuaternion);
-      camera.position.add(vector);
+      vector.add(camera.position);
+      this.dependencies.simulator.navigation.applyUserMovement(camera, vector);
     }
 
     if (control.rotate) {
@@ -294,17 +296,25 @@ export class EmbodiedControlExecutor {
       const world = core.registry.get(World);
       const targetWorldPos = new THREE.Vector3();
       this.getTargetWorldPosition(target, targetWorldPos);
+      targetCameraPosition.copy(targetWorldPos);
 
       if (target instanceof THREE.Object3D) {
         const forward = new THREE.Vector3(0, 0, 1).applyQuaternion(
           target.quaternion
         );
-        camera.position.copy(targetWorldPos).addScaledVector(forward, distance);
-      } else {
-        camera.position.copy(targetWorldPos);
+        targetCameraPosition.addScaledVector(forward, distance);
       }
+      this.dependencies.simulator.navigation.applyUserMovement(
+        camera,
+        targetCameraPosition
+      );
 
-      if (snapToGround && world?.planes && user) {
+      if (
+        snapToGround &&
+        !this.dependencies.simulator.navigation.constrained &&
+        world?.planes &&
+        user
+      ) {
         const horizontalPlanes = world.planes.get().filter((p) => {
           const orientation = (p.orientation || '').toLowerCase();
           const label = (p.label || '').toLowerCase();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -103,4 +103,4 @@ export const DEFAULT_DEVICE_CAMERA_WIDTH = 1280;
 export const DEFAULT_DEVICE_CAMERA_HEIGHT = 720;
 
 export const XR_BLOCKS_ASSETS_PATH =
-  'https://cdn.jsdelivr.net/gh/xrblocks/assets@02bbbf2093d20bcefdac18c65d3ff0f2b94b7535/';
+  'https://cdn.jsdelivr.net/gh/xrblocks/assets@d872cfdb7668443da5cd38361fc3a3d131aca04c/';

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -225,6 +225,7 @@ export class Core {
     this.registry.register(this.sound);
     this.registry.register(this.dragManager);
     this.registry.register(this.simulator);
+    this.registry.register(this.simulator.navigation);
     this.registry.register(this.scriptsManager);
     this.registry.register(this.depth);
     this.registry.register(this.world);

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -225,7 +225,7 @@ export class Core {
     this.registry.register(this.sound);
     this.registry.register(this.dragManager);
     this.registry.register(this.simulator);
-    this.registry.register(this.simulator.navigation);
+    this.registry.register(this.simulator.navMesh);
     this.registry.register(this.scriptsManager);
     this.registry.register(this.depth);
     this.registry.register(this.world);

--- a/src/simulator/Simulator.ts
+++ b/src/simulator/Simulator.ts
@@ -17,6 +17,7 @@ import {SimulatorControls} from './SimulatorControls';
 import {SimulatorDepth} from './SimulatorDepth';
 import {SimulatorHands} from './SimulatorHands';
 import {SimulatorInterface} from './SimulatorInterface';
+import {SimulatorNavigation} from './SimulatorNavigation';
 import {SimulatorOptions} from './SimulatorOptions';
 import {SimulatorScene} from './SimulatorScene';
 import {SimulatorUser} from './SimulatorUser';
@@ -40,6 +41,7 @@ export class Simulator extends Script {
   editorIcon = 'simulation';
   simulatorScene = new SimulatorScene();
   simulatorWorld = new SimulatorWorld();
+  navigation = new SimulatorNavigation();
   depth = new SimulatorDepth(this.simulatorScene);
   // Controller poses relative to the camera.
   simulatorControllerState = new SimulatorControllerState();
@@ -52,6 +54,7 @@ export class Simulator extends Script {
   controls = new SimulatorControls(
     this.simulatorControllerState,
     this.hands,
+    this.navigation,
     this.setStereoRenderMode.bind(this),
     this.userInterface
   );
@@ -118,10 +121,12 @@ export class Simulator extends Script {
       this.controls,
       this.hands,
       input,
-      this.simulatorScene
+      this.simulatorScene,
+      this.navigation
     );
     renderer.autoClearColor = false;
     await this.simulatorScene.init(simulatorOptions);
+    await this.navigation.init(simulatorOptions);
     await this.simulatorWorld.init(options, world, this.simulatorScene);
     await this.hands.init({input});
     this.controls.init({camera, input, timer, renderer, simulatorOptions});

--- a/src/simulator/Simulator.ts
+++ b/src/simulator/Simulator.ts
@@ -17,7 +17,7 @@ import {SimulatorControls} from './SimulatorControls';
 import {SimulatorDepth} from './SimulatorDepth';
 import {SimulatorHands} from './SimulatorHands';
 import {SimulatorInterface} from './SimulatorInterface';
-import {SimulatorNavigation} from './SimulatorNavigation';
+import {SimulatorNavMesh} from './SimulatorNavMesh';
 import {SimulatorOptions} from './SimulatorOptions';
 import {SimulatorScene} from './SimulatorScene';
 import {SimulatorUser} from './SimulatorUser';
@@ -41,7 +41,7 @@ export class Simulator extends Script {
   editorIcon = 'simulation';
   simulatorScene = new SimulatorScene();
   simulatorWorld = new SimulatorWorld();
-  navigation = new SimulatorNavigation();
+  navMesh = new SimulatorNavMesh();
   depth = new SimulatorDepth(this.simulatorScene);
   // Controller poses relative to the camera.
   simulatorControllerState = new SimulatorControllerState();
@@ -54,7 +54,7 @@ export class Simulator extends Script {
   controls = new SimulatorControls(
     this.simulatorControllerState,
     this.hands,
-    this.navigation,
+    this.navMesh,
     this.setStereoRenderMode.bind(this),
     this.userInterface
   );
@@ -122,11 +122,11 @@ export class Simulator extends Script {
       this.hands,
       input,
       this.simulatorScene,
-      this.navigation
+      this.navMesh
     );
     renderer.autoClearColor = false;
     await this.simulatorScene.init(simulatorOptions);
-    await this.navigation.init(simulatorOptions);
+    await this.navMesh.init(simulatorOptions);
     await this.simulatorWorld.init(options, world, this.simulatorScene);
     await this.hands.init({input});
     this.controls.init({camera, input, timer, renderer, simulatorOptions});

--- a/src/simulator/SimulatorControls.ts
+++ b/src/simulator/SimulatorControls.ts
@@ -15,6 +15,7 @@ import {SimulatorControllerState} from './SimulatorControllerState';
 import {SimulatorHands} from './SimulatorHands';
 import {SimulatorInterface} from './SimulatorInterface';
 import {SimulatorMode, SimulatorOptions} from './SimulatorOptions';
+import {SimulatorNavigation} from './SimulatorNavigation';
 import {ISimulatorSettingsPanelElement} from './interfaces/ISimulatorSettingsPanelElement';
 
 function preventDefault(event: Event) {
@@ -51,6 +52,7 @@ export class SimulatorControls {
   constructor(
     public simulatorControllerState: SimulatorControllerState,
     public hands: SimulatorHands,
+    public navigation: SimulatorNavigation,
     setStereoRenderMode: (_: SimulatorRenderMode) => void,
     private userInterface: SimulatorInterface
   ) {
@@ -68,6 +70,7 @@ export class SimulatorControls {
         this.simulatorControllerState,
         this.downKeys,
         hands,
+        navigation,
         setStereoRenderMode,
         toggleUserInterface,
         cycleSimulatorMode
@@ -76,6 +79,7 @@ export class SimulatorControls {
         this.simulatorControllerState,
         this.downKeys,
         hands,
+        navigation,
         setStereoRenderMode,
         toggleUserInterface,
         cycleSimulatorMode
@@ -84,6 +88,7 @@ export class SimulatorControls {
         this.simulatorControllerState,
         this.downKeys,
         hands,
+        navigation,
         setStereoRenderMode,
         toggleUserInterface,
         cycleSimulatorMode
@@ -92,6 +97,7 @@ export class SimulatorControls {
         this.simulatorControllerState,
         this.downKeys,
         hands,
+        navigation,
         setStereoRenderMode,
         toggleUserInterface,
         cycleSimulatorMode

--- a/src/simulator/SimulatorControls.ts
+++ b/src/simulator/SimulatorControls.ts
@@ -15,7 +15,7 @@ import {SimulatorControllerState} from './SimulatorControllerState';
 import {SimulatorHands} from './SimulatorHands';
 import {SimulatorInterface} from './SimulatorInterface';
 import {SimulatorMode, SimulatorOptions} from './SimulatorOptions';
-import {SimulatorNavigation} from './SimulatorNavigation';
+import {SimulatorNavMesh} from './SimulatorNavMesh';
 import {ISimulatorSettingsPanelElement} from './interfaces/ISimulatorSettingsPanelElement';
 
 function preventDefault(event: Event) {
@@ -52,7 +52,7 @@ export class SimulatorControls {
   constructor(
     public simulatorControllerState: SimulatorControllerState,
     public hands: SimulatorHands,
-    public navigation: SimulatorNavigation,
+    public navMesh: SimulatorNavMesh,
     setStereoRenderMode: (_: SimulatorRenderMode) => void,
     private userInterface: SimulatorInterface
   ) {
@@ -70,7 +70,7 @@ export class SimulatorControls {
         this.simulatorControllerState,
         this.downKeys,
         hands,
-        navigation,
+        navMesh,
         setStereoRenderMode,
         toggleUserInterface,
         cycleSimulatorMode
@@ -79,7 +79,7 @@ export class SimulatorControls {
         this.simulatorControllerState,
         this.downKeys,
         hands,
-        navigation,
+        navMesh,
         setStereoRenderMode,
         toggleUserInterface,
         cycleSimulatorMode
@@ -88,7 +88,7 @@ export class SimulatorControls {
         this.simulatorControllerState,
         this.downKeys,
         hands,
-        navigation,
+        navMesh,
         setStereoRenderMode,
         toggleUserInterface,
         cycleSimulatorMode
@@ -97,7 +97,7 @@ export class SimulatorControls {
         this.simulatorControllerState,
         this.downKeys,
         hands,
-        navigation,
+        navMesh,
         setStereoRenderMode,
         toggleUserInterface,
         cycleSimulatorMode

--- a/src/simulator/SimulatorInterface.ts
+++ b/src/simulator/SimulatorInterface.ts
@@ -4,6 +4,7 @@ import {Input} from '../input/Input.js';
 import {SimulatorControls} from './SimulatorControls.js';
 import {ISimulatorSettingsPanelElement} from './interfaces/ISimulatorSettingsPanelElement.js';
 import {SimulatorHands} from './SimulatorHands.js';
+import {SimulatorNavigation} from './SimulatorNavigation.js';
 import {
   SimulatorCustomInstruction,
   SimulatorOptions,
@@ -69,13 +70,15 @@ export class SimulatorInterface {
     simulatorControls: SimulatorControls,
     simulatorHands: SimulatorHands,
     input?: Input,
-    simulatorScene?: SimulatorScene
+    simulatorScene?: SimulatorScene,
+    simulatorNavigation?: SimulatorNavigation
   ) {
     if (simulatorScene) {
       this.createSimulatorSettingsPanel(
         simulatorOptions,
         simulatorControls,
-        simulatorScene
+        simulatorScene,
+        simulatorNavigation
       );
     }
     this.showGeminiLivePanel(simulatorOptions);
@@ -94,7 +97,8 @@ export class SimulatorInterface {
   createSimulatorSettingsPanel(
     simulatorOptions: SimulatorOptions,
     simulatorControls: SimulatorControls,
-    simulatorScene: SimulatorScene
+    simulatorScene: SimulatorScene,
+    simulatorNavigation?: SimulatorNavigation
   ) {
     if (simulatorOptions.simulatorSettingsPanel.enabled) {
       const settingsElement = document.createElement(
@@ -121,6 +125,10 @@ export class SimulatorInterface {
                 simulatorOptions.initialScenePosition.y,
                 simulatorOptions.initialScenePosition.z
               )
+            );
+            void simulatorNavigation?.setEnvironment(
+              activeEnv ?? null,
+              simulatorOptions
             );
           }
         }

--- a/src/simulator/SimulatorInterface.ts
+++ b/src/simulator/SimulatorInterface.ts
@@ -4,7 +4,7 @@ import {Input} from '../input/Input.js';
 import {SimulatorControls} from './SimulatorControls.js';
 import {ISimulatorSettingsPanelElement} from './interfaces/ISimulatorSettingsPanelElement.js';
 import {SimulatorHands} from './SimulatorHands.js';
-import {SimulatorNavigation} from './SimulatorNavigation.js';
+import {SimulatorNavMesh} from './SimulatorNavMesh.js';
 import {
   SimulatorCustomInstruction,
   SimulatorOptions,
@@ -71,14 +71,14 @@ export class SimulatorInterface {
     simulatorHands: SimulatorHands,
     input?: Input,
     simulatorScene?: SimulatorScene,
-    simulatorNavigation?: SimulatorNavigation
+    simulatorNavMesh?: SimulatorNavMesh
   ) {
     if (simulatorScene) {
       this.createSimulatorSettingsPanel(
         simulatorOptions,
         simulatorControls,
         simulatorScene,
-        simulatorNavigation
+        simulatorNavMesh
       );
     }
     this.showGeminiLivePanel(simulatorOptions);
@@ -98,7 +98,7 @@ export class SimulatorInterface {
     simulatorOptions: SimulatorOptions,
     simulatorControls: SimulatorControls,
     simulatorScene: SimulatorScene,
-    simulatorNavigation?: SimulatorNavigation
+    simulatorNavMesh?: SimulatorNavMesh
   ) {
     if (simulatorOptions.simulatorSettingsPanel.enabled) {
       const settingsElement = document.createElement(
@@ -126,7 +126,7 @@ export class SimulatorInterface {
                 simulatorOptions.initialScenePosition.z
               )
             );
-            void simulatorNavigation?.setEnvironment(
+            void simulatorNavMesh?.setEnvironment(
               activeEnv ?? null,
               simulatorOptions
             );

--- a/src/simulator/SimulatorNavMesh.ts
+++ b/src/simulator/SimulatorNavMesh.ts
@@ -9,10 +9,7 @@ const RANDOM_PATH_SAMPLE_ATTEMPTS = 8;
 
 type PathfindingConstructor = {
   new (): PathfindingType;
-  createZone: (
-    geometry: THREE.BufferGeometry,
-    tolerance?: number
-  ) => unknown;
+  createZone: (geometry: THREE.BufferGeometry, tolerance?: number) => unknown;
 };
 type PathfindingNode = ReturnType<PathfindingType['getClosestNode']>;
 type PathfindingZone = {

--- a/src/simulator/SimulatorNavMesh.ts
+++ b/src/simulator/SimulatorNavMesh.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import {GLTFLoader} from 'three/addons/loaders/GLTFLoader.js';
+import type {GLTF} from 'three/addons/loaders/GLTFLoader.js';
 import type {Pathfinding as PathfindingType} from 'three-pathfinding';
 
 import {SimulatorEnvironment, SimulatorOptions} from './SimulatorOptions';
@@ -87,8 +88,11 @@ export class SimulatorNavMesh {
         environment.navMeshPath,
         initialScenePosition
       );
-      await this.setGeometry(geometry);
-      geometry.dispose();
+      try {
+        await this.setGeometry(geometry);
+      } finally {
+        geometry.dispose();
+      }
     } catch (error) {
       console.warn(
         `SimulatorNavMesh: failed to load navmesh at ${environment.navMeshPath}.`,
@@ -293,18 +297,48 @@ export class SimulatorNavMesh {
   ): Promise<THREE.BufferGeometry> {
     const loader = new GLTFLoader();
     const gltf = await loader.loadAsync(path);
-    gltf.scene.position.copy(sceneOffset);
-    gltf.scene.updateMatrixWorld(true);
+    try {
+      gltf.scene.position.copy(sceneOffset);
+      gltf.scene.updateMatrixWorld(true);
 
-    const navMesh = this.findFirstMesh(gltf.scene);
+      const navMesh = this.findFirstMesh(gltf.scene);
 
-    if (!navMesh) {
-      throw new Error('No mesh found in navmesh glTF/GLB.');
+      if (!navMesh) {
+        throw new Error('No mesh found in navmesh glTF/GLB.');
+      }
+
+      const geometry = navMesh.geometry.clone();
+      geometry.applyMatrix4(navMesh.matrixWorld);
+      return geometry;
+    } finally {
+      this.disposeGLTFResources(gltf);
     }
+  }
 
-    const geometry = navMesh.geometry.clone();
-    geometry.applyMatrix4(navMesh.matrixWorld);
-    return geometry;
+  private disposeGLTFResources(gltf: GLTF) {
+    gltf.scene.traverse((object) => {
+      const mesh = object as THREE.Mesh;
+      if (!mesh.isMesh) return;
+      mesh.geometry?.dispose();
+      const materials = Array.isArray(mesh.material)
+        ? mesh.material
+        : [mesh.material];
+      for (const material of materials) {
+        this.disposeMaterial(material);
+      }
+    });
+  }
+
+  private disposeMaterial(material?: THREE.Material) {
+    if (!material) return;
+    for (const value of Object.values(
+      material as unknown as Record<string, unknown>
+    )) {
+      if (value instanceof THREE.Texture) {
+        value.dispose();
+      }
+    }
+    material.dispose();
   }
 
   private findFirstMesh(root: THREE.Object3D): THREE.Mesh | null {

--- a/src/simulator/SimulatorNavMesh.ts
+++ b/src/simulator/SimulatorNavMesh.ts
@@ -14,7 +14,7 @@ type PathfindingZone = {
   vertices: THREE.Vector3[];
 };
 
-export interface SimulatorNavigationPath {
+export interface SimulatorNavMeshPath {
   target: THREE.Vector3;
   path: THREE.Vector3[];
 }
@@ -30,7 +30,7 @@ const randomTriangleC = new THREE.Vector3();
 const randomTriangleAB = new THREE.Vector3();
 const randomTriangleAC = new THREE.Vector3();
 
-export class SimulatorNavigation {
+export class SimulatorNavMesh {
   enabled = false;
   ready = false;
 
@@ -47,8 +47,8 @@ export class SimulatorNavigation {
   }
 
   async init(options: SimulatorOptions) {
-    this.enabled = options.navigation.enabled;
-    this.eyeHeight = options.navigation.eyeHeight;
+    this.enabled = options.navMesh.enabled;
+    this.eyeHeight = options.navMesh.eyeHeight;
     const activeEnv =
       options.environments[options.activeEnvironmentIndex] ?? null;
     await this.setEnvironment(activeEnv, options);
@@ -58,8 +58,8 @@ export class SimulatorNavigation {
     environment: SimulatorEnvironment | null,
     options: SimulatorOptions
   ) {
-    this.enabled = options.navigation.enabled;
-    this.eyeHeight = options.navigation.eyeHeight;
+    this.enabled = options.navMesh.enabled;
+    this.eyeHeight = options.navMesh.eyeHeight;
     this.ready = false;
     this.groupId = null;
     this.currentNode = null;
@@ -69,7 +69,7 @@ export class SimulatorNavigation {
     if (!this.enabled) return;
     if (!environment?.navMeshPath) {
       console.warn(
-        'SimulatorNavigation: navigation is enabled, but the active environment has no navMeshPath.'
+        'SimulatorNavMesh: navmesh is enabled, but the active environment has no navMeshPath.'
       );
       return;
     }
@@ -88,7 +88,7 @@ export class SimulatorNavigation {
       geometry.dispose();
     } catch (error) {
       console.warn(
-        `SimulatorNavigation: failed to load navmesh at ${environment.navMeshPath}.`,
+        `SimulatorNavMesh: failed to load navmesh at ${environment.navMeshPath}.`,
         error
       );
     }
@@ -181,7 +181,7 @@ export class SimulatorNavigation {
 
   findRandomPathFrom(
     startCameraPosition: THREE.Vector3
-  ): SimulatorNavigationPath | null {
+  ): SimulatorNavMeshPath | null {
     if (!this.constrained || !this.pathfinding || !this.zone) return null;
     const start = startGroundPosition.copy(startCameraPosition);
     start.y -= this.eyeHeight;

--- a/src/simulator/SimulatorNavMesh.ts
+++ b/src/simulator/SimulatorNavMesh.ts
@@ -7,7 +7,13 @@ import {SimulatorEnvironment, SimulatorOptions} from './SimulatorOptions';
 const DEFAULT_ZONE_ID = 'simulator';
 const RANDOM_PATH_SAMPLE_ATTEMPTS = 8;
 
-type PathfindingConstructor = typeof import('three-pathfinding').Pathfinding;
+type PathfindingConstructor = {
+  new (): PathfindingType;
+  createZone: (
+    geometry: THREE.BufferGeometry,
+    tolerance?: number
+  ) => unknown;
+};
 type PathfindingNode = ReturnType<PathfindingType['getClosestNode']>;
 type PathfindingZone = {
   groups: PathfindingNode[][];

--- a/src/simulator/SimulatorNavigation.ts
+++ b/src/simulator/SimulatorNavigation.ts
@@ -1,0 +1,203 @@
+import * as THREE from 'three';
+import {GLTFLoader} from 'three/addons/loaders/GLTFLoader.js';
+import type {Pathfinding as PathfindingType} from 'three-pathfinding';
+
+import {SimulatorEnvironment, SimulatorOptions} from './SimulatorOptions';
+
+const DEFAULT_ZONE_ID = 'simulator';
+
+type PathfindingConstructor = typeof import('three-pathfinding').Pathfinding;
+type PathfindingNode = ReturnType<PathfindingType['getClosestNode']>;
+
+const desiredGroundPosition = new THREE.Vector3();
+const startGroundPosition = new THREE.Vector3();
+const clampedGroundPosition = new THREE.Vector3();
+const initialScenePosition = new THREE.Vector3();
+
+export class SimulatorNavigation {
+  enabled = false;
+  ready = false;
+
+  private Pathfinding?: PathfindingConstructor;
+  private pathfinding?: PathfindingType;
+  private zoneId = DEFAULT_ZONE_ID;
+  private groupId: number | null = null;
+  private currentNode: PathfindingNode | null = null;
+  private eyeHeight = 1.5;
+
+  get constrained() {
+    return this.enabled && this.ready;
+  }
+
+  async init(options: SimulatorOptions) {
+    this.enabled = options.navigation.enabled;
+    this.eyeHeight = options.navigation.eyeHeight;
+    const activeEnv =
+      options.environments[options.activeEnvironmentIndex] ?? null;
+    await this.setEnvironment(activeEnv, options);
+  }
+
+  async setEnvironment(
+    environment: SimulatorEnvironment | null,
+    options: SimulatorOptions
+  ) {
+    this.enabled = options.navigation.enabled;
+    this.eyeHeight = options.navigation.eyeHeight;
+    this.ready = false;
+    this.groupId = null;
+    this.currentNode = null;
+    this.pathfinding = undefined;
+
+    if (!this.enabled) return;
+    if (!environment?.navMeshPath) {
+      console.warn(
+        'SimulatorNavigation: navigation is enabled, but the active environment has no navMeshPath.'
+      );
+      return;
+    }
+
+    try {
+      initialScenePosition.set(
+        options.initialScenePosition.x,
+        options.initialScenePosition.y,
+        options.initialScenePosition.z
+      );
+      const geometry = await this.loadGeometry(
+        environment.navMeshPath,
+        initialScenePosition
+      );
+      await this.setGeometry(geometry);
+      geometry.dispose();
+    } catch (error) {
+      console.warn(
+        `SimulatorNavigation: failed to load navmesh at ${environment.navMeshPath}.`,
+        error
+      );
+    }
+  }
+
+  async setGeometry(geometry: THREE.BufferGeometry) {
+    const Pathfinding = await this.loadPathfinding();
+    this.pathfinding = new Pathfinding();
+    this.pathfinding.setZoneData(this.zoneId, Pathfinding.createZone(geometry));
+    this.ready = true;
+    this.groupId = null;
+    this.currentNode = null;
+  }
+
+  applyUserMovement(
+    camera: THREE.Camera,
+    desiredCameraPosition: THREE.Vector3
+  ) {
+    if (!this.constrained || !this.pathfinding) {
+      camera.position.copy(desiredCameraPosition);
+      return;
+    }
+
+    startGroundPosition.copy(camera.position);
+    startGroundPosition.y -= this.eyeHeight;
+    desiredGroundPosition.copy(desiredCameraPosition);
+    desiredGroundPosition.y -= this.eyeHeight;
+
+    if (this.groupId === null || this.currentNode === null) {
+      this.groupId = this.pathfinding.getGroup(
+        this.zoneId,
+        startGroundPosition
+      ) as number | null;
+      if (this.groupId === null) {
+        camera.position.copy(desiredCameraPosition);
+        return;
+      }
+      this.currentNode = this.pathfinding.getClosestNode(
+        startGroundPosition,
+        this.zoneId,
+        this.groupId,
+        true
+      );
+      this.currentNode ??= this.pathfinding.getClosestNode(
+        startGroundPosition,
+        this.zoneId,
+        this.groupId,
+        false
+      );
+    }
+
+    if (!this.currentNode || this.groupId === null) {
+      camera.position.copy(desiredCameraPosition);
+      return;
+    }
+
+    this.currentNode = this.pathfinding.clampStep(
+      startGroundPosition,
+      desiredGroundPosition,
+      this.currentNode,
+      this.zoneId,
+      this.groupId,
+      clampedGroundPosition
+    );
+    camera.position.set(
+      clampedGroundPosition.x,
+      clampedGroundPosition.y + this.eyeHeight,
+      clampedGroundPosition.z
+    );
+  }
+
+  findPathTo(
+    startCameraPosition: THREE.Vector3,
+    targetGroundPosition: THREE.Vector3
+  ) {
+    if (!this.constrained || !this.pathfinding) return null;
+    const start = startGroundPosition.copy(startCameraPosition);
+    start.y -= this.eyeHeight;
+    const groupId = this.pathfinding.getGroup(this.zoneId, start) as
+      | number
+      | null;
+    if (groupId === null) return null;
+    return this.pathfinding.findPath(
+      start,
+      targetGroundPosition,
+      this.zoneId,
+      groupId
+    );
+  }
+
+  private async loadGeometry(
+    path: string,
+    sceneOffset: THREE.Vector3
+  ): Promise<THREE.BufferGeometry> {
+    const loader = new GLTFLoader();
+    const gltf = await loader.loadAsync(path);
+    gltf.scene.position.copy(sceneOffset);
+    gltf.scene.updateMatrixWorld(true);
+
+    const navMesh = this.findFirstMesh(gltf.scene);
+
+    if (!navMesh) {
+      throw new Error('No mesh found in navmesh glTF/GLB.');
+    }
+
+    const geometry = navMesh.geometry.clone();
+    geometry.applyMatrix4(navMesh.matrixWorld);
+    return geometry;
+  }
+
+  private findFirstMesh(root: THREE.Object3D): THREE.Mesh | null {
+    const queue = [root];
+    while (queue.length > 0) {
+      const object = queue.shift()!;
+      const mesh = object as THREE.Mesh;
+      if (mesh.isMesh && mesh.geometry) {
+        return mesh;
+      }
+      queue.push(...object.children);
+    }
+    return null;
+  }
+
+  private async loadPathfinding() {
+    if (!this.Pathfinding) {
+      this.Pathfinding = (await import('three-pathfinding')).Pathfinding;
+    }
+    return this.Pathfinding;
+  }
+}

--- a/src/simulator/SimulatorNavigation.ts
+++ b/src/simulator/SimulatorNavigation.ts
@@ -5,6 +5,7 @@ import type {Pathfinding as PathfindingType} from 'three-pathfinding';
 import {SimulatorEnvironment, SimulatorOptions} from './SimulatorOptions';
 
 const DEFAULT_ZONE_ID = 'simulator';
+const RANDOM_PATH_SAMPLE_ATTEMPTS = 8;
 
 type PathfindingConstructor = typeof import('three-pathfinding').Pathfinding;
 type PathfindingNode = ReturnType<PathfindingType['getClosestNode']>;
@@ -187,27 +188,38 @@ export class SimulatorNavigation {
     const groupId = this.getGroup(start);
     if (groupId === null) return null;
 
-    const target = this.getRandomPointInGroup(groupId);
-    if (!target) return null;
-
-    const path = this.pathfinding.findPath(
-      start,
-      target,
-      this.zoneId,
-      groupId
-    );
-    if (!path) return null;
-    return {target, path};
+    for (let i = 0; i < RANDOM_PATH_SAMPLE_ATTEMPTS; i++) {
+      const target = this.getRandomPointInGroup(groupId);
+      if (!target) continue;
+      const path = this.pathfinding.findPath(
+        start,
+        target,
+        this.zoneId,
+        groupId
+      );
+      if (path) return {target, path};
+    }
+    return null;
   }
 
   isGroundPositionReachable(
     startCameraPosition: THREE.Vector3,
     targetGroundPosition: THREE.Vector3
   ) {
+    return this.isLocationReachable(startCameraPosition, targetGroundPosition);
+  }
+
+  isLocationReachable(
+    startCameraPosition: THREE.Vector3,
+    targetGroundPosition: THREE.Vector3
+  ) {
     return this.findPathTo(startCameraPosition, targetGroundPosition) !== null;
   }
 
-  isObjectReachable(startCameraPosition: THREE.Vector3, object: THREE.Object3D) {
+  isObjectReachable(
+    startCameraPosition: THREE.Vector3,
+    object: THREE.Object3D
+  ) {
     object.getWorldPosition(targetWorldPosition);
     return this.isGroundPositionReachable(
       startCameraPosition,
@@ -262,8 +274,14 @@ export class SimulatorNavigation {
 
     return new THREE.Vector3()
       .copy(randomTriangleA)
-      .addScaledVector(randomTriangleAB.subVectors(randomTriangleB, randomTriangleA), u)
-      .addScaledVector(randomTriangleAC.subVectors(randomTriangleC, randomTriangleA), v);
+      .addScaledVector(
+        randomTriangleAB.subVectors(randomTriangleB, randomTriangleA),
+        u
+      )
+      .addScaledVector(
+        randomTriangleAC.subVectors(randomTriangleC, randomTriangleA),
+        v
+      );
   }
 
   private async loadGeometry(

--- a/src/simulator/SimulatorNavigation.ts
+++ b/src/simulator/SimulatorNavigation.ts
@@ -8,11 +8,26 @@ const DEFAULT_ZONE_ID = 'simulator';
 
 type PathfindingConstructor = typeof import('three-pathfinding').Pathfinding;
 type PathfindingNode = ReturnType<PathfindingType['getClosestNode']>;
+type PathfindingZone = {
+  groups: PathfindingNode[][];
+  vertices: THREE.Vector3[];
+};
+
+export interface SimulatorNavigationPath {
+  target: THREE.Vector3;
+  path: THREE.Vector3[];
+}
 
 const desiredGroundPosition = new THREE.Vector3();
 const startGroundPosition = new THREE.Vector3();
 const clampedGroundPosition = new THREE.Vector3();
 const initialScenePosition = new THREE.Vector3();
+const targetWorldPosition = new THREE.Vector3();
+const randomTriangleA = new THREE.Vector3();
+const randomTriangleB = new THREE.Vector3();
+const randomTriangleC = new THREE.Vector3();
+const randomTriangleAB = new THREE.Vector3();
+const randomTriangleAC = new THREE.Vector3();
 
 export class SimulatorNavigation {
   enabled = false;
@@ -20,6 +35,7 @@ export class SimulatorNavigation {
 
   private Pathfinding?: PathfindingConstructor;
   private pathfinding?: PathfindingType;
+  private zone?: PathfindingZone;
   private zoneId = DEFAULT_ZONE_ID;
   private groupId: number | null = null;
   private currentNode: PathfindingNode | null = null;
@@ -47,6 +63,7 @@ export class SimulatorNavigation {
     this.groupId = null;
     this.currentNode = null;
     this.pathfinding = undefined;
+    this.zone = undefined;
 
     if (!this.enabled) return;
     if (!environment?.navMeshPath) {
@@ -78,8 +95,10 @@ export class SimulatorNavigation {
 
   async setGeometry(geometry: THREE.BufferGeometry) {
     const Pathfinding = await this.loadPathfinding();
+    const zone = Pathfinding.createZone(geometry) as PathfindingZone;
     this.pathfinding = new Pathfinding();
-    this.pathfinding.setZoneData(this.zoneId, Pathfinding.createZone(geometry));
+    this.pathfinding.setZoneData(this.zoneId, zone);
+    this.zone = zone;
     this.ready = true;
     this.groupId = null;
     this.currentNode = null;
@@ -149,9 +168,7 @@ export class SimulatorNavigation {
     if (!this.constrained || !this.pathfinding) return null;
     const start = startGroundPosition.copy(startCameraPosition);
     start.y -= this.eyeHeight;
-    const groupId = this.pathfinding.getGroup(this.zoneId, start) as
-      | number
-      | null;
+    const groupId = this.getGroup(start);
     if (groupId === null) return null;
     return this.pathfinding.findPath(
       start,
@@ -159,6 +176,94 @@ export class SimulatorNavigation {
       this.zoneId,
       groupId
     );
+  }
+
+  findRandomPathFrom(
+    startCameraPosition: THREE.Vector3
+  ): SimulatorNavigationPath | null {
+    if (!this.constrained || !this.pathfinding || !this.zone) return null;
+    const start = startGroundPosition.copy(startCameraPosition);
+    start.y -= this.eyeHeight;
+    const groupId = this.getGroup(start);
+    if (groupId === null) return null;
+
+    const target = this.getRandomPointInGroup(groupId);
+    if (!target) return null;
+
+    const path = this.pathfinding.findPath(
+      start,
+      target,
+      this.zoneId,
+      groupId
+    );
+    if (!path) return null;
+    return {target, path};
+  }
+
+  isGroundPositionReachable(
+    startCameraPosition: THREE.Vector3,
+    targetGroundPosition: THREE.Vector3
+  ) {
+    return this.findPathTo(startCameraPosition, targetGroundPosition) !== null;
+  }
+
+  isObjectReachable(startCameraPosition: THREE.Vector3, object: THREE.Object3D) {
+    object.getWorldPosition(targetWorldPosition);
+    return this.isGroundPositionReachable(
+      startCameraPosition,
+      targetWorldPosition
+    );
+  }
+
+  private getGroup(position: THREE.Vector3) {
+    if (!this.pathfinding) return null;
+    return this.pathfinding.getGroup(this.zoneId, position) as number | null;
+  }
+
+  private getRandomPointInGroup(groupId: number) {
+    const group = this.zone?.groups[groupId];
+    if (!group) return null;
+
+    let totalArea = 0;
+    const areas = group.map((node) => {
+      const area = this.getNodeArea(node);
+      totalArea += area;
+      return totalArea;
+    });
+    if (totalArea <= 0) return null;
+
+    const targetArea = Math.random() * totalArea;
+    const nodeIndex = areas.findIndex((area) => area >= targetArea);
+    const node = group[nodeIndex === -1 ? group.length - 1 : nodeIndex];
+    return this.sampleNode(node);
+  }
+
+  private getNodeArea(node: PathfindingNode) {
+    if (!node || !this.zone) return 0;
+    const [a, b, c] = node.vertexIds.map((id) => this.zone!.vertices[id]);
+    randomTriangleAB.subVectors(b, a);
+    randomTriangleAC.subVectors(c, a);
+    return randomTriangleAB.cross(randomTriangleAC).length() * 0.5;
+  }
+
+  private sampleNode(node: PathfindingNode) {
+    if (!node || !this.zone) return null;
+    const [a, b, c] = node.vertexIds.map((id) => this.zone!.vertices[id]);
+    randomTriangleA.copy(a);
+    randomTriangleB.copy(b);
+    randomTriangleC.copy(c);
+
+    let u = Math.random();
+    let v = Math.random();
+    if (u + v > 1) {
+      u = 1 - u;
+      v = 1 - v;
+    }
+
+    return new THREE.Vector3()
+      .copy(randomTriangleA)
+      .addScaledVector(randomTriangleAB.subVectors(randomTriangleB, randomTriangleA), u)
+      .addScaledVector(randomTriangleAC.subVectors(randomTriangleC, randomTriangleA), v);
   }
 
   private async loadGeometry(

--- a/src/simulator/SimulatorOptions.ts
+++ b/src/simulator/SimulatorOptions.ts
@@ -30,6 +30,7 @@ export interface SimulatorEnvironment {
   name: string;
   scenePath?: string | null;
   scenePlanesPath?: string | null;
+  navMeshPath?: string | null;
   videoPath?: string;
 }
 
@@ -75,6 +76,10 @@ export class SimulatorOptions {
   };
   stereo = {
     enabled: false,
+  };
+  navigation = {
+    enabled: false,
+    eyeHeight: 1.5,
   };
   deviceCamera = {
     // Whether to enable the simulator camera feed.

--- a/src/simulator/SimulatorOptions.ts
+++ b/src/simulator/SimulatorOptions.ts
@@ -45,6 +45,9 @@ export class SimulatorOptions {
       scenePlanesPath:
         XR_BLOCKS_ASSETS_PATH +
         'simulator/scenes/XREmulatorsceneV5_livingRoom_planes.json',
+      navMeshPath:
+        XR_BLOCKS_ASSETS_PATH +
+        'simulator/scenes/XREmulatorsceneV5_livingRoom_navmesh.glb',
     },
   ];
   activeEnvironmentIndex = 0;

--- a/src/simulator/SimulatorOptions.ts
+++ b/src/simulator/SimulatorOptions.ts
@@ -77,7 +77,7 @@ export class SimulatorOptions {
   stereo = {
     enabled: false,
   };
-  navigation = {
+  navMesh = {
     enabled: false,
     eyeHeight: 1.5,
   };

--- a/src/simulator/controlModes/SimulatorControlMode.ts
+++ b/src/simulator/controlModes/SimulatorControlMode.ts
@@ -22,6 +22,8 @@ const axisVec = new THREE.Vector3();
 const currentOffsetVec = new THREE.Vector3();
 const newOffsetVec = new THREE.Vector3();
 const euler = new THREE.Euler();
+const yawEuler = new THREE.Euler();
+const yawQuaternion = new THREE.Quaternion();
 const HAND_POSES = Object.values(SimulatorHandPose);
 
 export class SimulatorControlMode {
@@ -107,22 +109,15 @@ export class SimulatorControlMode {
 
     const deltaTime = this.timer.getDelta();
     const cameraRotation = this.camera.quaternion;
-    const cameraPosition = this.camera.position;
     const downKeys = this.downKeys;
-    desiredCameraPosition.copy(cameraPosition);
-    desiredCameraPosition.add(
-      vector3
-        .set(
-          Number(downKeys.has(D_CODE)) - Number(downKeys.has(A_CODE)),
-          this.navMesh.constrained
-            ? 0
-            : Number(downKeys.has(Q_CODE)) - Number(downKeys.has(E_CODE)),
-          Number(downKeys.has(S_CODE)) - Number(downKeys.has(W_CODE))
-        )
-        .multiplyScalar(deltaTime)
-        .applyQuaternion(cameraRotation)
+    this.applyYawRelativeMovement(
+      Number(downKeys.has(D_CODE)) - Number(downKeys.has(A_CODE)),
+      this.navMesh.constrained
+        ? 0
+        : Number(downKeys.has(Q_CODE)) - Number(downKeys.has(E_CODE)),
+      Number(downKeys.has(S_CODE)) - Number(downKeys.has(W_CODE)),
+      deltaTime
     );
-    this.navMesh.applyUserMovement(this.camera, desiredCameraPosition);
 
     // Gamepad stick input (if connected). Skip while the tab isn't
     // focused — the Gamepad API delivers state to every tab, so without
@@ -133,14 +128,7 @@ export class SimulatorControlMode {
 
       // Left stick → move camera.
       if (lx !== 0 || ly !== 0) {
-        desiredCameraPosition.copy(cameraPosition);
-        desiredCameraPosition.add(
-          vector3
-            .set(lx, 0, ly)
-            .multiplyScalar(deltaTime)
-            .applyQuaternion(cameraRotation)
-        );
-        this.navMesh.applyUserMovement(this.camera, desiredCameraPosition);
+        this.applyYawRelativeMovement(lx, 0, ly, deltaTime);
       }
 
       // Right stick → look (yaw + pitch).
@@ -160,12 +148,30 @@ export class SimulatorControlMode {
         const upVal = gp.getButtonValue(gp.bindings.getBinding('moveUp'));
         const verticalDelta = (upVal - downVal) * deltaTime;
         if (verticalDelta !== 0) {
-          desiredCameraPosition.copy(cameraPosition);
+          desiredCameraPosition.copy(this.camera.position);
           desiredCameraPosition.y += verticalDelta;
           this.navMesh.applyUserMovement(this.camera, desiredCameraPosition);
         }
       }
     }
+  }
+
+  private applyYawRelativeMovement(
+    localX: number,
+    localY: number,
+    localZ: number,
+    deltaTime: number
+  ) {
+    euler.setFromQuaternion(this.camera.quaternion, 'YXZ');
+    yawEuler.set(0, euler.y, 0, 'YXZ');
+    yawQuaternion.setFromEuler(yawEuler);
+    vector3
+      .set(localX, 0, localZ)
+      .multiplyScalar(deltaTime)
+      .applyQuaternion(yawQuaternion);
+    vector3.y += localY * deltaTime;
+    desiredCameraPosition.copy(this.camera.position).add(vector3);
+    this.navMesh.applyUserMovement(this.camera, desiredCameraPosition);
   }
 
   /**

--- a/src/simulator/controlModes/SimulatorControlMode.ts
+++ b/src/simulator/controlModes/SimulatorControlMode.ts
@@ -3,13 +3,15 @@ import * as THREE from 'three';
 import {GamepadController} from '../../input/GamepadController.js';
 import {Input} from '../../input/Input.js';
 import {Keycodes} from '../../utils/Keycodes';
+import {SimulatorHandPose} from '../handPoses/HandPoses';
 import {SimulatorRenderMode} from '../SimulatorConstants';
 import {SimulatorControllerState} from '../SimulatorControllerState';
 import {SimulatorHands} from '../SimulatorHands.js';
-import {SimulatorHandPose} from '../handPoses/HandPoses';
+import {SimulatorNavigation} from '../SimulatorNavigation';
 
 const {A_CODE, D_CODE, E_CODE, Q_CODE, S_CODE, W_CODE} = Keycodes;
 const vector3 = new THREE.Vector3();
+const desiredCameraPosition = new THREE.Vector3();
 const euler = new THREE.Euler();
 const HAND_POSES = Object.values(SimulatorHandPose);
 
@@ -26,6 +28,7 @@ export class SimulatorControlMode {
     protected simulatorControllerState: SimulatorControllerState,
     protected downKeys: Set<Keycodes>,
     protected hands: SimulatorHands,
+    protected navigation: SimulatorNavigation,
     protected setStereoRenderMode: (_: SimulatorRenderMode) => void,
     protected toggleUserInterface: () => void,
     protected cycleSimulatorMode: () => void = () => {}
@@ -93,15 +96,20 @@ export class SimulatorControlMode {
     const cameraRotation = this.camera.quaternion;
     const cameraPosition = this.camera.position;
     const downKeys = this.downKeys;
-    vector3
-      .set(
-        Number(downKeys.has(D_CODE)) - Number(downKeys.has(A_CODE)),
-        Number(downKeys.has(Q_CODE)) - Number(downKeys.has(E_CODE)),
-        Number(downKeys.has(S_CODE)) - Number(downKeys.has(W_CODE))
-      )
-      .multiplyScalar(deltaTime)
-      .applyQuaternion(cameraRotation);
-    cameraPosition.add(vector3);
+    desiredCameraPosition.copy(cameraPosition);
+    desiredCameraPosition.add(
+      vector3
+        .set(
+          Number(downKeys.has(D_CODE)) - Number(downKeys.has(A_CODE)),
+          this.navigation.constrained
+            ? 0
+            : Number(downKeys.has(Q_CODE)) - Number(downKeys.has(E_CODE)),
+          Number(downKeys.has(S_CODE)) - Number(downKeys.has(W_CODE))
+        )
+        .multiplyScalar(deltaTime)
+        .applyQuaternion(cameraRotation)
+    );
+    this.navigation.applyUserMovement(this.camera, desiredCameraPosition);
 
     // Gamepad stick input (if connected). Skip while the tab isn't
     // focused — the Gamepad API delivers state to every tab, so without
@@ -112,11 +120,14 @@ export class SimulatorControlMode {
 
       // Left stick → move camera.
       if (lx !== 0 || ly !== 0) {
-        vector3
-          .set(lx, 0, ly)
-          .multiplyScalar(deltaTime)
-          .applyQuaternion(cameraRotation);
-        cameraPosition.add(vector3);
+        desiredCameraPosition.copy(cameraPosition);
+        desiredCameraPosition.add(
+          vector3
+            .set(lx, 0, ly)
+            .multiplyScalar(deltaTime)
+            .applyQuaternion(cameraRotation)
+        );
+        this.navigation.applyUserMovement(this.camera, desiredCameraPosition);
       }
 
       // Right stick → look (yaw + pitch).
@@ -131,11 +142,15 @@ export class SimulatorControlMode {
       }
 
       // Configurable vertical movement bindings (defaults LT/RT, analog).
-      const downVal = gp.getButtonValue(gp.bindings.getBinding('moveDown'));
-      const upVal = gp.getButtonValue(gp.bindings.getBinding('moveUp'));
-      const verticalDelta = (upVal - downVal) * deltaTime;
-      if (verticalDelta !== 0) {
-        cameraPosition.y += verticalDelta;
+      if (!this.navigation.constrained) {
+        const downVal = gp.getButtonValue(gp.bindings.getBinding('moveDown'));
+        const upVal = gp.getButtonValue(gp.bindings.getBinding('moveUp'));
+        const verticalDelta = (upVal - downVal) * deltaTime;
+        if (verticalDelta !== 0) {
+          desiredCameraPosition.copy(cameraPosition);
+          desiredCameraPosition.y += verticalDelta;
+          this.navigation.applyUserMovement(this.camera, desiredCameraPosition);
+        }
       }
     }
   }

--- a/src/simulator/controlModes/SimulatorControlMode.ts
+++ b/src/simulator/controlModes/SimulatorControlMode.ts
@@ -7,7 +7,7 @@ import {SimulatorHandPose} from '../handPoses/HandPoses';
 import {SimulatorRenderMode} from '../SimulatorConstants';
 import {SimulatorControllerState} from '../SimulatorControllerState';
 import {SimulatorHands} from '../SimulatorHands.js';
-import {SimulatorNavigation} from '../SimulatorNavigation';
+import {SimulatorNavMesh} from '../SimulatorNavMesh';
 
 const {A_CODE, D_CODE, E_CODE, Q_CODE, S_CODE, W_CODE} = Keycodes;
 const vector3 = new THREE.Vector3();
@@ -28,7 +28,7 @@ export class SimulatorControlMode {
     protected simulatorControllerState: SimulatorControllerState,
     protected downKeys: Set<Keycodes>,
     protected hands: SimulatorHands,
-    protected navigation: SimulatorNavigation,
+    protected navMesh: SimulatorNavMesh,
     protected setStereoRenderMode: (_: SimulatorRenderMode) => void,
     protected toggleUserInterface: () => void,
     protected cycleSimulatorMode: () => void = () => {}
@@ -101,7 +101,7 @@ export class SimulatorControlMode {
       vector3
         .set(
           Number(downKeys.has(D_CODE)) - Number(downKeys.has(A_CODE)),
-          this.navigation.constrained
+          this.navMesh.constrained
             ? 0
             : Number(downKeys.has(Q_CODE)) - Number(downKeys.has(E_CODE)),
           Number(downKeys.has(S_CODE)) - Number(downKeys.has(W_CODE))
@@ -109,7 +109,7 @@ export class SimulatorControlMode {
         .multiplyScalar(deltaTime)
         .applyQuaternion(cameraRotation)
     );
-    this.navigation.applyUserMovement(this.camera, desiredCameraPosition);
+    this.navMesh.applyUserMovement(this.camera, desiredCameraPosition);
 
     // Gamepad stick input (if connected). Skip while the tab isn't
     // focused — the Gamepad API delivers state to every tab, so without
@@ -127,7 +127,7 @@ export class SimulatorControlMode {
             .multiplyScalar(deltaTime)
             .applyQuaternion(cameraRotation)
         );
-        this.navigation.applyUserMovement(this.camera, desiredCameraPosition);
+        this.navMesh.applyUserMovement(this.camera, desiredCameraPosition);
       }
 
       // Right stick → look (yaw + pitch).
@@ -142,14 +142,14 @@ export class SimulatorControlMode {
       }
 
       // Configurable vertical movement bindings (defaults LT/RT, analog).
-      if (!this.navigation.constrained) {
+      if (!this.navMesh.constrained) {
         const downVal = gp.getButtonValue(gp.bindings.getBinding('moveDown'));
         const upVal = gp.getButtonValue(gp.bindings.getBinding('moveUp'));
         const verticalDelta = (upVal - downVal) * deltaTime;
         if (verticalDelta !== 0) {
           desiredCameraPosition.copy(cameraPosition);
           desiredCameraPosition.y += verticalDelta;
-          this.navigation.applyUserMovement(this.camera, desiredCameraPosition);
+          this.navMesh.applyUserMovement(this.camera, desiredCameraPosition);
         }
       }
     }

--- a/src/simulator/controlModes/SimulatorControlMode.ts
+++ b/src/simulator/controlModes/SimulatorControlMode.ts
@@ -3,7 +3,6 @@ import * as THREE from 'three';
 import {GamepadController} from '../../input/GamepadController.js';
 import {Input} from '../../input/Input.js';
 import {Keycodes} from '../../utils/Keycodes';
-import {SimulatorHandPose} from '../handPoses/HandPoses';
 import {SimulatorRenderMode} from '../SimulatorConstants';
 import {SimulatorControllerState} from '../SimulatorControllerState';
 import {SimulatorHands} from '../SimulatorHands.js';

--- a/src/simulator/controlModes/SimulatorPointerLockMode.test.ts
+++ b/src/simulator/controlModes/SimulatorPointerLockMode.test.ts
@@ -4,6 +4,7 @@ import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {Input} from '../../input/Input';
 import {SimulatorControllerState} from '../SimulatorControllerState';
 import {SimulatorHands} from '../SimulatorHands';
+import {SimulatorNavigation} from '../SimulatorNavigation';
 import {SimulatorPointerLockMode} from './SimulatorPointerLockMode';
 
 describe('SimulatorPointerLockMode', () => {
@@ -41,6 +42,7 @@ describe('SimulatorPointerLockMode', () => {
       mockState,
       new Set(),
       mockHands,
+      new SimulatorNavigation(),
       vi.fn(),
       vi.fn(),
       vi.fn()

--- a/src/simulator/controlModes/SimulatorPointerLockMode.test.ts
+++ b/src/simulator/controlModes/SimulatorPointerLockMode.test.ts
@@ -4,7 +4,7 @@ import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {Input} from '../../input/Input';
 import {SimulatorControllerState} from '../SimulatorControllerState';
 import {SimulatorHands} from '../SimulatorHands';
-import {SimulatorNavigation} from '../SimulatorNavigation';
+import {SimulatorNavMesh} from '../SimulatorNavMesh';
 import {SimulatorPointerLockMode} from './SimulatorPointerLockMode';
 
 describe('SimulatorPointerLockMode', () => {
@@ -42,7 +42,7 @@ describe('SimulatorPointerLockMode', () => {
       mockState,
       new Set(),
       mockHands,
-      new SimulatorNavigation(),
+      new SimulatorNavMesh(),
       vi.fn(),
       vi.fn(),
       vi.fn()

--- a/src/simulator/userActions/WalkTowardsPanelAction.ts
+++ b/src/simulator/userActions/WalkTowardsPanelAction.ts
@@ -70,9 +70,10 @@ export class WalkTowardsPanelAction extends SimulatorUserAction {
     const camera = this.camera;
     this.target.getWorldPosition(targetWorldPosition);
     cameraToTargetVector.copy(targetWorldPosition).sub(camera.position);
+    cameraToTargetVector.y = 0;
     return (
-      Math.abs(cameraToTargetVector.length() - NEAR_TARGET_DISTANCE) <
-      NEAR_TARGET_THRESHOLD
+      cameraToTargetVector.length() <=
+      NEAR_TARGET_DISTANCE + NEAR_TARGET_THRESHOLD
     );
   }
 
@@ -105,20 +106,20 @@ export class WalkTowardsPanelAction extends SimulatorUserAction {
     const deltaTime = this.timer.getDelta();
     this.target.getWorldPosition(targetWorldPosition);
     cameraToTargetVector.copy(targetWorldPosition).sub(camera.position);
-    closeToTargetPosition
-      .copy(targetWorldPosition)
-      .addScaledVector(cameraToTargetVector, -NEAR_TARGET_THRESHOLD);
-    const cameraToCloseToTarget = closeToTargetPosition.sub(camera.position);
+    cameraToTargetVector.y = 0;
+    const distanceToTarget = cameraToTargetVector.length();
     const movementDistance = clamp(
-      cameraToCloseToTarget.length(),
+      distanceToTarget - NEAR_TARGET_DISTANCE,
       0,
       MOVEMENT_SPEED_METERS_PER_SECOND * deltaTime
     );
+    if (movementDistance === 0 || distanceToTarget === 0) return;
+
     closeToTargetPosition
       .copy(camera.position)
       .addScaledVector(
-        cameraToCloseToTarget,
-        movementDistance / cameraToCloseToTarget.length()
+        cameraToTargetVector,
+        movementDistance / distanceToTarget
       );
     this.navMesh.applyUserMovement(camera, closeToTargetPosition);
   }

--- a/src/simulator/userActions/WalkTowardsPanelAction.ts
+++ b/src/simulator/userActions/WalkTowardsPanelAction.ts
@@ -4,6 +4,7 @@ import {WaitFrame} from '../../core/components/WaitFrame';
 import {UP} from '../../utils/HelperConstants';
 import {clampRotationToAngle, lookAtRotation} from '../../utils/RotationUtils';
 import {clamp} from '../../utils/utils';
+import {SimulatorNavigation} from '../SimulatorNavigation';
 import {SimulatorUser} from '../SimulatorUser';
 
 import {SimulatorUserAction} from './SimulatorUserAction';
@@ -27,17 +28,31 @@ const inverseCameraRotation = new THREE.Quaternion();
  * Represents a action to walk towards a panel or object.
  */
 export class WalkTowardsPanelAction extends SimulatorUserAction {
-  static dependencies = {camera: THREE.Camera, timer: THREE.Timer};
+  static dependencies = {
+    camera: THREE.Camera,
+    timer: THREE.Timer,
+    navigation: SimulatorNavigation,
+  };
   camera!: THREE.Camera;
   timer!: THREE.Timer;
+  navigation!: SimulatorNavigation;
 
   constructor(private target: THREE.Object3D) {
     super();
   }
 
-  async init({camera, timer}: {camera: THREE.Camera; timer: THREE.Timer}) {
+  async init({
+    camera,
+    timer,
+    navigation,
+  }: {
+    camera: THREE.Camera;
+    timer: THREE.Timer;
+    navigation: SimulatorNavigation;
+  }) {
     this.camera = camera;
     this.timer = timer;
+    this.navigation = navigation;
   }
 
   isLookingAtTarget() {
@@ -99,10 +114,13 @@ export class WalkTowardsPanelAction extends SimulatorUserAction {
       0,
       MOVEMENT_SPEED_METERS_PER_SECOND * deltaTime
     );
-    camera.position.addScaledVector(
-      cameraToCloseToTarget,
-      movementDistance / cameraToCloseToTarget.length()
-    );
+    closeToTargetPosition
+      .copy(camera.position)
+      .addScaledVector(
+        cameraToCloseToTarget,
+        movementDistance / cameraToCloseToTarget.length()
+      );
+    this.navigation.applyUserMovement(camera, closeToTargetPosition);
   }
 
   async play({

--- a/src/simulator/userActions/WalkTowardsPanelAction.ts
+++ b/src/simulator/userActions/WalkTowardsPanelAction.ts
@@ -4,7 +4,7 @@ import {WaitFrame} from '../../core/components/WaitFrame';
 import {UP} from '../../utils/HelperConstants';
 import {clampRotationToAngle, lookAtRotation} from '../../utils/RotationUtils';
 import {clamp} from '../../utils/utils';
-import {SimulatorNavigation} from '../SimulatorNavigation';
+import {SimulatorNavMesh} from '../SimulatorNavMesh';
 import {SimulatorUser} from '../SimulatorUser';
 
 import {SimulatorUserAction} from './SimulatorUserAction';
@@ -31,11 +31,11 @@ export class WalkTowardsPanelAction extends SimulatorUserAction {
   static dependencies = {
     camera: THREE.Camera,
     timer: THREE.Timer,
-    navigation: SimulatorNavigation,
+    navMesh: SimulatorNavMesh,
   };
   camera!: THREE.Camera;
   timer!: THREE.Timer;
-  navigation!: SimulatorNavigation;
+  navMesh!: SimulatorNavMesh;
 
   constructor(private target: THREE.Object3D) {
     super();
@@ -44,15 +44,15 @@ export class WalkTowardsPanelAction extends SimulatorUserAction {
   async init({
     camera,
     timer,
-    navigation,
+    navMesh,
   }: {
     camera: THREE.Camera;
     timer: THREE.Timer;
-    navigation: SimulatorNavigation;
+    navMesh: SimulatorNavMesh;
   }) {
     this.camera = camera;
     this.timer = timer;
-    this.navigation = navigation;
+    this.navMesh = navMesh;
   }
 
   isLookingAtTarget() {
@@ -120,7 +120,7 @@ export class WalkTowardsPanelAction extends SimulatorUserAction {
         cameraToCloseToTarget,
         movementDistance / cameraToCloseToTarget.length()
       );
-    this.navigation.applyUserMovement(camera, closeToTargetPosition);
+    this.navMesh.applyUserMovement(camera, closeToTargetPosition);
   }
 
   async play({

--- a/src/xrblocks.ts
+++ b/src/xrblocks.ts
@@ -71,6 +71,7 @@ export * from './simulator/SimulatorDepthMaterial';
 export * from './simulator/SimulatorHands';
 export * from './simulator/SimulatorInterface';
 export * from './simulator/SimulatorMediaDeviceInfo';
+export * from './simulator/SimulatorNavigation';
 export * from './simulator/SimulatorOptions';
 export * from './simulator/SimulatorPointerLockController';
 export * from './simulator/interfaces/ISimulatorSettingsPanelElement';

--- a/src/xrblocks.ts
+++ b/src/xrblocks.ts
@@ -71,7 +71,7 @@ export * from './simulator/SimulatorDepthMaterial';
 export * from './simulator/SimulatorHands';
 export * from './simulator/SimulatorInterface';
 export * from './simulator/SimulatorMediaDeviceInfo';
-export * from './simulator/SimulatorNavigation';
+export * from './simulator/SimulatorNavMesh';
 export * from './simulator/SimulatorOptions';
 export * from './simulator/SimulatorPointerLockController';
 export * from './simulator/interfaces/ISimulatorSettingsPanelElement';


### PR DESCRIPTION
Simulator now can run on a navmesh to support bounded walking and realistic interactions in environments
- Added one new dependency [three-pathfinding](https://github.com/donmccurdy/three-pathfinding)
- created a navmesh for the simulator scene
- Added SimulatorNavMesh which sets up pathfinding and constrained movement throughout scenes on navmesh
- Added a demo for visualization

Leaving as draft since the navmesh isn't in the assets repo yet so the loading for that isn't done.

[demo](https://youtu.be/vwo7k1EaK7Q)