### PR TITLE
fix gemini object detection on the 3.6 flash default

### DIFF
--- a/src/world/objects/backends/GeminiDetectorBackend.ts
+++ b/src/world/objects/backends/GeminiDetectorBackend.ts
@@ -1,4 +1,5 @@
 import {Gemini} from '../../../ai/Gemini';
+import type {ThinkingLevel} from '@google/genai';
 import {GeminiResponse} from '../../../ai/AITypes';
 import {parseBase64DataURL} from '../../../utils/utils';
 import {BaseDetectorBackend} from '../ObjectDetectorBackend';
@@ -26,8 +27,12 @@ export class GeminiDetectorBackend<T> extends BaseDetectorBackend<T> {
   private buildGeminiConfig() {
     const geminiOptions = this.context.options.objects.backendConfig.gemini;
     return {
+      // Keep detection fast by asking for as little reasoning as possible.
+      // gemini-3.6-flash rejects a zero thinking budget, which 3.5 accepted,
+      // so use the minimal thinking level instead. Both resolve to no thought
+      // tokens and it is accepted by 3.5 and 3.6 alike.
       thinkingConfig: {
-        thinkingBudget: 0,
+        thinkingLevel: 'MINIMAL' as ThinkingLevel,
       },
       responseMimeType: 'application/json',
       responseSchema: geminiOptions.responseSchema,


### PR DESCRIPTION
fixes https://github.com/google/xrblocks/issues/470

object detection quietly stopped returning anything after the default flash model moved from `gemini-3.5-flash` to `gemini-3.6-flash` in #454. anything that scans the room — agent hands, world companion, objects 3d, simulator scene objects — just behaves like the room is empty, and the agent tells you it hasn't scanned yet.

the detector pins `thinkingConfig: { thinkingBudget: 0 }` to keep detection fast. 3.5 still accepted that, 3.6 rejects it with a 400 INVALID_ARGUMENT, and `detect()` catches the error and returns `[]`, so nothing surfaces except an empty object list. `thinking_level` is the gemini 3 control now and the [thinking docs](https://ai.google.dev/gemini-api/docs/thinking) list 3.6 flash as minimal/low/medium/high, with no off.

`'MINIMAL'` is the closest thing to the old intent and still comes back with zero thought tokens. it's also accepted by 3.5, so this isn't pinned to whatever the current default happens to be. timing the real detector payload against 3.6 flash it's the quickest of the valid options, ~1.3s median vs ~1.8s with no thinking config (defaults to medium) and ~2.2s on a dynamic budget. agent hands goes from 0 detections to 15, all grounded to depth-mesh points.

pulled in with `import type` so `@google/genai` stays dynamically loaded and nothing new lands in the bundle.
