### PR TITLE
faces: load BVH raycast acceleration lazily in FaceRecognizer.init()

### DIFF
--- a/src/world/faces/FaceRecognizer.ts
+++ b/src/world/faces/FaceRecognizer.ts
@@ -10,20 +10,6 @@ import {DetectedFace} from './DetectedFace';
 import {BaseFaceBackend, FaceBackendContext} from './FaceDetectorBackend';
 import {MediaPipeFaceBackend} from './backends/MediaPipeFaceBackend';
 
-// Kick off the BVH-accelerated raycast prototype patches at module
-// load so the per-landmark raycasts inside processFaceLandmarkerResult
-// go through the accelerated path. Fire-and-forget: the helper loads
-// three-mesh-bvh dynamically and the SDK keeps working even if the
-// module isn't installed or in the importmap (raycasts fall back to
-// the stock walker). idempotent across modules so multiple subsystems
-// can ping it safely.
-//
-// FaceLandmarker emits 478 landmarks per face and we raycast each one
-// against the depth-mesh snapshot. Stock three.js is O(triangles) per
-// ray; the depth mesh runs in the thousands of triangles so without
-// BVH the per-detection raycast loop alone dominates the frame budget.
-enableAcceleratedRaycast();
-
 /**
  * A detector script that orchestrates face landmark estimation. Manages
  * the backend face detector lifecycle (e.g. MediaPipe) and exposes the
@@ -78,6 +64,7 @@ export class FaceRecognizer extends Script {
     this.camera = camera;
     this.renderer = renderer;
     this.disposed = false;
+    void enableAcceleratedRaycast();
   }
 
   /**


### PR DESCRIPTION
## Description
This gets rid of the annoy three-mesh-bvh warning on apps which don't need it.
I moved the call into `init` for now, but I think it gets called automatically anyways.

## Type of Change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

On device, the console is clean now
<img width="1501" height="1009" alt="Screenshot 2026-07-31 at 4 59 07 PM" src="https://github.com/user-attachments/assets/2266452c-13db-42d6-b2f5-a798561d165f" />

I also checked the face demo in the simulator and it works just as before.