### PR TITLE
keep the AgentHands controls closer to neutral gaze

### DIFF
--- a/demos/agent_hands/main.js
+++ b/demos/agent_hands/main.js
@@ -61,6 +61,11 @@ const LEAN_CLAMP = 0.5; // max yaw lean toward a pointing target (rad)
 const LEAN_X_GAIN = 0.25; // pitch lean per unit target height
 const LEAN_X_CLAMP = 0.25; // max pitch lean (rad)
 
+// Keep the control card near neutral gaze at a comfortable viewing distance
+// instead of targeting it far below the user's view.
+const PANEL_HEIGHT_M = -0.2;
+const PANEL_DISTANCE_M = 0.9;
+
 // Scripted (no-key) pacing, in seconds: the gap before the first pose, between
 // poses, before the closing rest, and before advancing to the next line.
 const SCRIPT_START_S = 0.4;
@@ -370,7 +375,7 @@ class AgentHandsDemo extends xb.Script {
     // Gently follow the user so the controls stay in reach as they move.
     card.addBehavior(
       new HeadLeashBehavior({
-        offset: new THREE.Vector3(0, -0.55, -0.85),
+        offset: new THREE.Vector3(0, PANEL_HEIGHT_M, -PANEL_DISTANCE_M),
         posLerp: 0.08,
         rotLerp: 0.1,
       })


### PR DESCRIPTION
the control panel from #416 sits pretty far below the initial view on Galaxy XR, so it needs a noticeable look down before you can use it.

this lifts the leash target from 0.55 m below gaze to 0.2 m and keeps it close at 0.9 m. the panel still follows smoothly and keeps its drag behavior, but should start inside a more comfortable part of the view without making the desktop rendering soft from pushing it farther away.

opening this as a draft until the placement gets a Galaxy XR check.
