### PR TITLE
Add mouse wheel scaling for ModelViewers in the simulator

### DIFF
--- a/docs/docs/manual/Simulator.mdx
+++ b/docs/docs/manual/Simulator.mdx
@@ -67,6 +67,7 @@ In user mode, WASD on the keyboard controls the forward, left, backwards, and ri
 The mouse cursor is respresented to the application through a `MouseController` object which moves based on the camera and rotates based on the pose position in the window.
 Holding down the primary mouse button represents a selection on the `MouseController` object.
 Holding down the secondary mouse button allows the mouse cursor to rotate the camera.
+Point at a scalable `ModelViewer` and use the mouse wheel to scale it up or down.
 
 ### Navigation Mode
 

--- a/src/addons/simulator/instructions/UserInstructions.ts
+++ b/src/addons/simulator/instructions/UserInstructions.ts
@@ -35,6 +35,10 @@ export class UserInstructions extends SimulatorInstructionsCard {
         <li>
           <strong>Rotate Camera:</strong> Hold the right mouse button and drag.
         </li>
+        <li>
+          <strong>Scale a ModelViewer:</strong> Point at it and use the mouse
+          wheel.
+        </li>
         <li><strong>Select Object:</strong> Left-click the mouse.</li>
       </ul>
     `;

--- a/src/simulator/SimulatorControls.test.ts
+++ b/src/simulator/SimulatorControls.test.ts
@@ -1,0 +1,84 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {SimulatorControllerState} from './SimulatorControllerState';
+import {SimulatorControls} from './SimulatorControls';
+import {SimulatorHands} from './SimulatorHands';
+import {SimulatorInterface} from './SimulatorInterface';
+import {SimulatorNavMesh} from './SimulatorNavMesh';
+
+function createControls() {
+  return new SimulatorControls(
+    {} as SimulatorControllerState,
+    {} as SimulatorHands,
+    new SimulatorNavMesh(),
+    vi.fn(),
+    {} as SimulatorInterface
+  );
+}
+
+describe('SimulatorControls wheel input', () => {
+  const connectedControls: SimulatorControls[] = [];
+
+  afterEach(() => {
+    for (const controls of connectedControls) {
+      document.removeEventListener('keyup', controls.onKeyUp);
+      document.removeEventListener('keydown', controls.onKeyDown);
+      window.removeEventListener('blur', controls.onBlur);
+      document.removeEventListener('visibilitychange', controls.onBlur);
+    }
+    connectedControls.length = 0;
+  });
+
+  it('prevents the default wheel action when the active mode handles it', () => {
+    const controls = createControls();
+    const canvas = document.createElement('canvas');
+    controls.renderer = {domElement: canvas} as never;
+    const wheelSpy = vi
+      .spyOn(controls.simulatorModeControls, 'onWheel')
+      .mockReturnValue(true);
+    connectedControls.push(controls);
+    controls.connect();
+
+    const event = new WheelEvent('wheel', {
+      deltaY: -100,
+      cancelable: true,
+    });
+    canvas.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(wheelSpy).toHaveBeenCalledWith(event);
+  });
+
+  it('does not prevent the default wheel action when the active mode does not handle it', () => {
+    const controls = createControls();
+    const wheelSpy = vi
+      .spyOn(controls.simulatorModeControls, 'onWheel')
+      .mockReturnValue(false);
+    const event = new WheelEvent('wheel', {
+      deltaY: -100,
+      cancelable: true,
+    });
+
+    controls.onWheel(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(wheelSpy).toHaveBeenCalledWith(event);
+  });
+
+  it('does not capture or forward wheel events while controls are disabled', () => {
+    const controls = createControls();
+    const wheelSpy = vi
+      .spyOn(controls.simulatorModeControls, 'onWheel')
+      .mockReturnValue(true);
+    controls.enabled = false;
+    const event = new WheelEvent('wheel', {
+      deltaY: -100,
+      cancelable: true,
+    });
+
+    controls.onWheel(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(wheelSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/simulator/SimulatorControls.ts
+++ b/src/simulator/SimulatorControls.ts
@@ -147,6 +147,7 @@ export class SimulatorControls {
     domElement.addEventListener('pointermove', this.onPointerMove);
     domElement.addEventListener('pointerdown', this.onPointerDown);
     domElement.addEventListener('pointerup', this.onPointerUp);
+    domElement.addEventListener('wheel', this.onWheel, {passive: false});
     domElement.addEventListener('contextmenu', preventDefault);
     window.addEventListener('blur', this.onBlur);
     document.addEventListener('visibilitychange', this.onBlur);
@@ -171,6 +172,13 @@ export class SimulatorControls {
     if (!this.enabled) return;
     this.simulatorModeControls.onPointerUp(event);
     this.pointerDown = false;
+  };
+
+  onWheel = (event: WheelEvent) => {
+    if (!this.enabled) return;
+    if (this.simulatorModeControls.onWheel(event)) {
+      event.preventDefault();
+    }
   };
 
   onKeyDown = (event: KeyboardEvent) => {

--- a/src/simulator/controlModes/SimulatorControlMode.ts
+++ b/src/simulator/controlModes/SimulatorControlMode.ts
@@ -73,6 +73,9 @@ export class SimulatorControlMode {
   onPointerDown(_: MouseEvent) {}
   onPointerUp(_: MouseEvent) {}
   onPointerMove(_: MouseEvent) {}
+  onWheel(_: WheelEvent) {
+    return false;
+  }
   onKeyDown(event: KeyboardEvent) {
     if (event.code == Keycodes.DIGIT_1) {
       this.setStereoRenderMode(SimulatorRenderMode.STEREO_LEFT);

--- a/src/simulator/controlModes/SimulatorUserMode.test.ts
+++ b/src/simulator/controlModes/SimulatorUserMode.test.ts
@@ -1,0 +1,135 @@
+import * as THREE from 'three';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {Input} from '../../input/Input';
+import {MouseController} from '../../input/MouseController';
+import {ModelViewer} from '../../ui/interaction/ModelViewer';
+import {SimulatorControllerState} from '../SimulatorControllerState';
+import {SimulatorHands} from '../SimulatorHands';
+import {SimulatorNavMesh} from '../SimulatorNavMesh';
+import {SimulatorUserMode} from './SimulatorUserMode';
+
+describe('SimulatorUserMode wheel scaling', () => {
+  let canvas: HTMLCanvasElement;
+  let input: Input;
+  let mode: SimulatorUserMode;
+  let mouseController: MouseController;
+
+  beforeEach(() => {
+    canvas = document.createElement('canvas');
+    mouseController = {
+      updateMousePositionFromEvent: vi.fn(),
+      userData: {connected: true},
+    } as unknown as MouseController;
+    input = {
+      gamepadController: {init: vi.fn()},
+      intersectionsForController: new Map([[mouseController, []]]),
+      mouseController,
+      updateController: vi.fn(),
+    } as unknown as Input;
+    mode = new SimulatorUserMode(
+      {} as SimulatorControllerState,
+      new Set(),
+      {} as SimulatorHands,
+      new SimulatorNavMesh(),
+      vi.fn(),
+      vi.fn()
+    );
+    mode.init({
+      camera: new THREE.Camera(),
+      input,
+      timer: new THREE.Timer(),
+      domElement: canvas,
+    });
+  });
+
+  function pointAt(object: THREE.Object3D) {
+    input.intersectionsForController.set(mouseController, [
+      {object} as THREE.Intersection,
+    ]);
+  }
+
+  it('uniformly scales the ModelViewer under the mouse pointer', () => {
+    const modelViewer = new ModelViewer({});
+    const modelMesh = new THREE.Mesh();
+    modelViewer.add(modelMesh);
+    modelViewer.scale.set(1, 2, 3);
+    pointAt(modelMesh);
+    const event = new WheelEvent('wheel', {deltaY: -100});
+
+    expect(mode.onWheel(event)).toBe(true);
+
+    const scaleFactor = Math.exp(0.1);
+    expect(modelViewer.scale.x).toBeCloseTo(scaleFactor);
+    expect(modelViewer.scale.y).toBeCloseTo(2 * scaleFactor);
+    expect(modelViewer.scale.z).toBeCloseTo(3 * scaleFactor);
+    expect(mouseController.updateMousePositionFromEvent).toHaveBeenCalledWith(
+      event
+    );
+    expect(input.updateController).toHaveBeenCalledWith(mouseController);
+  });
+
+  it('scales down when scrolling in the opposite direction', () => {
+    const modelViewer = new ModelViewer({});
+    pointAt(modelViewer);
+
+    expect(mode.onWheel(new WheelEvent('wheel', {deltaY: 100}))).toBe(true);
+
+    expect(modelViewer.scale.x).toBeCloseTo(Math.exp(-0.1));
+    expect(modelViewer.scale.y).toBeCloseTo(Math.exp(-0.1));
+    expect(modelViewer.scale.z).toBeCloseTo(Math.exp(-0.1));
+  });
+
+  it('does not handle wheel input when the targeted ModelViewer is not scalable', () => {
+    const modelViewer = new ModelViewer({});
+    modelViewer.scalable = false;
+    pointAt(modelViewer);
+
+    expect(mode.onWheel(new WheelEvent('wheel', {deltaY: -100}))).toBe(false);
+    expect(modelViewer.scale.toArray()).toEqual([1, 1, 1]);
+  });
+
+  it('does not scale a ModelViewer behind a closer non-ModelViewer object', () => {
+    const foreground = new THREE.Mesh();
+    const modelViewer = new ModelViewer({});
+    input.intersectionsForController.set(mouseController, [
+      {object: foreground} as THREE.Intersection,
+      {object: modelViewer} as THREE.Intersection,
+    ]);
+
+    expect(mode.onWheel(new WheelEvent('wheel', {deltaY: -100}))).toBe(false);
+    expect(modelViewer.scale.toArray()).toEqual([1, 1, 1]);
+  });
+
+  it('normalizes line-based wheel deltas', () => {
+    const modelViewer = new ModelViewer({});
+    pointAt(modelViewer);
+
+    mode.onWheel(
+      new WheelEvent('wheel', {
+        deltaY: -3,
+        deltaMode: WheelEvent.DOM_DELTA_LINE,
+      })
+    );
+
+    expect(modelViewer.scale.x).toBeCloseTo(Math.exp(0.048));
+  });
+
+  it('normalizes page-based wheel deltas using the canvas height', () => {
+    const modelViewer = new ModelViewer({});
+    pointAt(modelViewer);
+    Object.defineProperty(canvas, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+
+    mode.onWheel(
+      new WheelEvent('wheel', {
+        deltaY: -1,
+        deltaMode: WheelEvent.DOM_DELTA_PAGE,
+      })
+    );
+
+    expect(modelViewer.scale.x).toBeCloseTo(Math.exp(0.6));
+  });
+});

--- a/src/simulator/controlModes/SimulatorUserMode.ts
+++ b/src/simulator/controlModes/SimulatorUserMode.ts
@@ -1,4 +1,10 @@
+import {ModelViewer} from '../../ui/interaction/ModelViewer.js';
+
 import {SimulatorControlMode} from './SimulatorControlMode.js';
+
+const WHEEL_SCALE_SPEED = 0.001;
+// Approximate one line-mode wheel unit as 16 CSS pixels.
+const WHEEL_LINE_HEIGHT = 16;
 
 export class SimulatorUserMode extends SimulatorControlMode {
   onModeActivated() {
@@ -39,5 +45,36 @@ export class SimulatorUserMode extends SimulatorControlMode {
     if (event.buttons & 2) {
       this.rotateOnPointerMove(event, this.camera.quaternion);
     }
+  }
+
+  override onWheel(event: WheelEvent) {
+    let deltaY = event.deltaY;
+    if (event.deltaMode === WheelEvent.DOM_DELTA_LINE) {
+      deltaY *= WHEEL_LINE_HEIGHT;
+    } else if (event.deltaMode === WheelEvent.DOM_DELTA_PAGE) {
+      deltaY *= this.domElement?.clientHeight || window.innerHeight;
+    }
+    if (deltaY === 0) {
+      return false;
+    }
+
+    const mouseController = this.input.mouseController;
+    mouseController.updateMousePositionFromEvent(event);
+    if (!mouseController.userData.connected) {
+      return false;
+    }
+    this.input.updateController(mouseController);
+
+    let target =
+      this.input.intersectionsForController.get(mouseController)?.[0]?.object;
+    while (target && !(target instanceof ModelViewer)) {
+      target = target.parent ?? undefined;
+    }
+    if (!(target instanceof ModelViewer) || !target.scalable) {
+      return false;
+    }
+
+    target.scale.multiplyScalar(Math.exp(-deltaY * WHEEL_SCALE_SPEED));
+    return true;
   }
 }


### PR DESCRIPTION
## Summary

- Scale the `ModelViewer` under the mouse pointer with the wheel in simulator User mode.
- Apply uniform model scaling as a desktop equivalent of the existing two-hand pinch gesture.
- Normalize pixel-, line-, and page-based wheel deltas.
- Preserve browser scrolling when no scalable `ModelViewer` is targeted.
- Update the simulator instructions and manual to describe the new control.
- Add tests for model targeting, scaling direction, delta normalization, and wheel event handling.

## Motivation

The simulator did not provide a mouse-based equivalent of the two-hand pinch gesture used to scale `ModelViewer` objects.

Mouse wheel input should change the targeted model's scale without moving the simulator camera or changing the user's viewport.

## Testing

- `npm run test` — 58 test files and 493 tests passed on Node.js 24
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `cd docs && npm run build`

Closes #428