### PR TITLE
Aligned Embodied Control to Simulation Clock

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -249,4 +249,4 @@ const sampleBuilds = globSync('samples/**/*.ts', {
 
 export default buildExamples
   ? [...sdkBuilds, ...demoBuilds, ...sampleBuilds]
-  : sdkBuilds.slice(0, 3);
+  : sdkBuilds;

--- a/src/addons/embodied-control/EmbodiedControlExecutor.ts
+++ b/src/addons/embodied-control/EmbodiedControlExecutor.ts
@@ -16,6 +16,7 @@ import {
   type HandControl,
   type LocomotionControl,
 } from './EmbodiedControlTypes';
+import {runTimedMotion, type TimedMotionTick} from './EmbodiedControlTiming';
 
 export type EmbodiedControlExecutorDependencies = {
   core: Core;
@@ -38,16 +39,6 @@ function mergeOptions(
       DEFAULT_EMBODIED_CONTROL_OPTIONS.applyHandRotationConstraints,
     realTime: options.realTime ?? DEFAULT_EMBODIED_CONTROL_OPTIONS.realTime,
   };
-}
-
-function nextAnimationFrame() {
-  return new Promise<void>((resolve) => {
-    if (typeof requestAnimationFrame === 'function') {
-      requestAnimationFrame(() => resolve());
-    } else {
-      setTimeout(resolve, 0);
-    }
-  });
 }
 
 export class EmbodiedControlBusyError extends Error {
@@ -79,6 +70,18 @@ export class EmbodiedControlExecutor {
     return this.activeStep;
   }
 
+  private async runTimedMotion(
+    requestedDurationMs: number,
+    applyTick: TimedMotionTick
+  ) {
+    return runTimedMotion({
+      requestedDurationMs,
+      tickMs: this.options.tickMs,
+      realTime: this.options.realTime,
+      applyTick,
+    });
+  }
+
   applyControl(control: XRCompoundControl) {
     if (this.activeStep) {
       throw new EmbodiedControlBusyError();
@@ -97,33 +100,18 @@ export class EmbodiedControlExecutor {
     this.activeStep = true;
 
     try {
-      const tickMs = this.options.tickMs;
-      const durationMs = step.durationMs ?? tickMs;
-      const stepCount = Math.max(1, Math.ceil(durationMs / tickMs));
-      let elapsedMs = 0;
+      const durationMs = step.durationMs ?? this.options.tickMs;
       const initialCameraQuaternion =
         this.dependencies.camera.quaternion.clone();
 
-      for (let i = 0; i < stepCount; i++) {
-        const remainingMs = Math.max(0, durationMs - elapsedMs);
-        const currentTickMs =
-          i === stepCount - 1
-            ? remainingMs || tickMs
-            : Math.min(tickMs, remainingMs);
-        const fraction = durationMs > 0 ? currentTickMs / durationMs : 1;
-
+      await this.runTimedMotion(durationMs, (_elapsed, currentTick, total) => {
         this.applyControlFraction(
           step.control || {},
-          fraction,
+          currentTick / total,
           initialCameraQuaternion
         );
-
-        this.dependencies.core.stepFrame(currentTickMs);
-        elapsedMs += currentTickMs;
-        if (this.options.realTime && i < stepCount - 1) {
-          await nextAnimationFrame();
-        }
-      }
+        this.dependencies.core.stepFrame(currentTick);
+      });
     } finally {
       this.activeStep = false;
     }
@@ -372,23 +360,11 @@ export class EmbodiedControlExecutor {
       const angle = Q_s.angleTo(Q_t);
       const durationMs = (angle / velocity) * 1000;
 
-      let elapsedMs = 0;
-      const tickMs = this.options.tickMs;
-      const stepCount = Math.max(1, Math.ceil(durationMs / tickMs));
-      for (let i = 0; i < stepCount; i++) {
-        const remainingMs = Math.max(0, durationMs - elapsedMs);
-        const currentTickMs =
-          i === stepCount - 1
-            ? remainingMs || tickMs
-            : Math.min(tickMs, remainingMs);
-        elapsedMs += currentTickMs;
-        const u = durationMs > 0 ? elapsedMs / durationMs : 1;
+      await this.runTimedMotion(durationMs, (elapsed, currentTick, total) => {
+        const u = elapsed / total;
         camera.quaternion.slerpQuaternions(Q_s, Q_t, u);
-        core.stepFrame(currentTickMs);
-        if (this.options.realTime && i < stepCount - 1) {
-          await nextAnimationFrame();
-        }
-      }
+        core.stepFrame(currentTick);
+      });
     });
   }
 
@@ -432,25 +408,13 @@ export class EmbodiedControlExecutor {
       const angle = startQuat.angleTo(targetQuat);
       const durationMs = (angle / velocity) * 1000;
 
-      let elapsedMs = 0;
-      const tickMs = this.options.tickMs;
-      const stepCount = Math.max(1, Math.ceil(durationMs / tickMs));
-      for (let i = 0; i < stepCount; i++) {
-        const remainingMs = Math.max(0, durationMs - elapsedMs);
-        const currentTickMs =
-          i === stepCount - 1
-            ? remainingMs || tickMs
-            : Math.min(tickMs, remainingMs);
-        elapsedMs += currentTickMs;
-        const u = durationMs > 0 ? elapsedMs / durationMs : 1;
+      await this.runTimedMotion(durationMs, (elapsed, currentTick, total) => {
+        const u = elapsed / total;
         simulator.simulatorControllerState.localControllerOrientations[
           handIndex
         ].slerpQuaternions(startQuat, targetQuat, u);
-        core.stepFrame(currentTickMs);
-        if (this.options.realTime && i < stepCount - 1) {
-          await nextAnimationFrame();
-        }
-      }
+        core.stepFrame(currentTick);
+      });
     });
   }
 
@@ -485,25 +449,13 @@ export class EmbodiedControlExecutor {
       const distance = startPos.distanceTo(targetCamSpace);
       const durationMs = (distance / velocity) * 1000;
 
-      let elapsedMs = 0;
-      const tickMs = this.options.tickMs;
-      const stepCount = Math.max(1, Math.ceil(durationMs / tickMs));
-      for (let i = 0; i < stepCount; i++) {
-        const remainingMs = Math.max(0, durationMs - elapsedMs);
-        const currentTickMs =
-          i === stepCount - 1
-            ? remainingMs || tickMs
-            : Math.min(tickMs, remainingMs);
-        elapsedMs += currentTickMs;
-        const u = durationMs > 0 ? elapsedMs / durationMs : 1;
+      await this.runTimedMotion(durationMs, (elapsed, currentTick, total) => {
+        const u = elapsed / total;
         simulator.simulatorControllerState.localControllerPositions[
           handIndex
         ].lerpVectors(startPos, targetCamSpace, u);
-        core.stepFrame(currentTickMs);
-        if (this.options.realTime && i < stepCount - 1) {
-          await nextAnimationFrame();
-        }
-      }
+        core.stepFrame(currentTick);
+      });
     });
   }
 

--- a/src/addons/embodied-control/EmbodiedControlTiming.ts
+++ b/src/addons/embodied-control/EmbodiedControlTiming.ts
@@ -1,0 +1,49 @@
+export type TimedMotionTick = (
+  elapsedMs: number,
+  tickMs: number,
+  durationMs: number
+) => void;
+
+function nextAnimationFrame() {
+  return new Promise<void>((resolve) => {
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => resolve());
+    } else {
+      setTimeout(resolve, 0);
+    }
+  });
+}
+
+export async function runTimedMotion(options: {
+  requestedDurationMs: number;
+  tickMs: number;
+  realTime: boolean;
+  applyTick: TimedMotionTick;
+}) {
+  const {requestedDurationMs, tickMs, realTime, applyTick} = options;
+  const durationMs = requestedDurationMs > 0 ? requestedDurationMs : tickMs;
+  let elapsedMs = 0;
+
+  const advanceTo = (targetElapsedMs: number) => {
+    while (elapsedMs < targetElapsedMs) {
+      const currentTickMs = Math.min(
+        tickMs,
+        targetElapsedMs - elapsedMs,
+        durationMs - elapsedMs
+      );
+      elapsedMs += currentTickMs;
+      applyTick(elapsedMs, currentTickMs, durationMs);
+    }
+  };
+
+  if (!realTime) {
+    advanceTo(durationMs);
+    return;
+  }
+
+  const startedAt = performance.now();
+  while (elapsedMs < durationMs) {
+    await nextAnimationFrame();
+    advanceTo(Math.min(durationMs, Math.max(0, performance.now() - startedAt)));
+  }
+}


### PR DESCRIPTION
Fixed a small issue where embodied control was computing ticks based on browser framerate which can be locked at 25 in playwright. 