### PR TITLE
Sim Reticle Jitter Fix in Depth

### DIFF
--- a/docs/docs/manual/Simulator.mdx
+++ b/docs/docs/manual/Simulator.mdx
@@ -184,6 +184,14 @@ The simulator also supplies simulated planes, meshes, object detections, a
 device-camera feed, and optional physics-backed environment objects when those
 subsystems are enabled.
 
+Simulated hands are excluded from generated depth data by default. This prevents
+hand rays from hitting the depth image of the same hand. Set the option to
+`false` when a test must include hand depth:
+
+```js
+options.simulator.excludeHandsFromDepth = false;
+```
+
 ## Hand reach and simulator physics
 
 Limit virtual hands to a shoulder-relative radius or forward cone:

--- a/skills/xb-simulator/SKILL.md
+++ b/skills/xb-simulator/SKILL.md
@@ -76,6 +76,13 @@ Disable all simulator-owned physics while leaving regular app physics available 
 options.simulator.physics.enabled = false;
 ```
 
+Simulated hands are excluded from generated depth data by default so hand rays do not
+hit the same hand. Include them when a test requires hand depth:
+
+```js
+options.simulator.excludeHandsFromDepth = false;
+```
+
 The top-level hand origins are shared by reach limits and hand physics. When hand physics
 is enabled, they act as invisible shoulder-to-palm tethers so fixed geometry cannot leave
 a hand trapped on the far side of a wall. Dynamic objects remain pushable by the hands.

--- a/src/simulator/Simulator.ts
+++ b/src/simulator/Simulator.ts
@@ -206,7 +206,7 @@ export class Simulator extends Script {
 
     if (options.depth.enabled) {
       this.renderDepthPass = true;
-      this.depth.init(renderer, camera, depth);
+      this.depth.init(renderer, camera, depth, this.hands);
     }
     scene.add(camera);
 

--- a/src/simulator/Simulator.ts
+++ b/src/simulator/Simulator.ts
@@ -206,7 +206,13 @@ export class Simulator extends Script {
 
     if (options.depth.enabled) {
       this.renderDepthPass = true;
-      this.depth.init(renderer, camera, depth, this.hands);
+      this.depth.init(
+        renderer,
+        camera,
+        depth,
+        this.hands,
+        simulatorOptions.excludeHandsFromDepth
+      );
     }
     scene.add(camera);
 

--- a/src/simulator/SimulatorOptions.ts
+++ b/src/simulator/SimulatorOptions.ts
@@ -45,6 +45,8 @@ export interface SimulatorHandPhysicsOptions {
 
 export class SimulatorOptions {
   initialCameraPosition = {x: 0, y: 1.5, z: 0};
+  /** Excludes simulated hands from generated depth data. */
+  excludeHandsFromDepth = true;
   environments = DEFAULT_ENVIRONMENTS.map((environment) => ({...environment}));
   activeEnvironmentIndex = 0;
   defaultMode = SimulatorMode.USER;

--- a/src/simulator/scene/SimulatorDepth.test.ts
+++ b/src/simulator/scene/SimulatorDepth.test.ts
@@ -65,6 +65,49 @@ describe('SimulatorDepth.update inflight guard', () => {
     );
   });
 
+  it('excludes hands from the depth render and restores visibility', () => {
+    const hands = {
+      leftController: new THREE.Object3D(),
+      rightController: new THREE.Object3D(),
+    };
+    hands.rightController.visible = false;
+    depthSim.init(
+      renderer.renderer as unknown as THREE.WebGLRenderer,
+      new THREE.PerspectiveCamera(),
+      {updateCPUDepthData: vi.fn()} as never,
+      hands as never
+    );
+    renderer.renderer.render.mockImplementation(() => {
+      expect(hands.leftController.visible).toBe(false);
+      expect(hands.rightController.visible).toBe(false);
+    });
+
+    depthSim.update();
+
+    expect(hands.leftController.visible).toBe(true);
+    expect(hands.rightController.visible).toBe(false);
+  });
+
+  it('includes hands when exclusion is disabled', () => {
+    const hands = {
+      leftController: new THREE.Object3D(),
+      rightController: new THREE.Object3D(),
+    };
+    depthSim.init(
+      renderer.renderer as unknown as THREE.WebGLRenderer,
+      new THREE.PerspectiveCamera(),
+      {updateCPUDepthData: vi.fn()} as never,
+      hands as never,
+      false
+    );
+    renderer.renderer.render.mockImplementation(() => {
+      expect(hands.leftController.visible).toBe(true);
+      expect(hands.rightController.visible).toBe(true);
+    });
+
+    depthSim.update();
+  });
+
   it('does NOT queue a second pass while an earlier readback is still in flight', () => {
     depthSim.update();
     expect(renderer.pendingReadback()).toBe(true);

--- a/src/simulator/scene/SimulatorDepth.ts
+++ b/src/simulator/scene/SimulatorDepth.ts
@@ -11,6 +11,7 @@ export class SimulatorDepth {
   private camera!: THREE.Camera;
   private depth!: Depth;
   private hands?: SimulatorHands;
+  private excludeHandsFromDepth = true;
   depthWidth = 160;
   depthHeight = 160;
   depthBufferSlice = new Float32Array();
@@ -47,12 +48,14 @@ export class SimulatorDepth {
     renderer: THREE.WebGLRenderer,
     camera: THREE.Camera,
     depth: Depth,
-    hands?: SimulatorHands
+    hands?: SimulatorHands,
+    excludeHandsFromDepth = true
   ) {
     this.renderer = renderer;
     this.camera = camera;
     this.depth = depth;
     this.hands = hands;
+    this.excludeHandsFromDepth = excludeHandsFromDepth;
 
     if (this.camera instanceof THREE.PerspectiveCamera) {
       this.depthCamera = new THREE.PerspectiveCamera();
@@ -116,19 +119,23 @@ export class SimulatorDepth {
     const originalRenderTarget = this.renderer.getRenderTarget();
     this.renderer.setRenderTarget(this.depthRenderTarget);
     this.simulatorScene.overrideMaterial = this.depthMaterial;
-    const leftWasVisible = this.hands?.leftController.visible ?? false;
-    const rightWasVisible = this.hands?.rightController.visible ?? false;
-    if (this.hands) {
-      this.hands.leftController.visible = false;
-      this.hands.rightController.visible = false;
+    const hands = this.excludeHandsFromDepth ? this.hands : undefined;
+    const leftWasVisible = hands?.leftController.visible ?? false;
+    const rightWasVisible = hands?.rightController.visible ?? false;
+    if (hands) {
+      hands.leftController.visible = false;
+      hands.rightController.visible = false;
     }
-    this.renderer.render(this.simulatorScene, this.depthCamera);
-    if (this.hands) {
-      this.hands.leftController.visible = leftWasVisible;
-      this.hands.rightController.visible = rightWasVisible;
+    try {
+      this.renderer.render(this.simulatorScene, this.depthCamera);
+    } finally {
+      if (hands) {
+        hands.leftController.visible = leftWasVisible;
+        hands.rightController.visible = rightWasVisible;
+      }
+      this.simulatorScene.overrideMaterial = null;
+      this.renderer.setRenderTarget(originalRenderTarget);
     }
-    this.simulatorScene.overrideMaterial = null;
-    this.renderer.setRenderTarget(originalRenderTarget);
   }
 
   private async updateDepth() {

--- a/src/simulator/scene/SimulatorDepth.ts
+++ b/src/simulator/scene/SimulatorDepth.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 
 import {Depth} from '../../depth/Depth';
 
+import type {SimulatorHands} from '../SimulatorHands';
 import {SimulatorDepthMaterial} from './SimulatorDepthMaterial';
 import {SimulatorScene} from './SimulatorScene';
 
@@ -9,6 +10,7 @@ export class SimulatorDepth {
   private renderer!: THREE.WebGLRenderer;
   private camera!: THREE.Camera;
   private depth!: Depth;
+  private hands?: SimulatorHands;
   depthWidth = 160;
   depthHeight = 160;
   depthBufferSlice = new Float32Array();
@@ -41,10 +43,16 @@ export class SimulatorDepth {
   /**
    * Initialize Simulator Depth.
    */
-  init(renderer: THREE.WebGLRenderer, camera: THREE.Camera, depth: Depth) {
+  init(
+    renderer: THREE.WebGLRenderer,
+    camera: THREE.Camera,
+    depth: Depth,
+    hands?: SimulatorHands
+  ) {
     this.renderer = renderer;
     this.camera = camera;
     this.depth = depth;
+    this.hands = hands;
 
     if (this.camera instanceof THREE.PerspectiveCamera) {
       this.depthCamera = new THREE.PerspectiveCamera();
@@ -108,7 +116,17 @@ export class SimulatorDepth {
     const originalRenderTarget = this.renderer.getRenderTarget();
     this.renderer.setRenderTarget(this.depthRenderTarget);
     this.simulatorScene.overrideMaterial = this.depthMaterial;
+    const leftWasVisible = this.hands?.leftController.visible ?? false;
+    const rightWasVisible = this.hands?.rightController.visible ?? false;
+    if (this.hands) {
+      this.hands.leftController.visible = false;
+      this.hands.rightController.visible = false;
+    }
     this.renderer.render(this.simulatorScene, this.depthCamera);
+    if (this.hands) {
+      this.hands.leftController.visible = leftWasVisible;
+      this.hands.rightController.visible = rightWasVisible;
+    }
     this.simulatorScene.overrideMaterial = null;
     this.renderer.setRenderTarget(originalRenderTarget);
   }


### PR DESCRIPTION
Fix for the sim reticle jittering infront of the hand due to the depth mesh rendering async with the reticle intersection check https://github.com/google/xrblocks/issues/461.

Only could fix it fully by disabling reticle casting on the hands and then removing the hands from the depth creation and readding after. 

There's an argument to be had this isn't 1:1 with real depth sensing since we cull the hands from the sensing but the jitter was causing alot of issues with simulator + reticle apps for me. A distance check didnt really work since its dependent on framerate + user speed and itd have to be something along the lines of .4m+ to work and cause issues.