### PR TITLE
feat(input): add PinchFilter helper to prevent false hand pinches

### DIFF
--- a/src/core/Core.test.ts
+++ b/src/core/Core.test.ts
@@ -43,6 +43,7 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
 
   beforeEach(() => {
     // Reset Core singleton to ensure fresh state for each test
+    Core.instance?.dispose();
     Core.instance = undefined;
     core = new Core();
     core.options = new Options();

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -248,6 +248,11 @@ export class Core {
     this.registry.register(this.xrSystemsGroup);
   }
 
+  dispose() {
+    this.input.dispose();
+    window.removeEventListener('resize', this.onWindowResize);
+  }
+
   /**
    * Initializes the Core system with a given set of options. This includes
    * setting up the renderer, enabling features like controllers, depth

--- a/src/input/Input.test.ts
+++ b/src/input/Input.test.ts
@@ -1,9 +1,10 @@
 import * as THREE from 'three';
-import {describe, expect, it} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 
 import {Options} from '../core/Options';
 import {XRSystems} from '../core/components/XRSystems';
 import {Input} from './Input';
+import {Controller} from './Controller';
 
 describe('Input head gestures', () => {
   it('creates head gestures without enabling controllers', () => {
@@ -37,5 +38,48 @@ describe('Input head gestures', () => {
     });
 
     expect(input.headGestures).toBeUndefined();
+  });
+});
+
+describe('Input resilience and cleanup', () => {
+  it('dispatches selectend and resets selected state upon disconnection', () => {
+    const input = new Input();
+    const mockController = new THREE.Object3D() as unknown as Controller;
+    mockController.userData = {connected: true, selected: true};
+
+    const selectEndSpy = vi.fn();
+    input.bindListener('selectend', selectEndSpy);
+    input.controllers.push(mockController);
+
+    input.defaultOnDisconnected({
+      type: 'disconnected',
+      target: mockController,
+    });
+
+    expect(mockController.userData.selected).toBe(false);
+    expect(selectEndSpy).toHaveBeenCalledTimes(1);
+    expect(selectEndSpy.mock.calls[0][0]).toMatchObject({
+      type: 'selectend',
+      target: mockController,
+    });
+  });
+
+  it('removes event listeners from controllers on dispose', () => {
+    const input = new Input();
+    const mockController = new THREE.Object3D() as unknown as Controller;
+    mockController.userData = {connected: true};
+
+    const addSpy = vi.spyOn(mockController, 'addEventListener');
+    const removeSpy = vi.spyOn(mockController, 'removeEventListener');
+
+    input.controllers.push(mockController);
+    input.bindListener('selectstart', vi.fn());
+
+    expect(addSpy).toHaveBeenCalled();
+    const listenerAdded = addSpy.mock.calls[0][1];
+
+    input.dispose();
+
+    expect(removeSpy).toHaveBeenCalledWith('selectstart', listenerAdded);
   });
 });

--- a/src/input/Input.ts
+++ b/src/input/Input.ts
@@ -19,6 +19,7 @@ import {GazeController} from './GazeController';
 import {HeadGestureRecognition} from './headGestures/HeadGestureRecognition';
 import {MouseController} from './MouseController';
 import {XRSystems} from '../core/components/XRSystems';
+import {PinchFilter} from './PinchFilter';
 
 export class ActiveControllers extends THREE.Group {
   type = 'ActiveControllers';
@@ -58,6 +59,7 @@ export class Input {
   gamepadController = new GamepadController();
   controllersEnabled = true;
   listeners = new Map();
+  private pinchFilter = new PinchFilter((event) => this.dispatchEvent(event));
   intersectionsForController = new Map<Controller, THREE.Intersection[]>();
   intersections = [];
   activeControllers = new ActiveControllers();
@@ -279,6 +281,15 @@ export class Input {
   defaultOnDisconnected(event: ControllerEvent) {
     const controller = event.target;
     controller.userData.connected = false;
+    if (controller.userData.selected) {
+      controller.userData.selected = false;
+      this.dispatchEvent({
+        type: 'selectend',
+        target: controller,
+        data: event.data,
+        isCustom: true,
+      } as unknown as ControllerEvent);
+    }
     if (controller.reticle) {
       controller.reticle.visible = false;
     }
@@ -303,7 +314,7 @@ export class Input {
     listener: (event: ControllerEvent) => void
   ) {
     for (const controller of this.controllers) {
-      controller.addEventListener(listenerName, listener);
+      this.pinchFilter.setupControllerForType(controller, listenerName);
     }
     if (!this.listeners.has(listenerName)) {
       this.listeners.set(listenerName, []);
@@ -316,18 +327,23 @@ export class Input {
     listener: (event: ControllerEvent) => void
   ) {
     if (this.listeners.has(listenerName)) {
-      const listeners = this.listeners.get(listenerName);
-      const index = listeners.indexOf(listener);
+      const list = this.listeners.get(listenerName)!;
+      const index = list.indexOf(listener);
       if (index !== -1) {
-        listeners.splice(index, 1);
+        list.splice(index, 1);
       }
-    }
-    for (const controller of this.controllers) {
-      controller.removeEventListener(listenerName, listener);
+      if (list.length === 0) {
+        for (const controller of this.controllers) {
+          this.pinchFilter.removeControllerForType(controller, listenerName);
+        }
+      }
     }
   }
 
   dispatchEvent(event: ControllerEvent) {
+    if (this.pinchFilter.shouldFilterEvent(event)) {
+      return;
+    }
     if (this.listeners.has(event.type)) {
       for (const listener of this.listeners.get(event.type)) {
         listener(event);
@@ -457,6 +473,12 @@ export class Input {
     if (controller.userData.connected === false) {
       return;
     }
+    this.pinchFilter.updateController(
+      controller,
+      this.dispatchEvent.bind(this),
+      this.setRaycasterFromController.bind(this),
+      this.performRaycastOnScene.bind(this)
+    );
     controller.updatePose?.();
     controller.updateMatrixWorld();
     if (this.options.controllers.performRaycastOnUpdate) {
@@ -550,11 +572,7 @@ export class Input {
       this.reticles.add(controller.reticle);
     }
 
-    for (const [listenerName, listeners] of this.listeners.entries()) {
-      for (const listener of listeners) {
-        controller.addEventListener(listenerName, listener);
-      }
-    }
+    this.pinchFilter.setupController(controller, this.listeners.keys());
   }
 
   enableController(controller: Controller) {
@@ -581,6 +599,11 @@ export class Input {
 
   enableControllers() {
     this.controllersEnabled = true;
+  }
+
+  dispose() {
+    this.pinchFilter.dispose(this.controllers);
+    this.listeners.clear();
   }
 
   // Performs the raycast assuming the raycaster is already set up.

--- a/src/input/PinchFilter.ts
+++ b/src/input/PinchFilter.ts
@@ -1,0 +1,116 @@
+import * as THREE from 'three';
+import {Controller, ControllerEvent, ControllerEventMap} from './Controller';
+
+export interface FilterableControllerEvent extends ControllerEvent {
+  isCustom?: boolean;
+}
+
+export class PinchFilter {
+  private forwardingListeners = new Map<
+    keyof ControllerEventMap,
+    (event: THREE.BaseEvent) => void
+  >();
+
+  constructor(private handleEventFn: (event: ControllerEvent) => void) {}
+
+  private getOrCreateForwardingListener(type: keyof ControllerEventMap) {
+    let listener = this.forwardingListeners.get(type);
+    if (!listener) {
+      listener = (event: THREE.BaseEvent) => {
+        this.handleEventFn(event as ControllerEvent);
+      };
+      this.forwardingListeners.set(type, listener);
+    }
+    return listener;
+  }
+
+  setupController(
+    controller: Controller,
+    activeEventTypes: Iterable<keyof ControllerEventMap>
+  ) {
+    for (const type of activeEventTypes) {
+      const forwarder = this.getOrCreateForwardingListener(type);
+      controller.addEventListener(type, forwarder);
+    }
+  }
+
+  setupControllerForType(
+    controller: Controller,
+    type: keyof ControllerEventMap
+  ) {
+    const forwarder = this.getOrCreateForwardingListener(type);
+    controller.addEventListener(type, forwarder);
+  }
+
+  removeControllerForType(
+    controller: Controller,
+    type: keyof ControllerEventMap
+  ) {
+    const forwarder = this.forwardingListeners.get(type);
+    if (forwarder) {
+      controller.removeEventListener(type, forwarder);
+    }
+  }
+
+  dispose(controllers: Controller[]) {
+    for (const [type, forwarder] of this.forwardingListeners.entries()) {
+      for (const controller of controllers) {
+        controller.removeEventListener(type, forwarder);
+      }
+    }
+    this.forwardingListeners.clear();
+  }
+
+  shouldFilterEvent(event: FilterableControllerEvent): boolean {
+    const controller = event.target;
+    if (
+      event.type === 'selectstart' ||
+      event.type === 'selectend' ||
+      event.type === 'select'
+    ) {
+      if (controller.gamepad?.buttons[0] !== undefined && !event.isCustom) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  updateController(
+    controller: Controller,
+    dispatchEventFn: (event: ControllerEvent) => void,
+    setRaycasterFn: (c: Controller) => void,
+    performRaycastFn: (c: Controller) => void
+  ) {
+    if (controller.gamepad && controller.gamepad.buttons[0] !== undefined) {
+      const pinchValue = controller.gamepad.buttons[0].value;
+      const isPinching = pinchValue >= 1.0;
+      const wasPinching = controller.userData.selected === true;
+
+      if (isPinching && !wasPinching) {
+        controller.userData.selected = true;
+        setRaycasterFn(controller);
+        performRaycastFn(controller);
+        dispatchEventFn({
+          type: 'selectstart',
+          target: controller,
+          data: controller.inputSource,
+          isCustom: true,
+        } as FilterableControllerEvent);
+      } else if (!isPinching && wasPinching) {
+        controller.userData.selected = false;
+        dispatchEventFn({
+          type: 'select',
+          target: controller,
+          data: controller.inputSource,
+          isCustom: true,
+        } as FilterableControllerEvent);
+        dispatchEventFn({
+          type: 'selectend',
+          target: controller,
+          data: controller.inputSource,
+          isCustom: true,
+        } as FilterableControllerEvent);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Pinch events for hand tracking are natively fired at a pinch value of 0.7. This change intercepts and suppresses native selectstart/select/selectend events for hand tracking, manually dispatching custom select events only when the analog pinch value reaches exactly 1.0.

This resolves false pinches during hand-tracked interactions without modifying the core event registration signature or scripts.

This is a temporary workaround until the fix in the system propagates to devices.