### PR TITLE
Interaction Module Implementation

### DIFF
--- a/src/interaction/DirectTouch.ts
+++ b/src/interaction/DirectTouch.ts
@@ -1,0 +1,165 @@
+import * as THREE from 'three';
+
+import type {Controller} from '../input/Controller';
+import {HitRegistry} from './HitRegistry';
+import {HitResolver} from './HitResolver';
+import {type DirectTouchInput, type ResolvedRay} from './InteractionTypes';
+
+export interface DirectTouchContact {
+  readonly phase: 'start' | 'move' | 'end';
+  readonly controller: Controller;
+  readonly resolved?: ResolvedRay;
+  readonly handIndex: number;
+  readonly hand?: THREE.Object3D;
+  readonly point: THREE.Vector3;
+  readonly orientation?: THREE.Quaternion;
+  readonly selected: boolean;
+  readonly endReason?: 'left-target' | 'target-changed' | 'source-lost';
+}
+
+interface ActiveContact {
+  resolved: ResolvedRay;
+  handIndex: number;
+  hand?: THREE.Object3D;
+  point: THREE.Vector3;
+}
+
+/**
+ * Converts registered-bounds contacts into source-neutral contact phases.
+ * Interaction owns callback dispatch, capture, completion, and cancellation.
+ */
+export class DirectTouch {
+  private static readonly EXIT_PADDING = 0.01;
+  private readonly active = new Map<Controller, ActiveContact>();
+  private readonly awaitingExit = new Set<Controller>();
+  private readonly contacts: DirectTouchContact[] = [];
+  private readonly present = new Set<Controller>();
+
+  constructor(
+    private readonly registry: HitRegistry,
+    private readonly resolver: HitResolver
+  ) {}
+
+  update(inputs: readonly DirectTouchInput[]): DirectTouchContact[] {
+    this.contacts.length = 0;
+    this.present.clear();
+    for (const input of inputs) {
+      this.present.add(input.controller);
+      const previous = this.active.get(input.controller);
+      const resolved = this.resolver.resolve(
+        this.registry.intersectionsAt(
+          input.point,
+          previous ? DirectTouch.EXIT_PADDING : 0,
+          previous?.resolved.hitObject
+        ),
+        'direct-touch'
+      );
+
+      if (this.awaitingExit.has(input.controller)) {
+        if (!resolved) this.awaitingExit.delete(input.controller);
+        continue;
+      }
+      if (!previous && !resolved?.target) continue;
+
+      if (!previous && resolved?.target) {
+        const active = {
+          resolved,
+          handIndex: input.handIndex,
+          hand: input.hand,
+          point: input.point.clone(),
+        };
+        this.active.set(input.controller, active);
+        this.contacts.push({
+          phase: 'start',
+          controller: input.controller,
+          resolved,
+          handIndex: input.handIndex,
+          hand: input.hand,
+          point: input.point,
+          orientation: input.orientation,
+          selected: input.selected,
+        });
+      } else if (
+        previous &&
+        resolved &&
+        resolved.target === previous.resolved.target
+      ) {
+        previous.resolved = resolved;
+        previous.point.copy(input.point);
+        this.contacts.push({
+          phase: 'move',
+          controller: input.controller,
+          resolved,
+          handIndex: input.handIndex,
+          hand: input.hand,
+          point: input.point,
+          orientation: input.orientation,
+          selected: input.selected,
+        });
+      } else if (previous) {
+        if (resolved) this.awaitingExit.add(input.controller);
+        this.contacts.push(
+          this.endContact(
+            input.controller,
+            input.selected,
+            resolved?.target ? 'target-changed' : 'left-target',
+            input.handIndex,
+            input.hand,
+            input.point,
+            input.orientation
+          )
+        );
+      }
+    }
+    for (const controller of this.active.keys()) {
+      if (!this.present.has(controller)) {
+        this.contacts.push(this.endContact(controller, false, 'source-lost'));
+      }
+    }
+    for (const controller of this.awaitingExit) {
+      if (!this.present.has(controller)) this.awaitingExit.delete(controller);
+    }
+    return this.contacts;
+  }
+
+  remove(controller: Controller): DirectTouchContact | undefined {
+    this.awaitingExit.delete(controller);
+    return this.active.has(controller)
+      ? this.endContact(controller, false, 'source-lost')
+      : undefined;
+  }
+
+  has(controller: Controller): boolean {
+    return this.active.has(controller);
+  }
+
+  clear(): void {
+    this.active.clear();
+    this.awaitingExit.clear();
+    this.contacts.length = 0;
+    this.present.clear();
+  }
+
+  private endContact(
+    controller: Controller,
+    selected: boolean,
+    endReason: NonNullable<DirectTouchContact['endReason']>,
+    handIndex?: number,
+    hand?: THREE.Object3D,
+    point?: THREE.Vector3,
+    orientation?: THREE.Quaternion
+  ): DirectTouchContact {
+    const previous = this.active.get(controller)!;
+    this.active.delete(controller);
+    return {
+      phase: 'end',
+      controller,
+      handIndex: handIndex ?? previous.handIndex,
+      hand: hand ?? previous.hand,
+      point: point ?? previous.point,
+      orientation,
+      selected,
+      endReason,
+    };
+  }
+}

--- a/src/interaction/GazeDwell.ts
+++ b/src/interaction/GazeDwell.ts
@@ -1,0 +1,74 @@
+import * as THREE from 'three';
+
+import type {Controller} from '../input/Controller.js';
+import type {ResolvedRay} from './InteractionTypes.js';
+
+interface GazeDwellState {
+  target?: THREE.Object3D;
+  elapsed: number;
+  lastPoint?: THREE.Vector3;
+  armed: boolean;
+}
+
+export interface GazeDwellUpdate {
+  progress: number;
+  completed: boolean;
+}
+
+const DWELL_SECONDS = 1.5;
+const MOVEMENT_THRESHOLD = 0.2;
+
+/** Tracks stable gaze time for each source and emits one completion per target. */
+export class GazeDwell {
+  private readonly states = new Map<Controller, GazeDwellState>();
+
+  update(
+    controller: Controller,
+    resolved: ResolvedRay | undefined,
+    deltaSeconds: number,
+    paused = false
+  ): GazeDwellUpdate {
+    const target = resolved?.target;
+    const point = target ? resolved?.intersection.point : undefined;
+    let state = this.states.get(controller);
+    if (!state || state.target !== target) {
+      state = {
+        target,
+        elapsed: 0,
+        lastPoint: point?.clone(),
+        armed: true,
+      };
+      this.states.set(controller, state);
+      return {progress: 0, completed: false};
+    }
+    if (!target || !point) return {progress: 0, completed: false};
+    if (paused) {
+      state.lastPoint?.copy(point);
+      return {
+        progress: state.elapsed / DWELL_SECONDS,
+        completed: false,
+      };
+    }
+    if (!state.armed) {
+      state.lastPoint?.copy(point);
+      return {progress: 1, completed: false};
+    }
+
+    const delta = Math.max(0, deltaSeconds);
+    const movement =
+      (state.lastPoint?.distanceTo(point) ?? 0) /
+      Math.max(delta, Number.EPSILON);
+    state.lastPoint ??= point.clone();
+    state.lastPoint.copy(point);
+    if (movement > MOVEMENT_THRESHOLD) state.elapsed = 0;
+    else state.elapsed = Math.min(DWELL_SECONDS, state.elapsed + delta);
+
+    const completed = state.elapsed === DWELL_SECONDS;
+    if (completed) state.armed = false;
+    return {progress: state.elapsed / DWELL_SECONDS, completed};
+  }
+
+  remove(controller: Controller): void {
+    this.states.delete(controller);
+  }
+}

--- a/src/interaction/HitRegistry.ts
+++ b/src/interaction/HitRegistry.ts
@@ -1,0 +1,201 @@
+import * as THREE from 'three';
+
+import {UI_OVERLAY_LAYER} from '../constants';
+
+export interface RegisteredHitSurface {
+  readonly physical: THREE.Object3D;
+  readonly logical: THREE.Object3D;
+}
+
+/** Owns physical hit registration, collection, and logical mapping. */
+export class HitRegistry {
+  private readonly raycaster = new THREE.Raycaster();
+  private readonly mappings = new WeakMap<
+    THREE.Object3D,
+    RegisteredHitSurface
+  >();
+  private readonly registered = new Set<RegisteredHitSurface>();
+  private readonly touchCandidates = new Map<
+    THREE.Object3D,
+    RegisteredHitSurface
+  >();
+
+  constructor() {
+    this.raycaster.layers.enable(UI_OVERLAY_LAYER);
+  }
+
+  register(physical: THREE.Object3D, logical: THREE.Object3D): () => void {
+    const entry = {physical, logical};
+    this.mappings.set(physical, entry);
+    this.registered.add(entry);
+    this.touchCandidates.set(physical, entry);
+    return () => {
+      if (this.mappings.get(physical) === entry) {
+        this.mappings.delete(physical);
+      }
+      this.registered.delete(entry);
+      if (this.touchCandidates.get(physical) === entry) {
+        this.touchCandidates.delete(physical);
+      }
+    };
+  }
+
+  setWorldTouchCandidates(objects: Iterable<THREE.Object3D>): void {
+    const next = new Set(objects);
+    for (const [physical, entry] of this.touchCandidates) {
+      if (!this.registered.has(entry)) this.touchCandidates.delete(physical);
+    }
+    for (const object of next) {
+      if (this.touchCandidates.has(object)) continue;
+      this.touchCandidates.set(object, {
+        physical: object,
+        logical: object,
+      });
+    }
+    for (const [physical, entry] of this.touchCandidates) {
+      if (this.registered.has(entry)) continue;
+      if (!next.has(physical)) this.touchCandidates.delete(physical);
+    }
+  }
+
+  resolve(object: THREE.Object3D): RegisteredHitSurface {
+    let current: THREE.Object3D | null = object;
+    while (current) {
+      const mapping = this.mappings.get(current);
+      if (mapping) return mapping;
+      current = current.parent;
+    }
+    return {physical: object, logical: object};
+  }
+
+  /** Collects ordered raw hits from the public scene and detached surfaces. */
+  raycast(
+    scene: THREE.Scene,
+    ray: THREE.Ray,
+    intersections: THREE.Intersection[]
+  ): readonly THREE.Intersection[] {
+    intersections.length = 0;
+    this.raycaster.ray.copy(ray);
+    this.raycaster.intersectObject(scene, true, intersections);
+
+    let publicCount = 0;
+    for (const intersection of intersections) {
+      if (hasPrivateAncestor(intersection.object)) continue;
+      intersections[publicCount++] = intersection;
+    }
+    intersections.length = publicCount;
+
+    for (const {physical} of this.registered) {
+      if (this.isBelowScene(physical, scene) && !hasPrivateAncestor(physical)) {
+        continue;
+      }
+      if (!effectiveVisible(physical)) continue;
+      if (!physical.layers.test(this.raycaster.layers)) continue;
+      physical.updateWorldMatrix(true, false);
+      physical.raycast(this.raycaster, intersections);
+    }
+    intersections.sort(compareRayIntersections);
+    return intersections;
+  }
+
+  intersectionsAt(
+    point: THREE.Vector3,
+    padding = 0,
+    preferred?: THREE.Object3D
+  ): THREE.Intersection[] {
+    const intersections: THREE.Intersection[] = [];
+    const box = new THREE.Box3();
+    const center = new THREE.Vector3();
+    for (const {physical} of this.touchCandidates.values()) {
+      if (!effectiveVisible(physical)) continue;
+      try {
+        box.setFromObject(physical);
+      } catch {
+        continue;
+      }
+      if (padding > 0) box.expandByScalar(padding);
+      if (box.isEmpty() || !box.containsPoint(point)) continue;
+      intersections.push({
+        distance: box.getCenter(center).distanceTo(point),
+        object: physical,
+        point: point.clone(),
+      });
+    }
+    intersections.sort((a, b) => compareTouchIntersections(a, b, preferred));
+    return intersections;
+  }
+
+  private isBelowScene(object: THREE.Object3D, scene: THREE.Scene): boolean {
+    let current = object.parent;
+    while (current) {
+      if (current === scene) return true;
+      current = current.parent;
+    }
+    return false;
+  }
+}
+
+function compareRayIntersections(
+  a: THREE.Intersection,
+  b: THREE.Intersection
+): number {
+  const aOverlay = a.object.layers.isEnabled(UI_OVERLAY_LAYER);
+  const bOverlay = b.object.layers.isEnabled(UI_OVERLAY_LAYER);
+  if (aOverlay !== bOverlay) return aOverlay ? -1 : 1;
+  const distance = a.distance - b.distance;
+  if (distance !== 0) return distance;
+  if (a.object.renderOrder !== b.object.renderOrder) {
+    return b.object.renderOrder - a.object.renderOrder;
+  }
+  return b.object.id - a.object.id;
+}
+
+function compareTouchIntersections(
+  a: THREE.Intersection,
+  b: THREE.Intersection,
+  preferred?: THREE.Object3D
+): number {
+  if (a.object === b.object) return 0;
+  if (a.object === preferred) return -1;
+  if (b.object === preferred) return 1;
+
+  const aOverlay = a.object.layers.isEnabled(UI_OVERLAY_LAYER);
+  const bOverlay = b.object.layers.isEnabled(UI_OVERLAY_LAYER);
+  if (aOverlay !== bOverlay) return aOverlay ? -1 : 1;
+
+  const aOrder = getInteractionHitOrder(a.object);
+  const bOrder = getInteractionHitOrder(b.object);
+  if (aOrder !== undefined && bOrder !== undefined && aOrder !== bOrder) {
+    return bOrder - aOrder;
+  }
+
+  return a.distance - b.distance;
+}
+
+function getInteractionHitOrder(object: THREE.Object3D): number | undefined {
+  let current: THREE.Object3D | null = object;
+  while (current) {
+    const order = current.userData.xrblocksHitOrder;
+    if (typeof order === 'number') return order;
+    current = current.parent;
+  }
+  return undefined;
+}
+
+function hasPrivateAncestor(object: THREE.Object3D): boolean {
+  let current: THREE.Object3D | null = object;
+  while (current) {
+    if (current.userData.xrblocksPrivate === true) return true;
+    current = current.parent;
+  }
+  return false;
+}
+
+function effectiveVisible(object: THREE.Object3D): boolean {
+  let current: THREE.Object3D | null = object;
+  while (current) {
+    if (!current.visible) return false;
+    current = current.parent;
+  }
+  return true;
+}

--- a/src/interaction/HitResolver.ts
+++ b/src/interaction/HitResolver.ts
@@ -1,0 +1,160 @@
+import * as THREE from 'three';
+
+import type {
+  InteractionCallbackDispatch,
+  InteractionSourceType,
+  ResolvedRay,
+} from './InteractionTypes.js';
+import {HitRegistry} from './HitRegistry.js';
+import type {ManipulationManager} from './manipulation/ManipulationManager.js';
+import {
+  isSemanticControl,
+  isSemanticControlDisabled,
+} from './SemanticControl.js';
+
+function cloneIntersection(
+  intersection: THREE.Intersection
+): THREE.Intersection {
+  return {
+    ...intersection,
+    point: intersection.point.clone(),
+    normal: intersection.normal?.clone(),
+    uv: intersection.uv?.clone(),
+    uv1: intersection.uv1?.clone(),
+  };
+}
+
+/** Resolves one ordered raw hit list into one blocking surface and target. */
+export class HitResolver {
+  constructor(
+    private readonly callbacks: InteractionCallbackDispatch,
+    private readonly manipulation: ManipulationManager,
+    private readonly registry = new HitRegistry()
+  ) {}
+
+  resolve(
+    intersections: readonly THREE.Intersection[],
+    sourceType: InteractionSourceType
+  ): ResolvedRay | undefined {
+    for (const rawIntersection of intersections) {
+      const registered = this.registry.resolve(rawIntersection.object);
+      if (
+        registered.logical === rawIntersection.object &&
+        hasPrivateAncestor(rawIntersection.object)
+      ) {
+        continue;
+      }
+      const surface = registered.logical;
+      const objectPath = this.getObjectPath(surface);
+      if (this.isExcluded(objectPath)) continue;
+
+      const eligiblePath = this.getEligiblePath(objectPath);
+      const semanticCandidate = eligiblePath.find(isSemanticControl);
+      const disabledSemantic =
+        semanticCandidate !== undefined &&
+        isSemanticControlDisabled(semanticCandidate);
+      const semanticControl = disabledSemantic ? undefined : semanticCandidate;
+      const physicalHandle =
+        registered.physical !== eligiblePath[0] &&
+        registered.physical.xb?.manipulationHandle !== undefined
+          ? registered.physical
+          : undefined;
+      const manipulation = semanticCandidate
+        ? undefined
+        : this.manipulation.resolve(
+            physicalHandle ? [physicalHandle, ...eligiblePath] : eligiblePath
+          );
+      const callbackTarget = eligiblePath.find((object) =>
+        this.callbacks.hasTargetHandler(object, sourceType)
+      );
+      const target = disabledSemantic
+        ? undefined
+        : (semanticControl ??
+          this.nearestTarget(
+            eligiblePath,
+            callbackTarget,
+            manipulation?.owner
+          ));
+      const scriptPath = target
+        ? eligiblePath.filter((object) => this.callbacks.isScript(object))
+        : [];
+
+      return {
+        intersection: {
+          ...cloneIntersection(rawIntersection),
+          object: surface,
+        },
+        hitObject: rawIntersection.object,
+        surface,
+        target,
+        scriptPath: Object.freeze(scriptPath),
+        objectPath: Object.freeze(objectPath),
+        reticleMode: this.getReticleMode(objectPath),
+        semanticControl,
+        manipulation,
+      };
+    }
+    return undefined;
+  }
+
+  private getObjectPath(surface: THREE.Object3D): THREE.Object3D[] {
+    const path: THREE.Object3D[] = [];
+    let object: THREE.Object3D | null = surface;
+    while (object) {
+      path.push(object);
+      object = object.parent;
+    }
+    return path;
+  }
+
+  private isExcluded(path: readonly THREE.Object3D[]): boolean {
+    return path.some(
+      (object) =>
+        object.visible === false || object.xb?.pointerEvents === 'none'
+    );
+  }
+
+  private getEligiblePath(
+    objectPath: readonly THREE.Object3D[]
+  ): THREE.Object3D[] {
+    const barrierIndex = objectPath.findIndex(
+      (object) => object.xb?.interactionEnabled === false
+    );
+    return barrierIndex < 0
+      ? [...objectPath]
+      : objectPath.slice(0, barrierIndex);
+  }
+
+  private nearestTarget(
+    path: readonly THREE.Object3D[],
+    callbackTarget?: THREE.Object3D,
+    manipulationOwner?: THREE.Object3D
+  ): THREE.Object3D | undefined {
+    if (!callbackTarget) return manipulationOwner;
+    if (!manipulationOwner) return callbackTarget;
+    return path.indexOf(callbackTarget) <= path.indexOf(manipulationOwner)
+      ? callbackTarget
+      : manipulationOwner;
+  }
+
+  private getReticleMode(
+    path: readonly THREE.Object3D[]
+  ): 'auto' | 'surface' | 'hidden' {
+    for (const object of path) {
+      const mode = object.xb?.reticleMode;
+      if (mode === 'auto' || mode === 'surface' || mode === 'hidden') {
+        return mode;
+      }
+    }
+    return 'auto';
+  }
+}
+
+function hasPrivateAncestor(object: THREE.Object3D): boolean {
+  let current: THREE.Object3D | null = object;
+  while (current) {
+    if (current.userData.xrblocksPrivate === true) return true;
+    current = current.parent;
+  }
+  return false;
+}

--- a/src/interaction/Interaction.test.ts
+++ b/src/interaction/Interaction.test.ts
@@ -1,0 +1,141 @@
+import * as THREE from 'three';
+import {describe, expect, it, vi} from 'vitest';
+
+import type {Controller} from '../input/Controller';
+import {Interaction} from './Interaction';
+import type {
+  InteractionCallbackDispatch,
+  InteractionFrameInput,
+  RaySourceInput,
+  SelectEndEvent,
+  SelectEvent,
+} from './InteractionTypes';
+
+class RecordingTarget extends THREE.Object3D {
+  readonly starts: SelectEvent[] = [];
+  readonly ends: SelectEndEvent[] = [];
+
+  onObjectSelectStart(event: SelectEvent): true {
+    this.starts.push(event);
+    return true;
+  }
+
+  onObjectSelectEnd(event: SelectEndEvent): true {
+    this.ends.push(event);
+    return true;
+  }
+}
+
+function callbackAdapter(): InteractionCallbackDispatch {
+  return {
+    isScript: (object) => object instanceof RecordingTarget,
+    hasTargetHandler: (object) => object instanceof RecordingTarget,
+    hasTargetHook: (object, hook) =>
+      typeof Reflect.get(object, hook) === 'function',
+    invokeTarget: (object, hook, argument) => {
+      const handler = Reflect.get(object, hook);
+      return typeof handler === 'function'
+        ? Reflect.apply(handler, object, [argument])
+        : undefined;
+    },
+    invokeSemantic: (_object, callback) => callback(),
+    invokeGlobal: vi.fn(),
+    invokeManipulation: () => false,
+  };
+}
+
+describe('Interaction', () => {
+  it('captures and completes one registered target through its callback seam', () => {
+    const interaction = new Interaction({callbacks: callbackAdapter()});
+    const physical = new THREE.Mesh(new THREE.PlaneGeometry(1, 1));
+    const target = new RecordingTarget();
+    interaction.registerHitSurface(physical, target);
+    const source = controller(0);
+
+    update(interaction, ray(source, false, physical));
+    update(interaction, ray(source, true, physical));
+    update(interaction, ray(source, false, physical));
+
+    expect(target.starts).toHaveLength(1);
+    expect(target.ends).toHaveLength(1);
+    expect(target.ends[0]).toMatchObject({
+      completed: true,
+      reason: 'released',
+    });
+  });
+
+  it('cancels capture when its source disappears', () => {
+    const interaction = new Interaction({callbacks: callbackAdapter()});
+    const physical = new THREE.Mesh(new THREE.PlaneGeometry(1, 1));
+    const target = new RecordingTarget();
+    interaction.registerHitSurface(physical, target);
+    const source = controller(0);
+
+    update(interaction, ray(source, true, physical));
+    interaction.update({raySources: [], directTouches: []});
+
+    expect(target.ends.at(-1)).toMatchObject({
+      completed: false,
+      reason: 'source-lost',
+    });
+  });
+
+  it('owns select-only raycast policy', () => {
+    const scene = new THREE.Scene();
+    const surface = new THREE.Mesh(new THREE.PlaneGeometry(1, 1));
+    surface.position.z = -1;
+    scene.add(surface);
+    scene.updateMatrixWorld(true);
+    const interaction = new Interaction({
+      callbacks: callbackAdapter(),
+      scene,
+      raycastMode: 'select',
+    });
+    const source = controller(0);
+
+    update(interaction, ray(source, false));
+    expect(interaction.getResolvedRay(source)).toBeUndefined();
+
+    update(interaction, ray(source, true));
+    expect(interaction.getResolvedRay(source)?.surface).toBe(surface);
+  });
+});
+
+function controller(id: number): Controller {
+  const value = new THREE.Object3D() as Controller;
+  value.userData = {id, connected: true, selected: false};
+  return value;
+}
+
+function ray(
+  source: Controller,
+  selected: boolean,
+  hitObject?: THREE.Object3D
+): RaySourceInput {
+  source.userData.selected = selected;
+  return {
+    controller: source,
+    sourceType: 'controller-ray',
+    selected,
+    ray: new THREE.Ray(new THREE.Vector3(), new THREE.Vector3(0, 0, -1)),
+    intersections: hitObject
+      ? [
+          {
+            distance: 1,
+            object: hitObject,
+            point: new THREE.Vector3(0, 0, -1),
+          },
+        ]
+      : undefined,
+    position: new THREE.Vector3(),
+    orientation: new THREE.Quaternion(),
+  };
+}
+
+function update(interaction: Interaction, source: RaySourceInput): void {
+  const frame: InteractionFrameInput = {
+    raySources: [source],
+    directTouches: [],
+  };
+  interaction.update(frame);
+}

--- a/src/interaction/Interaction.ts
+++ b/src/interaction/Interaction.ts
@@ -1,0 +1,1241 @@
+import * as THREE from 'three';
+
+import type {Controller} from '../input/Controller.js';
+import {objectIsDescendantOf} from '../utils/SceneGraphUtils.js';
+import {DirectTouch, type DirectTouchContact} from './DirectTouch.js';
+import {GazeDwell} from './GazeDwell.js';
+import {HitRegistry} from './HitRegistry.js';
+import {HitResolver} from './HitResolver.js';
+import {
+  getInteractionSource,
+  type HoverEvent,
+  type InteractionDependencies,
+  type InteractionFrameInput,
+  type InteractionReticleOptions,
+  InteractionSourceState,
+  type LongSelectEvent,
+  type ObjectGrabEvent,
+  type ObjectTouchEvent,
+  type ObjectTouchStartEvent,
+  type RaycastMode,
+  type RaySourceInput,
+  type ResolvedRay,
+  type SelectEndEvent,
+  type SelectEvent,
+  type SelectionCapture,
+  type SelectionEndReason,
+} from './InteractionTypes.js';
+import {
+  dispatchInteractionPath,
+  selectionInvalidReason,
+} from './InteractionUtils.js';
+import {
+  createPlanarSurfaceProjector,
+  type PlanarSurfaceProjector,
+} from './PlanarSurface.js';
+import {ReticlePresenter} from './ReticlePresenter.js';
+import {ManipulationManager} from './manipulation/ManipulationManager.js';
+import {
+  getSemanticControl,
+  isSemanticControlDisabled,
+  type SemanticControlState,
+} from './SemanticControl.js';
+
+type AutomaticAction = 'select' | 'semantic' | 'manipulate' | 'none';
+
+interface TargetCapture {
+  kind: 'target';
+  action: AutomaticAction;
+  selection: SelectionCapture;
+  ancestry: readonly THREE.Object3D[];
+  semantic?: SemanticControlState;
+  semanticControl?: THREE.Object3D;
+  sliderProjector?: PlanarSurfaceProjector;
+  exclusiveControl?: THREE.Object3D;
+  longSelectDuration: number;
+  longSelectFired: boolean;
+  lastStablePoint: THREE.Vector3;
+  touch: boolean;
+}
+
+interface TouchState {
+  readonly selection: SelectionCapture;
+  readonly handIndex: number;
+  readonly hand?: THREE.Object3D;
+  point: THREE.Vector3;
+  prevented: boolean;
+  grabbing: boolean;
+}
+
+type ActiveCapture = {kind: 'none'} | {kind: 'auxiliary'} | TargetCapture;
+
+const DEFAULT_LONG_SELECT_DURATION = 0.75;
+const DEFAULT_RETICLE_OPTIONS: InteractionReticleOptions = {
+  projectOnDepthMesh: false,
+  defaultRenderDistance: 0,
+};
+
+/** Owns all logical target, hover, capture, completion, and cancellation state. */
+export class Interaction {
+  private readonly callbacks;
+  private readonly manipulation;
+  private readonly reticle;
+  private readonly reticleOptions;
+  private readonly scene?: THREE.Scene;
+  private readonly registry = new HitRegistry();
+  private readonly resolver;
+  private readonly directTouch;
+  private longSelectDuration;
+  private readonly gazeDwell = new GazeDwell();
+  private readonly sourceStates = new Map<Controller, InteractionSourceState>();
+  private readonly frameSnapshots: InteractionSourceState[] = [];
+  private readonly rawIntersections = new Map<
+    Controller,
+    THREE.Intersection[]
+  >();
+  private readonly resolvedRays = new Map<Controller, ResolvedRay>();
+  private readonly hoverPaths = new Map<
+    Controller,
+    readonly THREE.Object3D[]
+  >();
+  private readonly captures = new Map<Controller, ActiveCapture>();
+  private readonly exclusiveControls = new Map<THREE.Object3D, Controller>();
+  private readonly touches = new Map<Controller, TouchState>();
+  private readonly suppressedUntilRelease = new Set<Controller>();
+  private readonly scaleIntents = new Map<Controller, number>();
+  private raycastMode: RaycastMode;
+  private frameSources = new Set<Controller>();
+  private nextFrameSources = new Set<Controller>();
+
+  constructor(dependencies: InteractionDependencies) {
+    this.callbacks = dependencies.callbacks;
+    this.scene = dependencies.scene;
+    this.manipulation = new ManipulationManager(
+      (script, event) => this.callbacks.invokeManipulation(script, event),
+      (controller) => this.suppressedUntilRelease.add(controller),
+      dependencies.camera,
+      dependencies.timer
+    );
+    this.reticleOptions =
+      dependencies.reticleOptions ?? DEFAULT_RETICLE_OPTIONS;
+    this.reticle =
+      dependencies.reticle ?? new ReticlePresenter(this.reticleOptions);
+    this.longSelectDuration =
+      dependencies.longSelectDuration ?? DEFAULT_LONG_SELECT_DURATION;
+    this.raycastMode = dependencies.raycastMode ?? 'continuous';
+    this.resolver = new HitResolver(
+      this.callbacks,
+      this.manipulation,
+      this.registry
+    );
+    this.directTouch = new DirectTouch(this.registry, this.resolver);
+  }
+
+  setLongSelectDuration(seconds: number): void {
+    if (!Number.isFinite(seconds) || seconds < 0) {
+      throw new Error(
+        'Options.interaction.longSelectDuration must be finite and nonnegative.'
+      );
+    }
+    this.longSelectDuration = seconds;
+  }
+
+  setRaycastMode(mode: RaycastMode): void {
+    this.raycastMode = mode;
+  }
+
+  /** Replaces all sampled physical interaction state for one engine frame. */
+  update(frame: InteractionFrameInput, deltaSeconds = 0): void {
+    const nextSources = this.nextFrameSources;
+    nextSources.clear();
+    for (const input of frame.raySources) nextSources.add(input.controller);
+    for (const input of frame.directTouches) nextSources.add(input.controller);
+    for (const controller of this.frameSources) {
+      if (!nextSources.has(controller)) {
+        this.removeSource(controller, 'source-lost');
+      }
+    }
+    this.nextFrameSources = this.frameSources;
+    this.frameSources = nextSources;
+
+    for (const [controller, capture] of this.captures) {
+      if (capture.kind === 'target') {
+        const reason = selectionInvalidReason(
+          capture.selection,
+          capture.ancestry,
+          capture.semanticControl !== undefined &&
+            isSemanticControlDisabled(capture.semanticControl)
+        );
+        if (reason) this.cancelCapture(controller, reason);
+      }
+    }
+
+    const snapshots = this.frameSnapshots;
+    snapshots.length = 0;
+    const touchContacts = this.directTouch.update(frame.directTouches);
+    for (const contact of touchContacts) {
+      const snapshot = this.processTouchContact(contact);
+      if (contact.phase !== 'end') snapshots.push(snapshot);
+    }
+
+    const deliberate = this.hasDeliberateInput(frame);
+    for (const input of frame.raySources) {
+      const snapshot = this.updateRay(input, deltaSeconds, deliberate);
+      if (snapshot) snapshots.push(snapshot);
+    }
+    for (const [controller, factor] of this.scaleIntents) {
+      this.applyScaleIntent(controller, factor);
+    }
+    this.scaleIntents.clear();
+
+    if (snapshots.length > 0) {
+      try {
+        this.manipulation.update(snapshots);
+      } catch (error) {
+        this.cancelFailedManipulations(error);
+      }
+    }
+    for (const [controller, capture] of this.captures) {
+      if (
+        (capture.kind === 'auxiliary' ||
+          (capture.kind === 'target' && capture.action === 'manipulate')) &&
+        this.manipulation.isSourceActive(controller) === false
+      ) {
+        this.cancelCapture(controller, 'disabled');
+      }
+    }
+    for (const snapshot of snapshots) {
+      const capture = this.captures.get(snapshot.controller);
+      if (!capture || capture.kind === 'none') continue;
+      try {
+        if (capture.kind === 'target') {
+          this.updateLongSelect(capture, snapshot, deltaSeconds);
+          this.updateSemantic(capture, snapshot);
+        }
+        this.callbacks.invokeGlobal(
+          'onSelecting',
+          this.createSelectEvent(snapshot.controller, capture)
+        );
+      } catch (error) {
+        this.cancelFailedCapture(snapshot.controller, error);
+      }
+    }
+  }
+
+  clear(): void {
+    for (const controller of this.frameSources) {
+      this.removeSource(controller, 'source-lost');
+    }
+    this.directTouch.clear();
+    this.frameSnapshots.length = 0;
+    this.rawIntersections.clear();
+    this.frameSources.clear();
+    this.nextFrameSources.clear();
+    this.exclusiveControls.clear();
+    this.scaleIntents.clear();
+  }
+
+  registerHitSurface(
+    physical: THREE.Object3D,
+    logical: THREE.Object3D
+  ): () => void {
+    return this.registry.register(physical, logical);
+  }
+
+  /** Refreshes bounded direct-touch candidates found by the lifecycle pass. */
+  syncTouchCandidates(candidates: Iterable<THREE.Object3D>): void {
+    this.registry.setWorldTouchCandidates(candidates);
+  }
+
+  /** Cancels captures that belong to an object before its Script is disposed. */
+  cancelObject(
+    object: THREE.Object3D,
+    reason: SelectionEndReason = 'removed'
+  ): void {
+    for (const [controller, capture] of this.captures) {
+      if (
+        capture.kind === 'target' &&
+        selectionBelongsTo(capture.selection, object)
+      ) {
+        this.cancelCapture(controller, reason);
+      }
+    }
+    for (const [controller, touch] of this.touches) {
+      if (!selectionBelongsTo(touch.selection, object)) continue;
+      const contact = this.directTouch.remove(controller);
+      if (contact) this.processTouchContact(contact);
+    }
+    for (const [controller, resolved] of this.resolvedRays) {
+      if (objectIsDescendantOf(resolved.surface, object)) {
+        this.clearResolvedRay(controller);
+        this.reticle.clear(controller);
+      }
+    }
+  }
+
+  removeSource(
+    controller: Controller,
+    reason: SelectionEndReason = 'source-lost'
+  ): void {
+    this.cancelCapture(controller, reason);
+    const contact = this.directTouch.remove(controller);
+    if (contact) this.processTouchContact(contact);
+    this.finishTouch(controller);
+    this.clearResolvedRay(controller);
+    this.reticle.clear(controller);
+    this.sourceStates.delete(controller);
+    this.rawIntersections.delete(controller);
+    this.hoverPaths.delete(controller);
+    this.gazeDwell.remove(controller);
+    this.suppressedUntilRelease.delete(controller);
+    this.scaleIntents.delete(controller);
+  }
+
+  getSourceSnapshot(
+    controller: Controller
+  ): InteractionSourceState | undefined {
+    return this.sourceStates.get(controller);
+  }
+
+  getResolvedRay(controller: Controller): ResolvedRay | undefined {
+    return this.resolvedRays.get(controller);
+  }
+
+  isPointingAt(object: THREE.Object3D): boolean {
+    for (const resolved of this.resolvedRays.values()) {
+      if (objectIsDescendantOf(resolved.surface, object)) return true;
+    }
+    return false;
+  }
+
+  isSelectingAt(object: THREE.Object3D): boolean {
+    for (const capture of this.captures.values()) {
+      if (
+        capture.kind === 'target' &&
+        objectIsDescendantOf(capture.selection.surface, object)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  isHovered(object: THREE.Object3D): boolean {
+    for (const resolved of this.resolvedRays.values()) {
+      if (objectIsDescendantOf(resolved.target ?? resolved.surface, object)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  getIntersectionAt(
+    object: THREE.Object3D,
+    controller?: Controller
+  ): THREE.Intersection | null {
+    let match: ResolvedRay | undefined;
+    let matchIndex = Number.POSITIVE_INFINITY;
+    for (const [source, resolved] of this.resolvedRays) {
+      if (controller && source !== controller) continue;
+      if (!objectIsDescendantOf(resolved.surface, object)) continue;
+      const index = controllerIndex(source);
+      if (index < matchIndex) {
+        match = resolved;
+        matchIndex = index;
+      }
+    }
+    return match
+      ? clonePublicIntersection(match.intersection, match.surface)
+      : null;
+  }
+
+  /** Writes up to two internal cursor points in controller order. */
+  writeCursorPointsAt(
+    object: THREE.Object3D,
+    first: THREE.Vector3,
+    second: THREE.Vector3
+  ): 0 | 1 | 2 {
+    let firstIndex = Number.POSITIVE_INFINITY;
+    let secondIndex = Number.POSITIVE_INFINITY;
+    let firstPoint: THREE.Vector3 | undefined;
+    let secondPoint: THREE.Vector3 | undefined;
+    for (const [controller, resolved] of this.resolvedRays) {
+      if (!objectIsDescendantOf(resolved.surface, object)) continue;
+      const index = controllerIndex(controller);
+      if (index < firstIndex) {
+        secondIndex = firstIndex;
+        secondPoint = firstPoint;
+        firstIndex = index;
+        firstPoint = resolved.intersection.point;
+      } else if (index < secondIndex) {
+        secondIndex = index;
+        secondPoint = resolved.intersection.point;
+      }
+    }
+    if (!firstPoint) return 0;
+    first.copy(firstPoint);
+    if (!secondPoint) return 1;
+    second.copy(secondPoint);
+    return 2;
+  }
+
+  isManipulating(object: THREE.Object3D): boolean {
+    return this.manipulation.isManipulating(object);
+  }
+
+  queueScaleIntent(controller: Controller, factor: number): boolean {
+    if (!Number.isFinite(factor) || factor <= 0) return false;
+    this.scaleIntents.set(
+      controller,
+      (this.scaleIntents.get(controller) ?? 1) * factor
+    );
+    return true;
+  }
+
+  private applyScaleIntent(controller: Controller, factor: number): boolean {
+    const snapshot = this.sourceStates.get(controller);
+    const resolved = this.resolvedRays.get(controller);
+    if (!snapshot || !resolved?.target) return false;
+    const source = getInteractionSource(controller, 'simulator');
+    const intentSnapshot = new InteractionSourceState(controller).copyFrom(
+      snapshot
+    );
+    intentSnapshot.source = source;
+    intentSnapshot.sourceType = 'simulator';
+    return this.manipulation.applyScaleIntent(
+      this.createSelection(controller, resolved),
+      intentSnapshot,
+      factor
+    );
+  }
+
+  private updateRay(
+    input: RaySourceInput,
+    deltaSeconds: number,
+    deliberate: boolean
+  ): InteractionSourceState | undefined {
+    if (this.directTouch.has(input.controller)) {
+      this.clearResolvedRay(input.controller);
+      this.reticle.clear(input.controller);
+      return undefined;
+    }
+
+    const previousSelected =
+      this.sourceStates.get(input.controller)?.selected ?? false;
+    const snapshot = this.updateRaySnapshot(input);
+    if (!snapshot.selected)
+      this.suppressedUntilRelease.delete(input.controller);
+
+    if (this.suppressedUntilRelease.has(input.controller)) {
+      this.clearResolvedRay(input.controller);
+      this.reticle.clear(input.controller);
+      return snapshot;
+    }
+
+    const intersections =
+      input.intersections ?? this.collectIntersections(input, previousSelected);
+    const resolved = this.resolver.resolve(intersections, input.sourceType);
+    let gazeCompleted = false;
+    if (input.sourceType === 'gaze') {
+      const semantic = resolved?.semanticControl
+        ? getSemanticControl(resolved.semanticControl)
+        : undefined;
+      const gazeTarget =
+        semantic?.kind === 'button' && resolved?.semanticControl
+          ? resolved
+          : undefined;
+      const dwell = this.gazeDwell.update(
+        input.controller,
+        gazeTarget,
+        deltaSeconds,
+        deliberate
+      );
+      snapshot.selectionProgress = dwell.progress;
+      gazeCompleted = dwell.completed;
+    } else {
+      snapshot.selectionProgress = undefined;
+      this.gazeDwell.remove(input.controller);
+    }
+
+    this.setResolvedRay(input.controller, snapshot, resolved);
+    if (gazeCompleted) {
+      this.beginSelection(input.controller, true);
+      this.endSelection(input.controller, 'released');
+    } else if (snapshot.selected !== previousSelected) {
+      if (snapshot.selected) this.beginSelection(input.controller);
+      else this.endSelection(input.controller, 'released');
+    }
+    return snapshot;
+  }
+
+  private collectIntersections(
+    input: RaySourceInput,
+    previousSelected: boolean
+  ): readonly THREE.Intersection[] {
+    let intersections = this.rawIntersections.get(input.controller);
+    if (!intersections) {
+      intersections = [];
+      this.rawIntersections.set(input.controller, intersections);
+    }
+    const shouldRaycast =
+      this.raycastMode === 'continuous' ||
+      input.sourceType === 'gaze' ||
+      input.selected ||
+      previousSelected ||
+      input.released === true;
+    if (!shouldRaycast || !this.scene) {
+      intersections.length = 0;
+      return intersections;
+    }
+    return this.registry.raycast(this.scene, input.ray, intersections);
+  }
+
+  private beginSelection(controller: Controller, gaze = false): void {
+    if (this.directTouch.has(controller) || this.captures.has(controller))
+      return;
+    const snapshot = this.sourceStates.get(controller);
+    if (!snapshot) return;
+    snapshot.selected = true;
+    const resolved = this.resolvedRays.get(controller);
+
+    const claimedScale = this.runManipulationTransition(() =>
+      this.manipulation.tryClaimScale(snapshot, resolved)
+    );
+    if (this.suppressedUntilRelease.has(controller)) return;
+    if (claimedScale) {
+      const capture = {kind: 'auxiliary'} as const;
+      this.installCapture(controller, capture);
+      this.runCaptureTransition(controller, () => {
+        this.clearResolvedRay(controller);
+        this.reticle.clear(controller);
+        this.callbacks.invokeGlobal(
+          'onSelectStart',
+          this.createSelectEvent(controller, capture)
+        );
+      });
+      return;
+    }
+
+    if (!resolved?.target) {
+      const capture = {kind: 'none'} as const;
+      this.installCapture(controller, capture);
+      this.runCaptureTransition(controller, () => {
+        this.callbacks.invokeGlobal(
+          'onSelectStart',
+          this.createSelectEvent(controller, capture)
+        );
+      });
+      return;
+    }
+    this.startTargetCapture(controller, snapshot, resolved, false, gaze);
+  }
+
+  private startTargetCapture(
+    controller: Controller,
+    snapshot: InteractionSourceState,
+    resolved: ResolvedRay,
+    touch: boolean,
+    gaze = false
+  ): TargetCapture {
+    const selection = this.createSelection(controller, resolved);
+    const semantic = resolved.semanticControl
+      ? getSemanticControl(resolved.semanticControl)
+      : undefined;
+    let action: AutomaticAction = 'select';
+    const wantsManipulation = !semantic && resolved.manipulation !== undefined;
+    if (semantic) {
+      action = 'semantic';
+      if (
+        semantic.kind === 'slider' &&
+        resolved.semanticControl &&
+        this.exclusiveControls.has(resolved.semanticControl)
+      ) {
+        action = 'none';
+      }
+    } else if (wantsManipulation) {
+      action = 'manipulate';
+    }
+    if (gaze && semantic?.kind !== 'button') action = 'none';
+    const sliderProjector =
+      action === 'semantic' && semantic?.kind === 'slider'
+        ? createPlanarSurfaceProjector(
+            this.registry.resolve(resolved.hitObject).physical
+          )
+        : undefined;
+
+    const capture: TargetCapture = {
+      kind: 'target',
+      action,
+      selection,
+      ancestry: Object.freeze([...resolved.objectPath]),
+      semantic,
+      semanticControl: resolved.semanticControl,
+      sliderProjector,
+      exclusiveControl:
+        action === 'semantic' && semantic?.kind === 'slider'
+          ? resolved.semanticControl
+          : undefined,
+      longSelectDuration: 0,
+      longSelectFired: false,
+      lastStablePoint: resolved.intersection.point.clone(),
+      touch,
+    };
+    this.installCapture(controller, capture);
+    this.runCaptureTransition(controller, () => {
+      const event = this.createSelectEvent(controller, capture);
+      dispatchInteractionPath(
+        this.callbacks,
+        selection.scriptPath,
+        'onObjectSelectStart',
+        event
+      );
+      if (
+        action === 'manipulate' &&
+        !this.manipulation.tryStart(selection, snapshot)
+      ) {
+        capture.action = 'none';
+      }
+      if (action === 'semantic') {
+        this.invokeSemantic(capture, () =>
+          semantic?.begin?.(semanticInput(snapshot, resolved, sliderProjector))
+        );
+      }
+      this.callbacks.invokeGlobal('onSelectStart', event);
+    });
+    return capture;
+  }
+
+  private endSelection(
+    controller: Controller,
+    reason: SelectionEndReason,
+    releasedTarget?: THREE.Object3D,
+    finalSnapshot?: InteractionSourceState
+  ): void {
+    const capture = this.detachCapture(controller);
+    if (!capture) return;
+    const snapshot = this.sourceStates.get(controller);
+    if (snapshot) snapshot.selected = false;
+
+    let completed = false;
+    let endReason = reason;
+    if (capture.kind === 'auxiliary') {
+      completed = this.runManipulationTransition(() =>
+        this.manipulation.end(controller, finalSnapshot ?? snapshot)
+      );
+    } else if (capture.kind === 'target') {
+      const released = this.resolvedRays.get(controller);
+      const sameTarget =
+        (releasedTarget ?? released?.target) === capture.selection.target;
+      if (capture.action === 'manipulate') {
+        completed = this.runManipulationTransition(() =>
+          this.manipulation.end(controller, finalSnapshot ?? snapshot)
+        );
+      } else if (capture.action === 'semantic') {
+        const slider = capture.semantic?.kind === 'slider';
+        completed =
+          !capture.longSelectFired &&
+          !isSemanticControlDisabled(capture.semanticControl!) &&
+          (slider || sameTarget);
+        if (completed) {
+          this.invokeSemantic(capture, () => {
+            if (slider) capture.semantic?.complete?.();
+            else capture.semantic?.activate();
+          });
+        } else {
+          this.invokeSemantic(capture, () => capture.semantic?.cancel?.());
+        }
+      } else {
+        completed =
+          capture.action === 'select' && !capture.longSelectFired && sameTarget;
+      }
+      endReason = completed
+        ? 'released'
+        : sameTarget
+          ? reason
+          : 'released-outside';
+      const endEvent: SelectEndEvent = {
+        ...this.createSelectEvent(controller, capture),
+        completed,
+        reason: endReason,
+      };
+      dispatchInteractionPath(
+        this.callbacks,
+        capture.selection.scriptPath,
+        'onObjectSelectEnd',
+        endEvent
+      );
+    }
+
+    const globalEvent = this.createSelectEvent(controller, capture);
+    if (completed) this.callbacks.invokeGlobal('onSelect', globalEvent);
+    this.callbacks.invokeGlobal('onSelectEnd', {
+      ...globalEvent,
+      completed,
+      reason: endReason,
+    });
+  }
+
+  private cancelCapture(
+    controller: Controller,
+    reason: SelectionEndReason
+  ): void {
+    const capture = this.detachCapture(controller);
+    if (!capture) return;
+    this.suppressedUntilRelease.add(controller);
+    this.runManipulationTransition(() =>
+      this.manipulation.cancelSource(controller)
+    );
+    const event: SelectEndEvent = {
+      ...this.createSelectEvent(controller, capture),
+      completed: false,
+      reason,
+    };
+    if (capture.kind === 'target') {
+      this.invokeSemantic(capture, () => capture.semantic?.cancel?.());
+      dispatchInteractionPath(
+        this.callbacks,
+        capture.selection.scriptPath,
+        'onObjectSelectEnd',
+        event
+      );
+    }
+    this.callbacks.invokeGlobal('onSelectEnd', event);
+  }
+
+  private processTouchContact(
+    contact: DirectTouchContact
+  ): InteractionSourceState {
+    const snapshot = this.updateTouchSnapshot(contact);
+    this.updateTouch(contact, snapshot);
+    if (contact.phase === 'end') snapshot.selected = false;
+    return snapshot;
+  }
+
+  private updateTouch(
+    contact: DirectTouchContact,
+    snapshot: InteractionSourceState
+  ): void {
+    if (contact.phase === 'start' && contact.resolved?.target) {
+      const selection = this.createSelection(
+        contact.controller,
+        contact.resolved
+      );
+      const touchState: TouchState = {
+        selection,
+        handIndex: contact.handIndex,
+        hand: contact.hand,
+        point: contact.point.clone(),
+        prevented: false,
+        grabbing: false,
+      };
+      this.touches.set(contact.controller, touchState);
+      try {
+        this.clearResolvedRay(contact.controller);
+        this.reticle.clear(contact.controller);
+        const prevented = this.dispatchTouchStart(touchState);
+        touchState.prevented = prevented;
+        if (!prevented) {
+          const capture = this.startTargetCapture(
+            contact.controller,
+            snapshot,
+            contact.resolved,
+            true
+          );
+          if (
+            capture.action === 'select' ||
+            (capture.action === 'semantic' &&
+              capture.semantic?.kind === 'button')
+          ) {
+            this.endSelection(
+              contact.controller,
+              'released',
+              capture.selection.target,
+              snapshot
+            );
+          }
+        }
+        this.updateGrab(touchState, contact);
+      } catch (error) {
+        this.touches.delete(contact.controller);
+        this.cancelFailedCapture(contact.controller, error);
+      }
+      return;
+    }
+
+    const touch = this.touches.get(contact.controller);
+    if (!touch) return;
+    touch.point.copy(contact.point);
+    if (contact.phase === 'move') {
+      try {
+        this.dispatchTouch(touch, 'onObjectTouching');
+        this.updateGrab(touch, contact);
+      } catch (error) {
+        this.touches.delete(contact.controller);
+        this.cancelFailedCapture(contact.controller, error);
+      }
+      return;
+    }
+
+    this.touches.delete(contact.controller);
+    this.suppressedUntilRelease.add(contact.controller);
+    try {
+      this.finishGrab(touch);
+      this.dispatchTouch(touch, 'onObjectTouchEnd');
+    } finally {
+      if (!touch.prevented) {
+        const capture = this.captures.get(contact.controller);
+        if (
+          contact.endReason === 'left-target' &&
+          capture?.kind === 'target' &&
+          capture.touch &&
+          capture.action !== 'none'
+        ) {
+          this.endSelection(
+            contact.controller,
+            'released',
+            touch.selection.target,
+            snapshot
+          );
+        } else {
+          this.cancelCapture(
+            contact.controller,
+            contact.endReason === 'source-lost'
+              ? 'source-lost'
+              : 'released-outside'
+          );
+        }
+      }
+    }
+  }
+
+  private finishTouch(controller: Controller): void {
+    const touch = this.touches.get(controller);
+    if (!touch) return;
+    this.touches.delete(controller);
+    this.finishGrab(touch);
+    this.dispatchTouch(touch, 'onObjectTouchEnd');
+  }
+
+  private dispatchTouchStart(touch: TouchState): boolean {
+    const state = {prevented: false};
+    for (const script of touch.selection.scriptPath) {
+      const event: ObjectTouchStartEvent = {
+        ...this.createTouchEvent(touch),
+        currentTarget: script,
+        get defaultPrevented() {
+          return state.prevented;
+        },
+        preventDefault() {
+          state.prevented = true;
+        },
+      };
+      if (
+        this.callbacks.invokeTarget(script, 'onObjectTouchStart', event) ===
+        true
+      ) {
+        break;
+      }
+    }
+    return state.prevented;
+  }
+
+  private dispatchTouch(
+    touch: TouchState,
+    hook: 'onObjectTouching' | 'onObjectTouchEnd'
+  ): void {
+    dispatchInteractionPath(
+      this.callbacks,
+      touch.selection.scriptPath,
+      hook,
+      this.createTouchEvent(touch)
+    );
+  }
+
+  private createTouchEvent(touch: TouchState): ObjectTouchEvent {
+    return {
+      source: touch.selection.publicSource,
+      target: touch.selection.target,
+      surface: touch.selection.surface,
+      handIndex: touch.handIndex,
+      hand: touch.hand,
+      touchPosition: touch.point.clone(),
+    };
+  }
+
+  private updateGrab(touch: TouchState, contact: DirectTouchContact): void {
+    if (!contact.selected || !touch.hand) {
+      this.finishGrab(touch);
+      return;
+    }
+    const event = this.createGrabEvent(touch);
+    if (!touch.grabbing) {
+      touch.grabbing = true;
+      dispatchInteractionPath(
+        this.callbacks,
+        touch.selection.scriptPath,
+        'onObjectGrabStart',
+        event
+      );
+    } else {
+      dispatchInteractionPath(
+        this.callbacks,
+        touch.selection.scriptPath,
+        'onObjectGrabbing',
+        event
+      );
+    }
+  }
+
+  private finishGrab(touch: TouchState): void {
+    if (!touch.grabbing || !touch.hand) return;
+    touch.grabbing = false;
+    dispatchInteractionPath(
+      this.callbacks,
+      touch.selection.scriptPath,
+      'onObjectGrabEnd',
+      this.createGrabEvent(touch)
+    );
+  }
+
+  private createGrabEvent(touch: TouchState): ObjectGrabEvent {
+    return {
+      ...this.createTouchEvent(touch),
+      hand: touch.hand!,
+    };
+  }
+
+  private updateSemantic(
+    capture: TargetCapture,
+    snapshot: InteractionSourceState
+  ): void {
+    if (capture.action !== 'semantic' || capture.semantic?.kind !== 'slider') {
+      return;
+    }
+    const projection = snapshot.ray
+      ? capture.sliderProjector?.(snapshot.ray)
+      : undefined;
+    if (projection) {
+      this.invokeSemantic(capture, () =>
+        capture.semantic?.update?.({
+          source: snapshot.source,
+          point: projection.point,
+          uv: projection.uv,
+        })
+      );
+      return;
+    }
+    const resolved = this.resolvedRays.get(snapshot.controller);
+    if (
+      resolved?.surface === capture.selection.surface &&
+      resolved.semanticControl === capture.semanticControl
+    ) {
+      this.invokeSemantic(capture, () =>
+        capture.semantic?.update?.(semanticInput(snapshot, resolved))
+      );
+    }
+  }
+
+  private updateLongSelect(
+    capture: TargetCapture,
+    snapshot: InteractionSourceState,
+    deltaSeconds: number
+  ): void {
+    if (
+      capture.longSelectFired ||
+      capture.action === 'manipulate' ||
+      capture.semantic?.kind === 'slider' ||
+      snapshot.sourceType === 'gaze' ||
+      !capture.selection.scriptPath.some((script) =>
+        this.callbacks.hasTargetHook(script, 'onObjectLongSelect')
+      )
+    ) {
+      return;
+    }
+    const resolved = this.resolvedRays.get(snapshot.controller);
+    const point = capture.touch
+      ? this.touches.get(snapshot.controller)?.point
+      : resolved?.target === capture.selection.target
+        ? resolved.intersection.point
+        : undefined;
+    if (!point) {
+      capture.longSelectDuration = 0;
+      return;
+    }
+    const threshold = snapshot.sourceType === 'direct-touch' ? 0.015 : 0.03;
+    if (point && point.distanceTo(capture.lastStablePoint) > threshold) {
+      capture.longSelectDuration = 0;
+      capture.lastStablePoint.copy(point);
+      return;
+    }
+    if (Number.isFinite(deltaSeconds) && deltaSeconds > 0) {
+      capture.longSelectDuration += deltaSeconds;
+    }
+    if (capture.longSelectDuration < this.longSelectDuration) return;
+
+    capture.longSelectFired = true;
+    const event: LongSelectEvent = {
+      ...this.createSelectEvent(snapshot.controller, capture),
+      duration: capture.longSelectDuration,
+    };
+    dispatchInteractionPath(
+      this.callbacks,
+      capture.selection.scriptPath,
+      'onObjectLongSelect',
+      event
+    );
+    this.callbacks.invokeGlobal('onLongSelect', event);
+  }
+
+  private setResolvedRay(
+    controller: Controller,
+    snapshot: InteractionSourceState,
+    resolved: ResolvedRay | undefined
+  ): void {
+    const previous = this.resolvedRays.get(controller);
+    if (resolved) this.resolvedRays.set(controller, resolved);
+    else this.resolvedRays.delete(controller);
+    this.updateHoverPath(controller, resolved, previous);
+    this.reticle.present(snapshot, resolved);
+  }
+
+  private clearResolvedRay(controller: Controller): void {
+    const previous = this.resolvedRays.get(controller);
+    this.resolvedRays.delete(controller);
+    this.updateHoverPath(controller, undefined, previous);
+  }
+
+  private updateHoverPath(
+    controller: Controller,
+    resolved: ResolvedRay | undefined,
+    previous?: ResolvedRay
+  ): void {
+    const nextPath = resolved?.scriptPath ?? [];
+    const oldPath = this.hoverPaths.get(controller) ?? [];
+    if (nextPath.length > 0) this.hoverPaths.set(controller, nextPath);
+    else this.hoverPaths.delete(controller);
+    let oldIndex = oldPath.length - 1;
+    let nextIndex = nextPath.length - 1;
+    while (
+      oldIndex >= 0 &&
+      nextIndex >= 0 &&
+      oldPath[oldIndex] === nextPath[nextIndex]
+    ) {
+      oldIndex--;
+      nextIndex--;
+    }
+    const eventFor = (value: ResolvedRay | undefined): HoverEvent => ({
+      source:
+        this.getSourceSnapshot(controller)?.source ??
+        getInteractionSource(controller, 'controller-ray'),
+      target: value?.target,
+      surface: value?.surface,
+      intersection: value?.intersection
+        ? clonePublicIntersection(value.intersection, value.surface)
+        : undefined,
+    });
+    dispatchInteractionPath(
+      this.callbacks,
+      oldPath.slice(0, oldIndex + 1),
+      'onHoverExit',
+      eventFor(previous)
+    );
+    const event = eventFor(resolved);
+    dispatchInteractionPath(
+      this.callbacks,
+      nextPath.slice(0, nextIndex + 1),
+      'onHoverEnter',
+      event
+    );
+    dispatchInteractionPath(this.callbacks, nextPath, 'onHovering', event);
+  }
+
+  private updateRaySnapshot(input: RaySourceInput): InteractionSourceState {
+    return this.getSourceState(input.controller).updateRay(input);
+  }
+
+  private updateTouchSnapshot(
+    contact: DirectTouchContact
+  ): InteractionSourceState {
+    return this.getSourceState(contact.controller).updateTouch(
+      contact.point,
+      contact.orientation
+    );
+  }
+
+  private getSourceState(controller: Controller): InteractionSourceState {
+    let snapshot = this.sourceStates.get(controller);
+    if (snapshot) return snapshot;
+    snapshot = new InteractionSourceState(controller);
+    this.sourceStates.set(controller, snapshot);
+    return snapshot;
+  }
+
+  private createSelection(
+    controller: Controller,
+    resolved: ResolvedRay
+  ): SelectionCapture {
+    const target = resolved.target!;
+    return {
+      source: controller,
+      publicSource:
+        this.getSourceSnapshot(controller)?.source ??
+        getInteractionSource(controller, 'controller-ray'),
+      target,
+      surface: resolved.surface,
+      owner: resolved.manipulation?.owner ?? target,
+      point: resolved.intersection.point.clone(),
+      uv: resolved.intersection.uv?.clone(),
+      scriptPath: Object.freeze([...resolved.scriptPath]),
+      manipulation: resolved.manipulation,
+    };
+  }
+
+  private createSelectEvent(
+    controller: Controller,
+    capture: ActiveCapture
+  ): SelectEvent {
+    const targetCapture = capture.kind === 'target' ? capture : undefined;
+    return {
+      source:
+        targetCapture?.selection.publicSource ??
+        this.getSourceSnapshot(controller)?.source ??
+        getInteractionSource(controller, 'controller-ray'),
+      target: targetCapture?.selection.target,
+      surface: targetCapture?.selection.surface,
+    };
+  }
+
+  private hasDeliberateInput(frame: InteractionFrameInput): boolean {
+    if (
+      frame.raySources.some(
+        (input) => input.sourceType !== 'gaze' && input.selected
+      ) ||
+      this.touches.size > 0
+    ) {
+      return true;
+    }
+    for (const capture of this.captures.values()) {
+      if (
+        capture.kind === 'auxiliary' ||
+        (capture.kind === 'target' && capture.action === 'manipulate')
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private installCapture(controller: Controller, capture: ActiveCapture): void {
+    this.captures.set(controller, capture);
+    if (capture.kind === 'target' && capture.exclusiveControl) {
+      this.exclusiveControls.set(capture.exclusiveControl, controller);
+    }
+  }
+
+  private detachCapture(controller: Controller): ActiveCapture | undefined {
+    const capture = this.captures.get(controller);
+    if (!capture) return undefined;
+    this.captures.delete(controller);
+    if (
+      capture.kind === 'target' &&
+      capture.exclusiveControl &&
+      this.exclusiveControls.get(capture.exclusiveControl) === controller
+    ) {
+      this.exclusiveControls.delete(capture.exclusiveControl);
+    }
+    return capture;
+  }
+
+  private runCaptureTransition(
+    controller: Controller,
+    transition: () => void
+  ): void {
+    try {
+      transition();
+    } catch (error) {
+      this.cancelFailedCapture(controller, error);
+    }
+  }
+
+  private cancelFailedCapture(controller: Controller, error: unknown): never {
+    this.suppressedUntilRelease.add(controller);
+    try {
+      this.cancelCapture(controller, 'pointer-cancel');
+    } catch {
+      // Preserve the callback error which caused the rollback.
+    }
+    throw error;
+  }
+
+  private cancelFailedManipulations(error: unknown): never {
+    for (const [controller, capture] of [...this.captures]) {
+      if (
+        (capture.kind === 'auxiliary' ||
+          (capture.kind === 'target' && capture.action === 'manipulate')) &&
+        !this.manipulation.isSourceActive(controller)
+      ) {
+        try {
+          this.cancelCapture(controller, 'pointer-cancel');
+        } catch {
+          // Preserve the manipulation callback error.
+        }
+      }
+    }
+    throw error;
+  }
+
+  private runManipulationTransition<Result>(transition: () => Result): Result {
+    try {
+      return transition();
+    } catch (error) {
+      this.cancelFailedManipulations(error);
+    }
+  }
+
+  private invokeSemantic(capture: TargetCapture, callback: () => void): void {
+    if (!capture.semanticControl) return;
+    this.callbacks.invokeSemantic(capture.semanticControl, callback);
+  }
+}
+
+function semanticInput(
+  snapshot: InteractionSourceState,
+  resolved: ResolvedRay,
+  projector?: PlanarSurfaceProjector
+) {
+  const projection = snapshot.ray ? projector?.(snapshot.ray) : undefined;
+  return {
+    source: snapshot.source,
+    point: projection?.point ?? resolved.intersection.point.clone(),
+    uv: projection?.uv ?? resolved.intersection.uv?.clone(),
+  };
+}
+
+function clonePublicIntersection(
+  intersection: THREE.Intersection,
+  surface: THREE.Object3D
+): THREE.Intersection {
+  return {
+    ...intersection,
+    object: surface,
+    point: intersection.point.clone(),
+    normal: intersection.normal?.clone(),
+    uv: intersection.uv?.clone(),
+    uv1: intersection.uv1?.clone(),
+  };
+}
+
+function controllerIndex(controller: Controller): number {
+  const value = controller.userData.id;
+  return typeof value === 'number' ? value : Number.MAX_SAFE_INTEGER;
+}
+
+function selectionBelongsTo(
+  selection: SelectionCapture,
+  object: THREE.Object3D
+): boolean {
+  return (
+    objectIsDescendantOf(selection.target, object) ||
+    selection.scriptPath.includes(object)
+  );
+}

--- a/src/interaction/InteractionTypes.ts
+++ b/src/interaction/InteractionTypes.ts
@@ -1,0 +1,328 @@
+import * as THREE from 'three';
+
+import type {Controller} from '../input/Controller.js';
+import type {
+  ManipulationAction,
+  ManipulationHandleOptions,
+  ManipulationEvent,
+  ManipulationOptions,
+} from './manipulation/ManipulationTypes.js';
+
+export type PointerEvents = 'auto' | 'none';
+export type ReticleMode = 'auto' | 'surface' | 'hidden';
+export type RaycastMode = 'continuous' | 'select';
+
+export interface InteractionReticleOptions {
+  projectOnDepthMesh?: boolean;
+  maxDistance?: number;
+  defaultRenderDistance?: number;
+}
+
+export interface ManipulationSurfaceOptions {
+  scale?: boolean;
+  translateFromSurface?: boolean;
+}
+
+export interface XBObjectOptions {
+  pointerEvents?: PointerEvents;
+  interactionEnabled?: boolean;
+  reticleMode?: ReticleMode;
+  manipulation?: boolean | ManipulationOptions;
+  manipulationHandle?: ManipulationHandleOptions | 'none';
+  manipulationSurface?: ManipulationSurfaceOptions;
+}
+
+declare module 'three' {
+  interface Object3D {
+    xb?: XBObjectOptions;
+  }
+}
+
+export type InteractionSourceType =
+  | 'mouse'
+  | 'controller-ray'
+  | 'hand-ray'
+  | 'direct-touch'
+  | 'gaze'
+  | 'simulator';
+
+export type RaySourceType = Exclude<InteractionSourceType, 'direct-touch'>;
+
+export interface InteractionSource {
+  readonly type: InteractionSourceType;
+  readonly handedness: 'left' | 'right' | 'none';
+  readonly controller: Controller;
+}
+
+export interface SelectEvent {
+  readonly source: InteractionSource;
+  readonly target?: THREE.Object3D;
+  readonly currentTarget?: THREE.Object3D;
+  readonly surface?: THREE.Object3D;
+}
+
+export type SelectionEndReason =
+  | 'released'
+  | 'released-outside'
+  | 'source-lost'
+  | 'pointer-cancel'
+  | 'removed'
+  | 'hidden'
+  | 'disabled';
+
+export interface SelectEndEvent extends SelectEvent {
+  readonly completed: boolean;
+  readonly reason: SelectionEndReason;
+}
+
+export interface LongSelectEvent extends SelectEvent {
+  readonly duration: number;
+}
+
+export interface ObjectTouchEvent {
+  readonly source: InteractionSource;
+  readonly target: THREE.Object3D;
+  readonly currentTarget?: THREE.Object3D;
+  readonly surface: THREE.Object3D;
+  readonly handIndex: number;
+  readonly hand?: THREE.Object3D;
+  readonly touchPosition: THREE.Vector3;
+}
+
+export interface ObjectTouchStartEvent extends ObjectTouchEvent {
+  readonly defaultPrevented: boolean;
+  preventDefault(): void;
+}
+
+export interface ObjectGrabEvent {
+  readonly source: InteractionSource;
+  readonly target: THREE.Object3D;
+  readonly currentTarget?: THREE.Object3D;
+  readonly surface: THREE.Object3D;
+  readonly handIndex: number;
+  readonly hand: THREE.Object3D;
+  readonly touchPosition: THREE.Vector3;
+}
+
+export interface HoverEvent extends SelectEvent {
+  readonly intersection?: THREE.Intersection;
+}
+
+export interface RaySourceInput {
+  controller: Controller;
+  sourceType: RaySourceType;
+  ray: THREE.Ray;
+  /** Optional raw hits supplied by an isolated Interaction adapter. */
+  intersections?: readonly THREE.Intersection[];
+  selected: boolean;
+  released?: boolean;
+  position?: THREE.Vector3;
+  orientation?: THREE.Quaternion;
+}
+
+export interface DirectTouchInput {
+  controller: Controller;
+  handIndex: number;
+  hand?: THREE.Object3D;
+  point: THREE.Vector3;
+  selected: boolean;
+  orientation?: THREE.Quaternion;
+}
+
+/** All physical interaction input sampled for one engine frame. */
+export interface InteractionFrameInput {
+  readonly raySources: readonly RaySourceInput[];
+  readonly directTouches: readonly DirectTouchInput[];
+}
+
+/** Mutable internal storage for one controller's current logical source. */
+export class InteractionSourceState {
+  source: InteractionSource;
+  sourceType: InteractionSourceType = 'controller-ray';
+  readonly position = new THREE.Vector3();
+  readonly orientation = new THREE.Quaternion();
+  private readonly rayValue = new THREE.Ray();
+  ray?: THREE.Ray;
+  selected = false;
+  selectionProgress?: number;
+
+  constructor(readonly controller: Controller) {
+    this.source = getInteractionSource(controller, this.sourceType);
+  }
+
+  updateRay(input: RaySourceInput): this {
+    this.source = getInteractionSource(this.controller, input.sourceType);
+    this.sourceType = input.sourceType;
+    if (input.position) this.position.copy(input.position);
+    else this.controller.getWorldPosition(this.position);
+    if (input.orientation) this.orientation.copy(input.orientation);
+    else this.controller.getWorldQuaternion(this.orientation);
+    this.rayValue.copy(input.ray);
+    this.ray = this.rayValue;
+    this.selected = input.sourceType === 'gaze' ? false : input.selected;
+    this.selectionProgress = undefined;
+    return this;
+  }
+
+  updateTouch(point: THREE.Vector3, orientation?: THREE.Quaternion): this {
+    this.source = getInteractionSource(this.controller, 'direct-touch');
+    this.sourceType = 'direct-touch';
+    this.position.copy(point);
+    if (orientation) this.orientation.copy(orientation);
+    else this.controller.getWorldQuaternion(this.orientation);
+    this.ray = undefined;
+    this.selected = true;
+    this.selectionProgress = undefined;
+    return this;
+  }
+
+  copyFrom(source: InteractionSourceState): this {
+    this.source = source.source;
+    this.sourceType = source.sourceType;
+    this.position.copy(source.position);
+    this.orientation.copy(source.orientation);
+    if (source.ray) {
+      this.rayValue.copy(source.ray);
+      this.ray = this.rayValue;
+    } else {
+      this.ray = undefined;
+    }
+    this.selected = source.selected;
+    this.selectionProgress = source.selectionProgress;
+    return this;
+  }
+}
+
+export interface ResolvedRay {
+  readonly intersection: THREE.Intersection;
+  /** Physical object that supplied the hit geometry. */
+  readonly hitObject: THREE.Object3D;
+  /** Public object that owns the hit. */
+  readonly surface: THREE.Object3D;
+  readonly target?: THREE.Object3D;
+  readonly scriptPath: readonly THREE.Object3D[];
+  readonly objectPath: readonly THREE.Object3D[];
+  readonly reticleMode: ReticleMode;
+  readonly semanticControl?: THREE.Object3D;
+  readonly manipulation?: ManipulationResolution;
+}
+
+export interface SelectionCapture {
+  readonly source: Controller;
+  readonly publicSource: InteractionSource;
+  readonly target: THREE.Object3D;
+  readonly surface: THREE.Object3D;
+  readonly owner: THREE.Object3D;
+  readonly point: THREE.Vector3;
+  readonly uv?: THREE.Vector2;
+  readonly scriptPath: readonly THREE.Object3D[];
+  readonly manipulation?: ManipulationResolution;
+}
+
+export type ResolvedManipulationAction = Exclude<ManipulationAction, 'none'>;
+
+export interface ManipulationResolution {
+  readonly owner: THREE.Object3D;
+  readonly action?: ResolvedManipulationAction;
+  readonly handle?: THREE.Object3D;
+}
+
+export type TargetedInteractionHook =
+  | 'onObjectSelectStart'
+  | 'onObjectSelectEnd'
+  | 'onObjectLongSelect'
+  | 'onObjectTouchStart'
+  | 'onObjectTouching'
+  | 'onObjectTouchEnd'
+  | 'onObjectGrabStart'
+  | 'onObjectGrabbing'
+  | 'onObjectGrabEnd'
+  | 'onHoverEnter'
+  | 'onHovering'
+  | 'onHoverExit';
+
+export type GlobalInteractionHook =
+  | 'onSelectStart'
+  | 'onSelecting'
+  | 'onSelect'
+  | 'onSelectEnd'
+  | 'onLongSelect';
+
+export type GlobalInteractionEvent<Hook extends GlobalInteractionHook> =
+  Hook extends 'onSelectEnd'
+    ? SelectEndEvent
+    : Hook extends 'onLongSelect'
+      ? LongSelectEvent
+      : SelectEvent;
+
+/**
+ * The only Script-facing seam. The implementation applies the existing Script
+ * exception policy to each invocation.
+ */
+export interface InteractionCallbackDispatch {
+  isScript(object: THREE.Object3D): boolean;
+  hasTargetHandler(
+    object: THREE.Object3D,
+    sourceType: InteractionSourceType
+  ): boolean;
+  hasTargetHook(object: THREE.Object3D, hook: TargetedInteractionHook): boolean;
+  invokeTarget(
+    script: THREE.Object3D,
+    hook: TargetedInteractionHook,
+    argument: unknown
+  ): unknown;
+  invokeSemantic(object: THREE.Object3D, callback: () => void): void;
+  invokeGlobal<Hook extends GlobalInteractionHook>(
+    hook: Hook,
+    event: GlobalInteractionEvent<Hook>
+  ): void;
+  invokeManipulation(script: THREE.Object3D, event: ManipulationEvent): boolean;
+}
+
+export interface ReticlePresentationObserver {
+  present(
+    snapshot: InteractionSourceState,
+    resolved: ResolvedRay | undefined
+  ): void;
+  clear(controller: Controller): void;
+}
+
+export interface InteractionDependencies {
+  callbacks: InteractionCallbackDispatch;
+  scene?: THREE.Scene;
+  raycastMode?: RaycastMode;
+  camera?: THREE.Camera;
+  timer?: THREE.Timer;
+  reticle?: ReticlePresentationObserver;
+  reticleOptions?: InteractionReticleOptions;
+  longSelectDuration?: number;
+}
+
+const PUBLIC_SOURCES = new WeakMap<
+  Controller,
+  Map<InteractionSourceType, InteractionSource>
+>();
+
+/** Returns one stable public source for a controller and modality. */
+export function getInteractionSource(
+  controller: Controller,
+  type: InteractionSourceType
+): InteractionSource {
+  let byType = PUBLIC_SOURCES.get(controller);
+  if (!byType) {
+    byType = new Map();
+    PUBLIC_SOURCES.set(controller, byType);
+  }
+  const source = byType.get(type);
+  if (source) return source;
+  const created: InteractionSource = Object.freeze({
+    type,
+    controller,
+    get handedness(): InteractionSource['handedness'] {
+      const value = controller.inputSource?.handedness;
+      return value === 'left' || value === 'right' ? value : 'none';
+    },
+  });
+  byType.set(type, created);
+  return created;
+}

--- a/src/interaction/InteractionUtils.ts
+++ b/src/interaction/InteractionUtils.ts
@@ -1,0 +1,44 @@
+import * as THREE from 'three';
+
+import type {
+  InteractionCallbackDispatch,
+  SelectionCapture,
+  TargetedInteractionHook,
+} from './InteractionTypes.js';
+
+export function dispatchInteractionPath(
+  callbacks: InteractionCallbackDispatch,
+  path: readonly THREE.Object3D[],
+  hook: TargetedInteractionHook,
+  argument: unknown
+): void {
+  for (const script of path) {
+    if (callbacks.invokeTarget(script, hook, argument) === true) return;
+  }
+}
+
+export function selectionInvalidReason(
+  selection: SelectionCapture,
+  ancestry: readonly THREE.Object3D[],
+  semanticDisabled: boolean
+): 'removed' | 'hidden' | 'disabled' | undefined {
+  const ownerIndex = ancestry.indexOf(selection.owner);
+  if (ownerIndex < 0) return 'removed';
+
+  for (let index = 0; index + 1 < ancestry.length; index++) {
+    if (ancestry[index].parent !== ancestry[index + 1]) return 'removed';
+  }
+
+  for (let index = 0; index < ancestry.length; index++) {
+    const object = ancestry[index];
+    if (object.visible === false) return 'hidden';
+  }
+
+  if (semanticDisabled) return 'disabled';
+  for (let index = 0; index < ancestry.length; index++) {
+    const object = ancestry[index];
+    if (object.xb?.pointerEvents === 'none') return 'disabled';
+    if (index <= ownerIndex && object.xb?.interactionEnabled === false)
+      return 'disabled';
+  }
+}

--- a/src/interaction/PlanarSurface.ts
+++ b/src/interaction/PlanarSurface.ts
@@ -1,0 +1,61 @@
+import * as THREE from 'three';
+
+export interface SurfaceProjection {
+  readonly point: THREE.Vector3;
+  readonly uv: THREE.Vector2;
+}
+
+export type PlanarSurfaceProjector = (
+  ray: THREE.Ray
+) => SurfaceProjection | undefined;
+
+/** Captures a mesh's local XY plane for continued pointer projection. */
+export function createPlanarSurfaceProjector(
+  surface: THREE.Object3D
+): PlanarSurfaceProjector | undefined {
+  if (!(surface instanceof THREE.Mesh)) return undefined;
+  surface.geometry.computeBoundingBox();
+  const bounds = surface.geometry.boundingBox?.clone();
+  if (!bounds || !hasFinitePlanarBounds(bounds)) return undefined;
+
+  const width = bounds.max.x - bounds.min.x;
+  const height = bounds.max.y - bounds.min.y;
+  const plane = new THREE.Plane(
+    new THREE.Vector3(0, 0, 1),
+    -(bounds.min.z + bounds.max.z) / 2
+  );
+  const worldToLocal = new THREE.Matrix4();
+  const localRay = new THREE.Ray();
+  const localPoint = new THREE.Vector3();
+
+  return (ray) => {
+    surface.updateWorldMatrix(true, false);
+    if (Math.abs(surface.matrixWorld.determinant()) < Number.EPSILON) {
+      return undefined;
+    }
+    worldToLocal.copy(surface.matrixWorld).invert();
+    localRay.copy(ray).applyMatrix4(worldToLocal);
+    if (!localRay.intersectPlane(plane, localPoint)) return undefined;
+
+    return {
+      point: localPoint.clone().applyMatrix4(surface.matrixWorld),
+      uv: new THREE.Vector2(
+        (localPoint.x - bounds.min.x) / width,
+        (localPoint.y - bounds.min.y) / height
+      ),
+    };
+  };
+}
+
+function hasFinitePlanarBounds(bounds: THREE.Box3): boolean {
+  return (
+    Number.isFinite(bounds.min.x) &&
+    Number.isFinite(bounds.max.x) &&
+    Number.isFinite(bounds.min.y) &&
+    Number.isFinite(bounds.max.y) &&
+    Number.isFinite(bounds.min.z) &&
+    Number.isFinite(bounds.max.z) &&
+    bounds.max.x > bounds.min.x &&
+    bounds.max.y > bounds.min.y
+  );
+}

--- a/src/interaction/ReticlePresenter.ts
+++ b/src/interaction/ReticlePresenter.ts
@@ -1,0 +1,120 @@
+import * as THREE from 'three';
+
+import type {Controller} from '../input/Controller.js';
+import type {
+  InteractionReticleOptions,
+  InteractionSourceState,
+  ResolvedRay,
+  ReticlePresentationObserver,
+} from './InteractionTypes.js';
+
+const NORMAL_MATRIX = new THREE.Matrix3();
+const WORLD_NORMAL = new THREE.Vector3();
+
+/** Presents resolved state. It never performs a raycast or changes targeting. */
+export class ReticlePresenter implements ReticlePresentationObserver {
+  private readonly scene = new THREE.Scene();
+
+  constructor(
+    private readonly options: InteractionReticleOptions = {
+      defaultRenderDistance: 0,
+    },
+    private readonly reticles?: THREE.Object3D
+  ) {
+    if (reticles) this.scene.add(reticles);
+  }
+
+  /** Draws reticles after every world and UI pass. */
+  render(renderer: THREE.WebGLRenderer, camera: THREE.Camera): void {
+    if (!this.reticles || this.reticles.children.length === 0) return;
+    const autoClear = renderer.autoClear;
+    try {
+      renderer.autoClear = false;
+      renderer.render(this.scene, camera);
+    } finally {
+      renderer.autoClear = autoClear;
+    }
+  }
+
+  present(
+    snapshot: InteractionSourceState,
+    resolved: ResolvedRay | undefined
+  ): void {
+    const reticle = snapshot.controller.reticle;
+    if (!reticle) return;
+    const ray = snapshot.ray;
+    if (!ray) {
+      this.clear(snapshot.controller);
+      return;
+    }
+
+    reticle.direction.copy(ray.direction).normalize();
+    if (snapshot.selectionProgress === undefined) {
+      reticle.setPressed(snapshot.selected);
+    } else {
+      reticle.setPressedAmount(snapshot.selectionProgress);
+    }
+
+    if (resolved?.reticleMode === 'hidden') {
+      this.clear(snapshot.controller);
+      return;
+    }
+
+    const beyondPresentationRange =
+      resolved &&
+      this.options.maxDistance !== undefined &&
+      resolved.intersection.distance >= this.options.maxDistance;
+    if (!resolved || beyondPresentationRange) {
+      reticle.intersection = undefined;
+      reticle.targetObject = undefined;
+      setHovering(reticle, false);
+      const defaultRenderDistance = this.options.defaultRenderDistance ?? 0;
+      if (defaultRenderDistance <= 0) {
+        reticle.visible = false;
+        return;
+      }
+
+      reticle.visible = true;
+      reticle.position
+        .copy(ray.origin)
+        .addScaledVector(reticle.direction, defaultRenderDistance);
+      WORLD_NORMAL.copy(reticle.direction).negate();
+      reticle.setRotationFromNormalVector(WORLD_NORMAL);
+      return;
+    }
+
+    const {intersection} = resolved;
+    reticle.visible = true;
+    reticle.intersection = intersection;
+    const showsTarget = resolved.reticleMode === 'auto';
+    reticle.targetObject = showsTarget ? resolved.target : undefined;
+    setHovering(reticle, showsTarget && resolved.target !== undefined);
+    reticle.position.copy(intersection.point);
+
+    if (intersection.normal) {
+      resolved.hitObject.updateWorldMatrix(true, false);
+      NORMAL_MATRIX.getNormalMatrix(resolved.hitObject.matrixWorld);
+      WORLD_NORMAL.copy(intersection.normal)
+        .applyMatrix3(NORMAL_MATRIX)
+        .normalize();
+    } else {
+      WORLD_NORMAL.copy(ray.direction).negate().normalize();
+    }
+    reticle.setRotationFromNormalVector(WORLD_NORMAL);
+  }
+
+  clear(controller: Controller): void {
+    if (!controller.reticle) return;
+    controller.reticle.visible = false;
+    controller.reticle.intersection = undefined;
+    controller.reticle.targetObject = undefined;
+    setHovering(controller.reticle, false);
+  }
+}
+
+function setHovering(reticle: THREE.Object3D, hovering: boolean): void {
+  const hoverable = reticle as THREE.Object3D & {
+    setHovering?: (value: boolean) => void;
+  };
+  hoverable.setHovering?.(hovering);
+}

--- a/src/interaction/SemanticControl.ts
+++ b/src/interaction/SemanticControl.ts
@@ -1,0 +1,43 @@
+import type * as THREE from 'three';
+
+import type {InteractionSource} from './InteractionTypes';
+
+export interface SemanticControlInput {
+  readonly source: InteractionSource;
+  readonly point: THREE.Vector3;
+  readonly uv?: THREE.Vector2;
+}
+
+export interface SemanticControlState {
+  readonly kind: 'button' | 'slider';
+  isDisabled(): boolean;
+  activate(): void;
+  begin?(input: SemanticControlInput): void;
+  update?(input: SemanticControlInput): void;
+  complete?(): void;
+  cancel?(): void;
+}
+
+const CONTROLS = new WeakMap<THREE.Object3D, SemanticControlState>();
+
+/** Registers one built-in semantic control without exposing UI internals. */
+export function registerSemanticControl(
+  object: THREE.Object3D,
+  state: SemanticControlState
+): void {
+  CONTROLS.set(object, state);
+}
+
+export function isSemanticControl(object: THREE.Object3D): boolean {
+  return CONTROLS.has(object);
+}
+
+export function isSemanticControlDisabled(object: THREE.Object3D): boolean {
+  return CONTROLS.get(object)?.isDisabled() ?? true;
+}
+
+export function getSemanticControl(
+  object: THREE.Object3D
+): SemanticControlState | undefined {
+  return CONTROLS.get(object);
+}

--- a/src/interaction/manipulation/ManipulationConfig.ts
+++ b/src/interaction/manipulation/ManipulationConfig.ts
@@ -1,0 +1,109 @@
+import * as THREE from 'three';
+
+import type {ResolvedManipulationAction} from '../InteractionTypes';
+import {
+  ManipulationAction,
+  type ManipulationOptions,
+  type RotateOptions,
+  type ScaleOptions,
+  type TranslateOptions,
+} from './ManipulationTypes';
+
+const EPSILON = 1e-8;
+
+export type NormalizedManipulationConfig = {
+  translate?: TranslateOptions;
+  rotate?: RotateOptions;
+  scale?: ScaleOptions;
+  handle?: ResolvedManipulationAction | typeof ManipulationAction.None;
+};
+
+export function normalizeManipulationConfig(
+  value: boolean | ManipulationOptions | undefined
+): NormalizedManipulationConfig | undefined {
+  if (!value) return undefined;
+  if (value === true) {
+    return {
+      translate: {},
+      scale: {},
+      handle: ManipulationAction.Translate,
+    };
+  }
+  const translate = normalizeAction(value.actions?.translate);
+  const rotate = normalizeAction(value.actions?.rotate);
+  const scale = normalizeAction(value.actions?.scale);
+  const handle = value.handle?.action;
+  if (handle !== undefined && !isHandleAction(handle)) return undefined;
+  if (!translate && !rotate && !scale) return undefined;
+  return {translate, rotate, scale, handle};
+}
+
+export function isManipulationActionEnabled(
+  config: NormalizedManipulationConfig,
+  action: ResolvedManipulationAction
+): boolean {
+  if (action === ManipulationAction.Translate) return !!config.translate;
+  if (action === ManipulationAction.Rotate) return !!config.rotate;
+  if (action === ManipulationAction.Scale) return !!config.scale;
+  return false;
+}
+
+export function isHandleAction(
+  value: unknown
+): value is ResolvedManipulationAction | typeof ManipulationAction.None {
+  return value === ManipulationAction.None || isManipulationAction(value);
+}
+
+export function normalizeRotationAxis(
+  axis: RotateOptions['axis']
+): THREE.Vector3 | undefined {
+  const vector =
+    axis === undefined || axis === 'y'
+      ? new THREE.Vector3(0, 1, 0)
+      : axis === 'x'
+        ? new THREE.Vector3(1, 0, 0)
+        : axis === 'z'
+          ? new THREE.Vector3(0, 0, 1)
+          : new THREE.Vector3(axis.x, axis.y, axis.z);
+  if (!isFiniteVector(vector) || vector.lengthSq() < EPSILON) return undefined;
+  return vector.normalize();
+}
+
+export function cloneScaleOptions(
+  options: ScaleOptions | undefined
+): ScaleOptions {
+  const cloneLimit = (
+    value: number | THREE.Vector3Like | undefined
+  ): number | THREE.Vector3Like | undefined =>
+    typeof value === 'object' && value !== null
+      ? {x: value.x, y: value.y, z: value.z}
+      : value;
+  return {
+    minScale: cloneLimit(options?.minScale),
+    maxScale: cloneLimit(options?.maxScale),
+  };
+}
+
+function normalizeAction<T extends object>(
+  value: boolean | T | undefined
+): T | undefined {
+  return value === true ? ({} as T) : value || undefined;
+}
+
+function isManipulationAction(
+  value: unknown
+): value is ResolvedManipulationAction {
+  return (
+    value === ManipulationAction.Translate ||
+    value === ManipulationAction.Rotate ||
+    value === ManipulationAction.Scale
+  );
+}
+
+function isFiniteVector(value: THREE.Vector3): boolean {
+  return (
+    Number.isFinite(value.x) &&
+    Number.isFinite(value.y) &&
+    Number.isFinite(value.z)
+  );
+}

--- a/src/interaction/manipulation/ManipulationManager.ts
+++ b/src/interaction/manipulation/ManipulationManager.ts
@@ -1,0 +1,698 @@
+import * as THREE from 'three';
+
+import type {Controller} from '../../input/Controller';
+import {
+  resumeTransformScripts,
+  suspendTransformScripts,
+} from '../../placement/TransformScript';
+import {objectIsDescendantOf} from '../../utils/SceneGraphUtils';
+import {
+  InteractionSourceState,
+  type InteractionSource,
+  type ManipulationResolution,
+  type ResolvedManipulationAction,
+  type ResolvedRay,
+  type SelectionCapture,
+} from '../InteractionTypes';
+import {
+  isHandleAction,
+  isManipulationActionEnabled,
+  normalizeManipulationConfig,
+  type NormalizedManipulationConfig,
+} from './ManipulationConfig';
+import {
+  clampScaleFactor,
+  isPositiveFinite,
+  isPositiveVector,
+} from './ManipulationMath';
+import {
+  ManipulationAction,
+  type ManipulationEvent,
+  type ManipulationPhase,
+} from './ManipulationTypes';
+import type {PhaseBaseline, Proposal} from './drivers/DriverTypes';
+import {RotateDriver} from './drivers/RotateDriver';
+import {ScaleDriver} from './drivers/ScaleDriver';
+import {TranslateDriver} from './drivers/TranslateDriver';
+
+export type DispatchManipulationEvent = (
+  script: THREE.Object3D,
+  event: ManipulationEvent
+) => boolean | void;
+
+interface PrimaryRole {
+  capture: SelectionCapture;
+  snapshot: InteractionSourceState;
+}
+
+interface Session {
+  owner: THREE.Object3D;
+  ownerParent: THREE.Object3D | null;
+  config: NormalizedManipulationConfig;
+  primary: PrimaryRole;
+  primaryAction?: ResolvedManipulationAction;
+  auxiliary?: InteractionSourceState;
+  phase?: ActivePhase;
+  cardEdge?: {
+    primaryCorner?: CardCorner;
+  };
+}
+
+type CardCorner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+interface ActivePhase {
+  action: ResolvedManipulationAction;
+  baseline: PhaseBaseline;
+  defaultPrevented: boolean;
+  lastProposal?: Proposal;
+}
+
+/**
+ * Private runtime used by Interaction. It does not observe input or raycast.
+ * It is exported only so the sibling Interaction module can construct it.
+ */
+export class ManipulationManager {
+  private readonly sessions = new Map<THREE.Object3D, Session>();
+  private readonly roles = new Map<Controller, Session>();
+  private readonly translateDriver: TranslateDriver;
+  private readonly rotateDriver = new RotateDriver();
+  private readonly scaleDriver = new ScaleDriver();
+
+  constructor(
+    private readonly dispatch: DispatchManipulationEvent,
+    private readonly suppressSource: (source: Controller) => void,
+    camera?: THREE.Camera,
+    timer?: THREE.Timer
+  ) {
+    this.translateDriver = new TranslateDriver(camera, timer);
+  }
+
+  resolve(path: readonly THREE.Object3D[]): ManipulationResolution | undefined {
+    let childHandle:
+      | ResolvedManipulationAction
+      | typeof ManipulationAction.None
+      | undefined;
+    let hasChildHandle = false;
+    let handle: THREE.Object3D | undefined;
+
+    for (const current of path) {
+      const options = current.xb;
+      if (!hasChildHandle && options?.manipulationHandle !== undefined) {
+        hasChildHandle = true;
+        handle = current;
+        const action =
+          options.manipulationHandle === 'none'
+            ? ManipulationAction.None
+            : options.manipulationHandle.action;
+        if (action !== undefined && !isHandleAction(action)) return undefined;
+        childHandle = action;
+      }
+
+      if (options?.manipulation !== undefined) {
+        if (
+          options.manipulation === false ||
+          options.manipulationHandle !== undefined
+        ) {
+          return undefined;
+        }
+        const config = normalizeManipulationConfig(options.manipulation);
+        if (!config) return undefined;
+
+        const edge = getCardEdge(current);
+        if (edge && !hasChildHandle && !edge.translateFromSurface) {
+          return undefined;
+        }
+
+        const requested = hasChildHandle ? childHandle : config.handle;
+        if (requested === ManipulationAction.None) return undefined;
+        if (requested !== undefined) {
+          return isManipulationActionEnabled(config, requested)
+            ? {owner: current, action: requested, handle}
+            : undefined;
+        }
+
+        const primaryActions = [
+          config.translate && ManipulationAction.Translate,
+          config.rotate && ManipulationAction.Rotate,
+        ].filter(Boolean) as ResolvedManipulationAction[];
+        if (primaryActions.length === 1) {
+          return {owner: current, action: primaryActions[0], handle};
+        }
+        if (primaryActions.length === 0 && config.scale) {
+          return {owner: current, handle};
+        }
+        return undefined;
+      }
+    }
+    return undefined;
+  }
+
+  /** Starts a primary session after Interaction has dispatched Select start. */
+  tryStart(
+    capture: SelectionCapture,
+    snapshot: InteractionSourceState
+  ): boolean {
+    if (
+      snapshot.sourceType === 'gaze' ||
+      capture.source !== snapshot.controller ||
+      this.roles.has(snapshot.controller)
+    ) {
+      return false;
+    }
+
+    const resolution = capture.manipulation;
+    if (!resolution || this.sessions.has(resolution.owner)) return false;
+    const config = normalizeManipulationConfig(
+      resolution.owner.xb?.manipulation
+    );
+    if (!config) return false;
+
+    const session: Session = {
+      owner: resolution.owner,
+      ownerParent: resolution.owner.parent,
+      config,
+      primary: {
+        capture,
+        snapshot: new InteractionSourceState(snapshot.controller).copyFrom(
+          snapshot
+        ),
+      },
+      primaryAction:
+        resolution.action === ManipulationAction.Scale
+          ? undefined
+          : resolution.action,
+    };
+    const edge = getCardEdge(session.owner);
+    if (edge && resolution.handle) {
+      session.cardEdge = {
+        primaryCorner: edge.scale ? getCardCorner(capture.uv) : undefined,
+      };
+    }
+    const baseline = session.primaryAction
+      ? this.captureBaseline(session, session.primaryAction)
+      : undefined;
+    if (session.primaryAction && !baseline) return false;
+
+    this.sessions.set(session.owner, session);
+    suspendTransformScripts(session.owner);
+    this.roles.set(snapshot.controller, session);
+    try {
+      if (
+        session.primaryAction &&
+        baseline &&
+        !this.beginPhase(session, session.primaryAction, baseline)
+      ) {
+        this.removeSession(session, false);
+        return false;
+      }
+      return true;
+    } catch (error) {
+      this.removeSession(session, false);
+      throw error;
+    }
+  }
+
+  /** Claims a free spatial Select for Scale before normal target resolution. */
+  tryClaimScale(
+    snapshot: InteractionSourceState,
+    resolved?: ResolvedRay
+  ): boolean {
+    if (snapshot.sourceType === 'gaze' || this.roles.has(snapshot.controller)) {
+      return false;
+    }
+    let eligible: Session | undefined;
+    for (const session of this.sessions.values()) {
+      if (!session.config.scale || session.auxiliary) continue;
+      const edge = getCardEdge(session.owner);
+      let matches = true;
+      if (edge?.scale) {
+        const primaryCorner = session.cardEdge?.primaryCorner;
+        const corner =
+          resolved?.manipulation?.owner === session.owner &&
+          resolved.manipulation.handle
+            ? getCardCorner(resolved.intersection.uv)
+            : undefined;
+        matches =
+          primaryCorner !== undefined &&
+          corner !== undefined &&
+          oppositeCorner(primaryCorner) === corner;
+      }
+      if (!matches) continue;
+      if (eligible) return false;
+      eligible = session;
+    }
+    if (!eligible) return false;
+
+    const session = eligible;
+    const auxiliary = new InteractionSourceState(snapshot.controller).copyFrom(
+      snapshot
+    );
+    const baseline = this.captureBaseline(
+      session,
+      ManipulationAction.Scale,
+      auxiliary
+    );
+    if (baseline?.action !== ManipulationAction.Scale) return false;
+
+    try {
+      if (session.phase) this.finishPhase(session, 'end');
+      session.auxiliary = auxiliary;
+      this.roles.set(snapshot.controller, session);
+      if (!this.beginPhase(session, ManipulationAction.Scale, baseline)) {
+        this.removeSession(session, true);
+        return false;
+      }
+      return true;
+    } catch (error) {
+      this.removeSession(session, true);
+      throw error;
+    }
+  }
+
+  /** Runs a one-shot Scale phase for simulator and equivalent private intents. */
+  applyScaleIntent(
+    capture: SelectionCapture,
+    snapshot: InteractionSourceState,
+    requestedFactor: number
+  ): boolean {
+    if (
+      snapshot.sourceType === 'gaze' ||
+      capture.source !== snapshot.controller ||
+      this.roles.has(snapshot.controller) ||
+      !isPositiveFinite(requestedFactor)
+    ) {
+      return false;
+    }
+    const resolution = capture.manipulation;
+    if (!resolution || this.sessions.has(resolution.owner)) return false;
+    const config = normalizeManipulationConfig(
+      resolution.owner.xb?.manipulation
+    );
+    if (!config?.scale || !isPositiveVector(resolution.owner.scale)) {
+      return false;
+    }
+    const factor = clampScaleFactor(
+      requestedFactor,
+      resolution.owner.scale,
+      config.scale
+    );
+    if (!isPositiveFinite(factor)) return false;
+
+    const scale = resolution.owner.scale.clone().multiplyScalar(factor);
+    if (!isPositiveVector(scale)) return false;
+    const session: Session = {
+      owner: resolution.owner,
+      ownerParent: resolution.owner.parent,
+      config,
+      primary: {
+        capture,
+        snapshot: new InteractionSourceState(snapshot.controller).copyFrom(
+          snapshot
+        ),
+      },
+      primaryAction: resolution.action,
+      phase: {
+        action: ManipulationAction.Scale,
+        baseline: {
+          action: ManipulationAction.Scale,
+          scale: resolution.owner.scale.clone(),
+          distance: 1,
+          options: {...config.scale},
+        },
+        defaultPrevented: false,
+      },
+    };
+    const proposal: Proposal = {
+      action: ManipulationAction.Scale,
+      factor,
+      center: resolution.owner.getWorldPosition(new THREE.Vector3()),
+      scale,
+      apply: () => resolution.owner.scale.copy(scale),
+    };
+    const phase = session.phase!;
+    this.dispatchPhase(session, phase, 'start', proposal);
+    if (!phase.defaultPrevented) proposal.apply();
+    this.dispatchPhase(session, phase, 'update', proposal);
+    session.phase = undefined;
+    this.dispatchPhase(session, phase, 'end', proposal);
+    return true;
+  }
+
+  /** Updates active sessions from Interaction's current frame snapshots. */
+  update(snapshots: Iterable<InteractionSourceState>): void {
+    for (const snapshot of snapshots) {
+      const session = this.roles.get(snapshot.controller);
+      if (!session) continue;
+      if (session.primary.snapshot.controller === snapshot.controller) {
+        session.primary.snapshot.copyFrom(snapshot);
+      } else if (session.auxiliary?.controller === snapshot.controller) {
+        session.auxiliary.copyFrom(snapshot);
+      }
+    }
+
+    for (const session of this.sessions.values()) {
+      if (!this.validate(session)) continue;
+      this.updateSession(session);
+    }
+  }
+
+  /** Ends the role held by a source. Returns true when the source was claimed. */
+  end(source: Controller, finalSnapshot?: InteractionSourceState): boolean {
+    const session = this.roles.get(source);
+    if (!session) return false;
+    if (finalSnapshot) {
+      if (session.primary.snapshot.controller === source) {
+        session.primary.snapshot.copyFrom(finalSnapshot);
+      } else if (session.auxiliary?.controller === source) {
+        session.auxiliary.copyFrom(finalSnapshot);
+      }
+      this.updateSession(session);
+    }
+
+    if (session.primary.snapshot.controller === source) {
+      this.finishSession(session, 'end', true);
+      return true;
+    }
+
+    if (session.auxiliary?.controller === source) {
+      this.finishAuxiliary(session, source, 'end');
+      return true;
+    }
+    return false;
+  }
+
+  cancelSource(source: Controller): boolean {
+    const session = this.roles.get(source);
+    if (!session) return false;
+    if (session.primary.snapshot.controller === source) {
+      this.finishSession(session, 'cancel', true);
+      return true;
+    }
+    if (session.auxiliary?.controller === source) {
+      this.finishAuxiliary(session, source, 'cancel');
+      return true;
+    }
+    return false;
+  }
+
+  cancelOwner(owner: THREE.Object3D): boolean {
+    const session = this.sessions.get(owner);
+    if (!session) return false;
+    this.finishSession(session, 'cancel', true);
+    return true;
+  }
+
+  isManipulating(object?: THREE.Object3D): boolean {
+    return object ? this.sessions.has(object) : this.sessions.size > 0;
+  }
+
+  isSourceActive(source: Controller): boolean {
+    return this.roles.has(source);
+  }
+
+  private validate(session: Session): boolean {
+    const current = normalizeManipulationConfig(session.owner.xb?.manipulation);
+    const edge = getCardEdge(session.owner);
+    if (
+      !current ||
+      !session.owner.visible ||
+      session.owner.parent !== session.ownerParent ||
+      !objectIsDescendantOf(session.primary.capture.surface, session.owner) ||
+      (session.cardEdge && !edge) ||
+      (session.cardEdge?.primaryCorner &&
+        (!edge?.scale || !current.scale || !current.translate))
+    ) {
+      this.cancelOwner(session.owner);
+      return false;
+    }
+
+    if (session.phase?.action === ManipulationAction.Scale && !current.scale) {
+      const auxiliary = session.auxiliary;
+      session.config = current;
+      if (auxiliary) {
+        this.finishAuxiliary(session, auxiliary.controller, 'cancel');
+      } else {
+        this.finishPhase(session, 'cancel');
+      }
+      return false;
+    }
+    if (
+      session.primaryAction &&
+      !isManipulationActionEnabled(current, session.primaryAction)
+    ) {
+      this.cancelOwner(session.owner);
+      return false;
+    }
+    session.config = current;
+    return true;
+  }
+
+  private removeSession(session: Session, suppressAuxiliary: boolean): void {
+    session.phase = undefined;
+    if (this.sessions.get(session.owner) === session) {
+      this.sessions.delete(session.owner);
+      resumeTransformScripts(session.owner);
+    }
+    if (this.roles.get(session.primary.snapshot.controller) === session) {
+      this.roles.delete(session.primary.snapshot.controller);
+    }
+    if (session.auxiliary) {
+      if (this.roles.get(session.auxiliary.controller) === session) {
+        this.roles.delete(session.auxiliary.controller);
+      }
+      if (suppressAuxiliary && session.auxiliary.selected) {
+        this.suppressSource(session.auxiliary.controller);
+      }
+    }
+  }
+
+  private startPhase(
+    session: Session,
+    action: ResolvedManipulationAction
+  ): boolean {
+    const baseline = this.captureBaseline(session, action);
+    return baseline ? this.beginPhase(session, action, baseline) : false;
+  }
+
+  private beginPhase(
+    session: Session,
+    action: ResolvedManipulationAction,
+    baseline: PhaseBaseline
+  ): boolean {
+    session.phase = {action, baseline, defaultPrevented: false};
+    const phase = session.phase;
+    const proposal = this.propose(session);
+    if (!proposal) {
+      session.phase = undefined;
+      return false;
+    }
+    phase.lastProposal = proposal;
+    try {
+      this.dispatchPhase(session, phase, 'start', proposal);
+    } catch (error) {
+      if (session.phase === phase) session.phase = undefined;
+      throw error;
+    }
+    return true;
+  }
+
+  private finishPhase(session: Session, phase: 'end' | 'cancel'): void {
+    const active = session.phase;
+    if (!active) return;
+    const proposal = this.propose(session) ?? active.lastProposal;
+    session.phase = undefined;
+    this.dispatchPhase(session, active, phase, proposal);
+  }
+
+  private updateSession(session: Session): void {
+    if (!session.phase) return;
+    const proposal = this.propose(session);
+    if (!proposal) return;
+    session.phase.lastProposal = proposal;
+    if (!session.phase.defaultPrevented) proposal.apply();
+    try {
+      this.dispatchPhase(session, session.phase, 'update', proposal);
+    } catch (error) {
+      this.removeSession(session, true);
+      throw error;
+    }
+  }
+
+  private finishSession(
+    session: Session,
+    phase: 'end' | 'cancel',
+    suppressAuxiliary: boolean
+  ): void {
+    const active = session.phase;
+    const proposal = active
+      ? (this.propose(session) ?? active.lastProposal)
+      : undefined;
+    this.removeSession(session, suppressAuxiliary);
+    if (active) this.dispatchPhase(session, active, phase, proposal);
+  }
+
+  private finishAuxiliary(
+    session: Session,
+    source: Controller,
+    phase: 'end' | 'cancel'
+  ): void {
+    let phaseFinished = false;
+    try {
+      this.finishPhase(session, phase);
+      phaseFinished = true;
+    } finally {
+      this.releaseAuxiliaryRole(session, source);
+      if (!phaseFinished) this.removeSession(session, true);
+    }
+    if (!session.primaryAction) return;
+    try {
+      if (this.startPhase(session, session.primaryAction)) return;
+    } catch (error) {
+      this.removeSession(session, true);
+      throw error;
+    }
+    this.removeSession(session, true);
+  }
+
+  private releaseAuxiliaryRole(session: Session, source: Controller): void {
+    if (this.roles.get(source) === session) this.roles.delete(source);
+    if (session.auxiliary?.controller === source) session.auxiliary = undefined;
+  }
+
+  private captureBaseline(
+    session: Session,
+    action: ResolvedManipulationAction,
+    auxiliary = session.auxiliary
+  ): PhaseBaseline | undefined {
+    session.owner.updateWorldMatrix(true, false);
+    if (action === ManipulationAction.Translate) {
+      return this.translateDriver.capture(session);
+    }
+    if (action === ManipulationAction.Rotate) {
+      return this.rotateDriver.capture(session);
+    }
+    return this.scaleDriver.capture(session, auxiliary);
+  }
+
+  private propose(session: Session): Proposal | undefined {
+    const baseline = session.phase?.baseline;
+    if (!baseline) return undefined;
+    if (baseline.action === ManipulationAction.Translate) {
+      return this.translateDriver.propose(session, baseline);
+    }
+    if (baseline.action === ManipulationAction.Rotate) {
+      return this.rotateDriver.propose(session, baseline);
+    }
+    return this.scaleDriver.propose(session, baseline);
+  }
+
+  private dispatchPhase(
+    session: Session,
+    active: ActivePhase,
+    phase: ManipulationPhase,
+    proposal: Proposal | undefined
+  ): void {
+    if (!proposal) return;
+    const preventState = {value: active.defaultPrevented};
+    for (const script of session.primary.capture.scriptPath) {
+      const event = createEvent(session, script, phase, proposal, preventState);
+      if (this.dispatch(script, event) === true) break;
+    }
+    if (phase === 'start') active.defaultPrevented = preventState.value;
+  }
+}
+
+function getCardEdge(
+  owner: THREE.Object3D
+):
+  | {readonly scale?: boolean; readonly translateFromSurface?: boolean}
+  | undefined {
+  return owner.xb?.manipulationSurface;
+}
+
+function oppositeCorner(corner: CardCorner): CardCorner {
+  if (corner === 'top-left') return 'bottom-right';
+  if (corner === 'top-right') return 'bottom-left';
+  if (corner === 'bottom-left') return 'top-right';
+  return 'top-left';
+}
+
+function getCardCorner(uv: THREE.Vector2 | undefined): CardCorner | undefined {
+  if (!uv) return undefined;
+  const horizontal = uv.x <= 0.2 ? 'left' : uv.x >= 0.8 ? 'right' : undefined;
+  const vertical = uv.y <= 0.2 ? 'bottom' : uv.y >= 0.8 ? 'top' : undefined;
+  return horizontal && vertical ? `${vertical}-${horizontal}` : undefined;
+}
+
+function createEvent(
+  session: Session,
+  currentTarget: THREE.Object3D,
+  phase: ManipulationPhase,
+  proposal: Proposal,
+  preventState: {value: boolean}
+): ManipulationEvent {
+  const common = {
+    phase,
+    action: proposal.action,
+    source: session.primary.snapshot.source,
+    sources: Object.freeze(
+      [session.primary.snapshot.source, session.auxiliary?.source].filter(
+        Boolean
+      ) as InteractionSource[]
+    ),
+    target: session.primary.capture.target,
+    surface: session.primary.capture.surface,
+    owner: session.owner,
+    currentTarget,
+    defaultPrevented: preventState.value,
+    preventDefault() {
+      if (phase === 'start') preventState.value = true;
+    },
+  };
+
+  if (proposal.action === ManipulationAction.Translate) {
+    return withDefaultPrevented(
+      {
+        ...common,
+        action: proposal.action,
+        point: proposal.point.clone(),
+        delta: proposal.delta.clone(),
+        position: proposal.position.clone(),
+        worldPosition: proposal.worldPosition.clone(),
+      },
+      preventState
+    );
+  }
+  if (proposal.action === ManipulationAction.Rotate) {
+    return withDefaultPrevented(
+      {
+        ...common,
+        action: proposal.action,
+        angle: proposal.angle,
+        quaternion: proposal.quaternion.clone(),
+      },
+      preventState
+    );
+  }
+  return withDefaultPrevented(
+    {
+      ...common,
+      action: proposal.action,
+      factor: proposal.factor,
+      center: proposal.center.clone(),
+      scale: proposal.scale.clone(),
+    },
+    preventState
+  );
+}
+
+function withDefaultPrevented<T extends ManipulationEvent>(
+  event: T,
+  state: {value: boolean}
+): T {
+  Object.defineProperty(event, 'defaultPrevented', {
+    enumerable: true,
+    get: () => state.value,
+  });
+  return event;
+}

--- a/src/interaction/manipulation/ManipulationMath.ts
+++ b/src/interaction/manipulation/ManipulationMath.ts
@@ -1,0 +1,89 @@
+import * as THREE from 'three';
+
+import type {ScaleOptions} from './ManipulationTypes';
+
+export {faceCameraQuaternion} from '../../utils/FaceCameraMath';
+
+const EPSILON = 1e-8;
+
+export function worldPositionToLocal(
+  worldPosition: THREE.Vector3,
+  parentWorldMatrix?: THREE.Matrix4
+): THREE.Vector3 {
+  if (!parentWorldMatrix) return worldPosition.clone();
+  return worldPosition.clone().applyMatrix4(parentWorldMatrix.clone().invert());
+}
+
+export function worldQuaternionToLocal(
+  worldQuaternion: THREE.Quaternion,
+  parentWorldQuaternion?: THREE.Quaternion
+): THREE.Quaternion {
+  if (!parentWorldQuaternion) return worldQuaternion.clone();
+  return parentWorldQuaternion.clone().invert().multiply(worldQuaternion);
+}
+
+export function clampScaleFactor(
+  factor: number,
+  baseline: THREE.Vector3,
+  options: ScaleOptions
+): number {
+  const minimum = scaleLimitVector(options.minScale, EPSILON, false);
+  const maximum = scaleLimitVector(options.maxScale, Infinity, true);
+  if (!minimum || !maximum) return NaN;
+  const minimumFactor = Math.max(
+    minimum.x / baseline.x,
+    minimum.y / baseline.y,
+    minimum.z / baseline.z
+  );
+  const maximumFactor = Math.min(
+    maximum.x / baseline.x,
+    maximum.y / baseline.y,
+    maximum.z / baseline.z
+  );
+  if (minimumFactor > maximumFactor) return NaN;
+  return THREE.MathUtils.clamp(factor, minimumFactor, maximumFactor);
+}
+
+export function isPositiveFinite(value: number): boolean {
+  return Number.isFinite(value) && value > EPSILON;
+}
+
+export function isFiniteVector(value: THREE.Vector3): boolean {
+  return (
+    Number.isFinite(value.x) &&
+    Number.isFinite(value.y) &&
+    Number.isFinite(value.z)
+  );
+}
+
+export function isPositiveVector(value: THREE.Vector3): boolean {
+  return isFiniteVector(value) && value.x > 0 && value.y > 0 && value.z > 0;
+}
+
+export function isFiniteQuaternion(value: THREE.Quaternion): boolean {
+  return (
+    Number.isFinite(value.x) &&
+    Number.isFinite(value.y) &&
+    Number.isFinite(value.z) &&
+    Number.isFinite(value.w)
+  );
+}
+
+function scaleLimitVector(
+  value: number | THREE.Vector3Like | undefined,
+  fallback: number,
+  allowInfinity: boolean
+): THREE.Vector3 | undefined {
+  if (value === undefined)
+    return new THREE.Vector3(fallback, fallback, fallback);
+  const result =
+    typeof value === 'number'
+      ? new THREE.Vector3(value, value, value)
+      : new THREE.Vector3(value.x, value.y, value.z);
+  const valid = [result.x, result.y, result.z].every(
+    (component) =>
+      component > 0 &&
+      (Number.isFinite(component) || (allowInfinity && component === Infinity))
+  );
+  return valid ? result : undefined;
+}

--- a/src/interaction/manipulation/ManipulationTypes.ts
+++ b/src/interaction/manipulation/ManipulationTypes.ts
@@ -1,0 +1,93 @@
+import type * as THREE from 'three';
+
+import type {InteractionSource} from '../InteractionTypes';
+import type {FaceCameraMode} from '../../utils/FaceCameraMath';
+
+export type {FaceCameraMode} from '../../utils/FaceCameraMath';
+
+export const ManipulationAction = {
+  Translate: 'translate',
+  Rotate: 'rotate',
+  Scale: 'scale',
+  None: 'none',
+} as const;
+
+export type ManipulationAction =
+  (typeof ManipulationAction)[keyof typeof ManipulationAction];
+
+export interface TranslateOptions {
+  faceCamera?: boolean;
+  /** Camera-facing rotation mode used while translating. */
+  mode?: FaceCameraMode;
+  /** Camera-facing rotation smoothing, matching `FaceCamera`. */
+  smoothing?: number;
+}
+
+export interface RotateOptions {
+  axis?: 'x' | 'y' | 'z' | THREE.Vector3Like;
+  space?: 'local' | 'world';
+  sensitivity?: number;
+}
+
+export interface ScaleOptions {
+  minScale?: number | THREE.Vector3Like;
+  maxScale?: number | THREE.Vector3Like;
+}
+
+export interface ManipulationHandleOptions {
+  action?:
+    | typeof ManipulationAction.Translate
+    | typeof ManipulationAction.Rotate
+    | typeof ManipulationAction.Scale
+    | typeof ManipulationAction.None;
+}
+
+export interface ManipulationOptions {
+  actions?: {
+    translate?: boolean | TranslateOptions;
+    rotate?: boolean | RotateOptions;
+    scale?: boolean | ScaleOptions;
+  };
+  handle?: ManipulationHandleOptions;
+}
+
+export type ManipulationPhase = 'start' | 'update' | 'end' | 'cancel';
+
+export interface BaseManipulationEvent {
+  readonly phase: ManipulationPhase;
+  readonly action: ManipulationAction;
+  readonly source: InteractionSource;
+  readonly sources: readonly InteractionSource[];
+  readonly target: THREE.Object3D;
+  readonly surface: THREE.Object3D;
+  readonly owner: THREE.Object3D;
+  readonly currentTarget: THREE.Object3D;
+  readonly defaultPrevented: boolean;
+  preventDefault(): void;
+}
+
+export interface TranslateManipulationEvent extends BaseManipulationEvent {
+  readonly action: typeof ManipulationAction.Translate;
+  readonly point: THREE.Vector3;
+  readonly delta: THREE.Vector3;
+  readonly position: THREE.Vector3;
+  readonly worldPosition: THREE.Vector3;
+}
+
+export interface RotateManipulationEvent extends BaseManipulationEvent {
+  readonly action: typeof ManipulationAction.Rotate;
+  readonly angle: number;
+  readonly quaternion: THREE.Quaternion;
+}
+
+export interface ScaleManipulationEvent extends BaseManipulationEvent {
+  readonly action: typeof ManipulationAction.Scale;
+  readonly factor: number;
+  readonly center: THREE.Vector3;
+  readonly scale: THREE.Vector3;
+}
+
+export type ManipulationEvent =
+  | TranslateManipulationEvent
+  | RotateManipulationEvent
+  | ScaleManipulationEvent;

--- a/src/interaction/manipulation/drivers/DriverTypes.ts
+++ b/src/interaction/manipulation/drivers/DriverTypes.ts
@@ -1,0 +1,92 @@
+import type * as THREE from 'three';
+
+import type {
+  InteractionSourceState,
+  ResolvedManipulationAction,
+  SelectionCapture,
+} from '../../InteractionTypes';
+import type {NormalizedManipulationConfig} from '../ManipulationConfig';
+import {
+  ManipulationAction,
+  type RotateOptions,
+  type ScaleOptions,
+  type TranslateOptions,
+} from '../ManipulationTypes';
+
+export interface ManipulationDriverSession {
+  readonly owner: THREE.Object3D;
+  readonly config: NormalizedManipulationConfig;
+  readonly primary: {
+    readonly capture: SelectionCapture;
+    snapshot: InteractionSourceState;
+  };
+  auxiliary?: InteractionSourceState;
+}
+
+export interface TranslateBaseline {
+  readonly action: typeof ManipulationAction.Translate;
+  readonly worldPosition: THREE.Vector3;
+  readonly sourcePosition: THREE.Vector3;
+  rayDepth?: number;
+  rayPoint?: THREE.Vector3;
+  readonly options: TranslateOptions;
+}
+
+export interface RotateBaseline {
+  readonly action: typeof ManipulationAction.Rotate;
+  readonly localQuaternion: THREE.Quaternion;
+  readonly worldQuaternion: THREE.Quaternion;
+  readonly sourcePosition: THREE.Vector3;
+  readonly sourceOrientationInverse: THREE.Quaternion;
+  readonly axis: THREE.Vector3;
+  readonly options: Required<Pick<RotateOptions, 'space' | 'sensitivity'>>;
+}
+
+export interface ScaleBaseline {
+  readonly action: typeof ManipulationAction.Scale;
+  readonly scale: THREE.Vector3;
+  readonly distance: number;
+  readonly options: ScaleOptions;
+}
+
+export type PhaseBaseline = TranslateBaseline | RotateBaseline | ScaleBaseline;
+
+interface ProposalBase {
+  apply(): void;
+}
+
+export type Proposal = ProposalBase &
+  (
+    | {
+        action: typeof ManipulationAction.Translate;
+        point: THREE.Vector3;
+        delta: THREE.Vector3;
+        position: THREE.Vector3;
+        worldPosition: THREE.Vector3;
+      }
+    | {
+        action: typeof ManipulationAction.Rotate;
+        angle: number;
+        quaternion: THREE.Quaternion;
+      }
+    | {
+        action: typeof ManipulationAction.Scale;
+        factor: number;
+        center: THREE.Vector3;
+        scale: THREE.Vector3;
+      }
+  );
+
+export interface ManipulationDriver<
+  Baseline extends PhaseBaseline = PhaseBaseline,
+> {
+  readonly action: ResolvedManipulationAction;
+  capture(
+    session: ManipulationDriverSession,
+    auxiliary?: InteractionSourceState
+  ): Baseline | undefined;
+  propose(
+    session: ManipulationDriverSession,
+    baseline: Baseline
+  ): Proposal | undefined;
+}

--- a/src/interaction/manipulation/drivers/RotateDriver.ts
+++ b/src/interaction/manipulation/drivers/RotateDriver.ts
@@ -1,0 +1,85 @@
+import * as THREE from 'three';
+
+import {normalizeRotationAxis} from '../ManipulationConfig';
+import {isFiniteQuaternion, worldQuaternionToLocal} from '../ManipulationMath';
+import {ManipulationAction} from '../ManipulationTypes';
+import type {
+  ManipulationDriver,
+  ManipulationDriverSession,
+  Proposal,
+  RotateBaseline,
+} from './DriverTypes';
+
+/** Captures and proposes Rotate data. It does not own sessions or events. */
+export class RotateDriver implements ManipulationDriver<RotateBaseline> {
+  readonly action = ManipulationAction.Rotate;
+
+  capture(session: ManipulationDriverSession): RotateBaseline | undefined {
+    const raw = session.config.rotate ?? {};
+    const axis = normalizeRotationAxis(raw.axis);
+    const sensitivity = raw.sensitivity ?? 10;
+    if (!axis || !Number.isFinite(sensitivity)) return undefined;
+    return {
+      action: this.action,
+      localQuaternion: session.owner.quaternion.clone(),
+      worldQuaternion: session.owner.getWorldQuaternion(new THREE.Quaternion()),
+      sourcePosition: session.primary.snapshot.position.clone(),
+      sourceOrientationInverse: session.primary.snapshot.orientation
+        .clone()
+        .invert(),
+      axis,
+      options: {space: raw.space ?? 'world', sensitivity},
+    };
+  }
+
+  propose(
+    session: ManipulationDriverSession,
+    baseline: RotateBaseline
+  ): Proposal | undefined {
+    const snapshot = session.primary.snapshot;
+    let angle: number;
+    if (snapshot.sourceType === 'mouse') {
+      const deltaRotation = snapshot.orientation
+        .clone()
+        .multiply(baseline.sourceOrientationInverse);
+      angle =
+        -new THREE.Euler().setFromQuaternion(deltaRotation, 'YXZ').y *
+        baseline.options.sensitivity;
+    } else {
+      const localDelta = snapshot.position
+        .clone()
+        .sub(baseline.sourcePosition)
+        .applyQuaternion(baseline.sourceOrientationInverse);
+      angle = localDelta.x * baseline.options.sensitivity;
+    }
+    const offset = new THREE.Quaternion().setFromAxisAngle(
+      baseline.axis,
+      angle
+    );
+    let quaternion: THREE.Quaternion;
+    if (baseline.options.space === 'local') {
+      quaternion = baseline.localQuaternion.clone().multiply(offset);
+    } else {
+      const world = offset.multiply(baseline.worldQuaternion);
+      const parent = session.owner.parent;
+      parent?.updateWorldMatrix(true, false);
+      quaternion = worldQuaternionToLocal(
+        world,
+        parent?.getWorldQuaternion(new THREE.Quaternion())
+      );
+    }
+    if (!Number.isFinite(angle) || !isFiniteQuaternion(quaternion)) {
+      return undefined;
+    }
+    return {
+      action: this.action,
+      angle,
+      quaternion,
+      apply: () => {
+        if (Number.isFinite(angle) && isFiniteQuaternion(quaternion)) {
+          session.owner.quaternion.copy(quaternion).normalize();
+        }
+      },
+    };
+  }
+}

--- a/src/interaction/manipulation/drivers/ScaleDriver.ts
+++ b/src/interaction/manipulation/drivers/ScaleDriver.ts
@@ -1,0 +1,69 @@
+import type {InteractionSourceState} from '../../InteractionTypes';
+import {cloneScaleOptions} from '../ManipulationConfig';
+import {
+  clampScaleFactor,
+  isPositiveFinite,
+  isPositiveVector,
+} from '../ManipulationMath';
+import {ManipulationAction} from '../ManipulationTypes';
+import type {
+  ManipulationDriver,
+  ManipulationDriverSession,
+  Proposal,
+  ScaleBaseline,
+} from './DriverTypes';
+
+/** Captures and proposes Scale data. It does not own sessions or events. */
+export class ScaleDriver implements ManipulationDriver<ScaleBaseline> {
+  readonly action = ManipulationAction.Scale;
+
+  capture(
+    session: ManipulationDriverSession,
+    auxiliary?: InteractionSourceState
+  ): ScaleBaseline | undefined {
+    if (!auxiliary) return undefined;
+    const distance = session.primary.snapshot.position.distanceTo(
+      auxiliary.position
+    );
+    if (!isPositiveFinite(distance) || !isPositiveVector(session.owner.scale)) {
+      return undefined;
+    }
+    const options = cloneScaleOptions(session.config.scale);
+    if (!isPositiveFinite(clampScaleFactor(1, session.owner.scale, options))) {
+      return undefined;
+    }
+    return {
+      action: this.action,
+      scale: session.owner.scale.clone(),
+      distance,
+      options,
+    };
+  }
+
+  propose(
+    session: ManipulationDriverSession,
+    baseline: ScaleBaseline
+  ): Proposal | undefined {
+    if (!session.auxiliary) return undefined;
+    const currentDistance = session.primary.snapshot.position.distanceTo(
+      session.auxiliary.position
+    );
+    let factor = currentDistance / baseline.distance;
+    if (!isPositiveFinite(factor)) return undefined;
+    factor = clampScaleFactor(factor, baseline.scale, baseline.options);
+    if (!isPositiveFinite(factor)) return undefined;
+    const scale = baseline.scale.clone().multiplyScalar(factor);
+    if (!isPositiveVector(scale)) return undefined;
+    const center = session.primary.snapshot.position
+      .clone()
+      .add(session.auxiliary.position)
+      .multiplyScalar(0.5);
+    return {
+      action: this.action,
+      factor,
+      center,
+      scale,
+      apply: () => session.owner.scale.copy(scale),
+    };
+  }
+}

--- a/src/interaction/manipulation/drivers/TranslateDriver.ts
+++ b/src/interaction/manipulation/drivers/TranslateDriver.ts
@@ -1,0 +1,117 @@
+import * as THREE from 'three';
+
+import {
+  DEFAULT_FACE_CAMERA_SMOOTHING,
+  faceCameraSlerpAlpha,
+} from '../../../utils/FaceCameraMath';
+import {
+  faceCameraQuaternion,
+  isFiniteVector,
+  worldPositionToLocal,
+} from '../ManipulationMath';
+import {ManipulationAction} from '../ManipulationTypes';
+import type {
+  ManipulationDriver,
+  ManipulationDriverSession,
+  Proposal,
+  TranslateBaseline,
+} from './DriverTypes';
+
+/** Captures and proposes Translate data. It does not own sessions or events. */
+export class TranslateDriver implements ManipulationDriver<TranslateBaseline> {
+  readonly action = ManipulationAction.Translate;
+
+  constructor(
+    private readonly camera?: THREE.Camera,
+    private readonly timer?: THREE.Timer
+  ) {}
+
+  capture(session: ManipulationDriverSession): TranslateBaseline | undefined {
+    const snapshot = session.primary.snapshot;
+    const options = session.config.translate ?? {};
+    if (
+      options.faceCamera &&
+      ((options.mode !== undefined &&
+        options.mode !== 'cylindrical' &&
+        options.mode !== 'spherical') ||
+        (options.smoothing !== undefined &&
+          (!Number.isFinite(options.smoothing) || options.smoothing < 0)))
+    ) {
+      return undefined;
+    }
+    const baseline: TranslateBaseline = {
+      action: this.action,
+      worldPosition: session.owner.getWorldPosition(new THREE.Vector3()),
+      sourcePosition: snapshot.position.clone(),
+      options: {...options},
+    };
+    if (snapshot.ray) {
+      baseline.rayDepth = snapshot.ray.direction.dot(
+        session.primary.capture.point.clone().sub(snapshot.ray.origin)
+      );
+      baseline.rayPoint = snapshot.ray
+        .at(baseline.rayDepth, new THREE.Vector3())
+        .clone();
+    }
+    return baseline;
+  }
+
+  propose(
+    session: ManipulationDriverSession,
+    baseline: TranslateBaseline
+  ): Proposal | undefined {
+    const snapshot = session.primary.snapshot;
+    let delta: THREE.Vector3;
+    let point: THREE.Vector3;
+    if (snapshot.ray && baseline.rayDepth !== undefined && baseline.rayPoint) {
+      point = snapshot.ray.at(baseline.rayDepth, new THREE.Vector3());
+      delta = point.clone().sub(baseline.rayPoint);
+    } else {
+      delta = snapshot.position.clone().sub(baseline.sourcePosition);
+      point = session.primary.capture.point.clone().add(delta);
+    }
+    const worldPosition = baseline.worldPosition.clone().add(delta);
+    const parent = session.owner.parent;
+    parent?.updateWorldMatrix(true, false);
+    const localPosition = worldPositionToLocal(
+      worldPosition,
+      parent?.matrixWorld
+    );
+    const localQuaternion = baseline.options.faceCamera
+      ? faceCameraQuaternion(
+          worldPosition,
+          this.camera?.getWorldPosition(new THREE.Vector3()),
+          parent?.getWorldQuaternion(new THREE.Quaternion()),
+          baseline.options.mode
+        )
+      : undefined;
+    const rotationAlpha = this.timer
+      ? faceCameraSlerpAlpha(
+          baseline.options.smoothing ?? DEFAULT_FACE_CAMERA_SMOOTHING,
+          this.timer.getDelta()
+        )
+      : 1;
+    if (
+      !isFiniteVector(point) ||
+      !isFiniteVector(delta) ||
+      !isFiniteVector(worldPosition) ||
+      !isFiniteVector(localPosition)
+    ) {
+      return undefined;
+    }
+    return {
+      action: this.action,
+      point,
+      delta,
+      position: localPosition,
+      worldPosition,
+      apply: () => {
+        if (!isFiniteVector(localPosition)) return;
+        session.owner.position.copy(localPosition);
+        if (localQuaternion) {
+          session.owner.quaternion.slerp(localQuaternion, rotationAlpha);
+        }
+      },
+    };
+  }
+}

--- a/src/interaction/reticle/Reticle.ts
+++ b/src/interaction/reticle/Reticle.ts
@@ -25,9 +25,6 @@ export class Reticle extends THREE.Mesh<
   /** Ensures the reticle is drawn on top of other transparent objects. */
   renderOrder = 1000;
 
-  /** The smoothing factor for rotational slerp interpolation. */
-  rotationSmoothing: number;
-
   /** The z-offset to prevent visual artifacts (z-fighting). */
   offset: number;
 
@@ -59,7 +56,7 @@ export class Reticle extends THREE.Mesh<
    * objects. Defaults to `false` to ensure it is always visible.
    */
   constructor(
-    rotationSmoothing = 0.8,
+    public rotationSmoothing = 0.8,
     offset = 0.001,
     size = 0.019,
     depthTest = false

--- a/src/interaction/reticle/Reticle.ts
+++ b/src/interaction/reticle/Reticle.ts
@@ -1,0 +1,201 @@
+import * as THREE from 'three';
+
+import {lerp} from '../../utils/utils';
+import {ReticleShader} from './ReticleShader';
+
+const HOVER_RING_BRIGHTNESS = 0.4;
+const HOVER_RING_OPACITY = 0.7;
+
+/**
+ * A 3D visual marker used to indicate a user's aim or interaction
+ * point in an XR scene. It orients itself to surfaces it intersects with and
+ * provides visual feedback for states like "pressed".
+ */
+export class Reticle extends THREE.Mesh<
+  THREE.BufferGeometry,
+  THREE.ShaderMaterial
+> {
+  /** Text description of the PanelMesh */
+  name = 'Reticle';
+  editorIcon = 'target';
+
+  /** The world-space direction vector of the ray that hit the target. */
+  direction = new THREE.Vector3();
+
+  /** Ensures the reticle is drawn on top of other transparent objects. */
+  renderOrder = 1000;
+
+  /** The smoothing factor for rotational slerp interpolation. */
+  rotationSmoothing: number;
+
+  /** The z-offset to prevent visual artifacts (z-fighting). */
+  offset: number;
+
+  /** The most recent intersection data that positioned this reticle. */
+  intersection?: THREE.Intersection;
+
+  /** Object on which the reticle is hovering. */
+  targetObject?: THREE.Object3D;
+
+  /** Ring shown when the reticle is over an interactable object. */
+  private readonly hoverRing: THREE.Mesh<
+    THREE.RingGeometry,
+    THREE.MeshBasicMaterial
+  >;
+
+  // --- Private properties for performance optimization ---
+  private readonly originalNormal = new THREE.Vector3(0, 0, 1);
+  private readonly newRotation = new THREE.Quaternion();
+  private readonly objectRotation = new THREE.Quaternion();
+  private readonly normalVector = new THREE.Vector3();
+
+  /**
+   * Creates an instance of Reticle.
+   * @param rotationSmoothing - A factor between 0.0 (no smoothing) and
+   * 1.0 (no movement) to smoothly animate orientation changes.
+   * @param offset - A small z-axis offset to prevent z-fighting.
+   * @param size - The radius of the reticle's circle geometry.
+   * @param depthTest - Determines if the reticle should be occluded by other
+   * objects. Defaults to `false` to ensure it is always visible.
+   */
+  constructor(
+    rotationSmoothing = 0.8,
+    offset = 0.001,
+    size = 0.019,
+    depthTest = false
+  ) {
+    const geometry = new THREE.CircleGeometry(size, 32);
+    geometry.applyMatrix4(new THREE.Matrix4().makeTranslation(0, 0, offset));
+
+    super(
+      geometry,
+      new THREE.ShaderMaterial({
+        uniforms: THREE.UniformsUtils.clone(ReticleShader.uniforms),
+        vertexShader: ReticleShader.vertexShader,
+        fragmentShader: ReticleShader.fragmentShader,
+        depthTest: depthTest,
+        transparent: true,
+      })
+    );
+
+    this.rotationSmoothing = rotationSmoothing;
+    this.offset = offset;
+
+    this.hoverRing = new THREE.Mesh(
+      new THREE.RingGeometry(size, size * 1.15, 32),
+      new THREE.MeshBasicMaterial({
+        color: getHoverRingColor(this.getColor()),
+        depthTest,
+        depthWrite: false,
+        transparent: true,
+        opacity: HOVER_RING_OPACITY,
+      })
+    );
+    this.hoverRing.position.z = offset;
+    this.hoverRing.renderOrder = this.renderOrder;
+    this.hoverRing.visible = false;
+    this.hoverRing.raycast = () => {};
+    this.add(this.hoverRing);
+  }
+
+  /**
+   * Orients the reticle to be flush with a surface, based on the surface
+   * normal. It smoothly interpolates the rotation for a polished visual effect.
+   * @param normal - The world-space normal of the surface.
+   */
+  setRotationFromNormalVector(normal: THREE.Vector3) {
+    this.normalVector.copy(normal).normalize();
+    this.newRotation.setFromUnitVectors(this.originalNormal, this.normalVector);
+
+    // Smoothly interpolate from the current rotation to the new rotation.
+    this.quaternion.slerp(this.newRotation, 1.0 - this.rotationSmoothing);
+  }
+
+  /**
+   * Updates the reticle's complete pose (position and rotation) from a
+   * raycaster intersection object.
+   * @param intersection - The intersection data from a raycast.
+   */
+  setPoseFromIntersection(intersection: THREE.Intersection) {
+    if (!intersection || !intersection.normal) return;
+
+    this.intersection = intersection;
+    this.position.copy(intersection.point);
+
+    // The intersection normal is in the local space of the intersected object.
+    // It must be transformed into world space to correctly orient the reticle.
+    intersection.object.getWorldQuaternion(this.objectRotation);
+    this.normalVector
+      .copy(intersection.normal)
+      .applyQuaternion(this.objectRotation);
+    this.setRotationFromNormalVector(this.normalVector);
+  }
+
+  /**
+   * Sets the color of the reticle via its shader uniform.
+   * @param color - The color to apply.
+   */
+  setColor(color: THREE.Color | number | string) {
+    this.material.uniforms.uColor.value.set(color);
+    this.hoverRing.material.color.copy(
+      getHoverRingColor(this.material.uniforms.uColor.value)
+    );
+  }
+
+  /**
+   * Gets the current color of the reticle.
+   * @returns The current color from the shader uniform.
+   */
+  getColor(): THREE.Color {
+    return this.material.uniforms.uColor.value;
+  }
+
+  /**
+   * Sets the visual state of the reticle to "pressed" or "unpressed".
+   * This provides visual feedback to the user during interaction.
+   * @param pressed - True to show the pressed state, false otherwise.
+   */
+  setPressed(pressed: boolean) {
+    this.material.uniforms.uPressed.value = pressed ? 1.0 : 0.0;
+    this.scale.setScalar(pressed ? 0.7 : 1.0);
+  }
+
+  /**
+   * Sets the pressed state as a continuous value for smooth animations.
+   * @param pressedAmount - A value from 0.0 (unpressed) to 1.0 (fully
+   * pressed).
+   */
+  setPressedAmount(pressedAmount: number) {
+    this.material.uniforms.uPressed.value = pressedAmount;
+    this.scale.setScalar(lerp(1.0, 0.7, pressedAmount));
+  }
+
+  /**
+   * Shows a ring around the reticle while it hovers over an interactable
+   * object.
+   */
+  setHovering(hovering: boolean) {
+    this.hoverRing.visible = hovering;
+  }
+
+  /** Releases the GPU resources owned by this Reticle. */
+  dispose() {
+    this.removeFromParent();
+    this.geometry.dispose();
+    this.material.dispose();
+    this.hoverRing.geometry.dispose();
+    this.hoverRing.material.dispose();
+    this.intersection = undefined;
+    this.targetObject = undefined;
+  }
+
+  /**
+   * Overrides the default raycast method to make the reticle ignored by
+   * raycasters.
+   */
+  raycast() {}
+}
+
+function getHoverRingColor(color: THREE.Color) {
+  return color.clone().multiplyScalar(HOVER_RING_BRIGHTNESS);
+}

--- a/src/interaction/reticle/ReticleShader.ts
+++ b/src/interaction/reticle/ReticleShader.ts
@@ -1,0 +1,93 @@
+import * as THREE from 'three';
+
+/**
+ * Shader for the Reticle UI component.
+ *
+ * This shader renders a dynamic, anti-aliased circle that provides visual
+ * feedback for user interaction. It can smoothly transition between a hollow
+ * ring (idle/hover state) and a solid, shrinking circle (pressed state).
+ * The anti-aliasing is achieved using screen-space derivatives (fwidth) to
+ * ensure crisp edges at any resolution or distance.
+ */
+export const ReticleShader = {
+  name: 'ReticleShader',
+  uniforms: {
+    uColor: {value: new THREE.Color().setHex(0xffffff)},
+    uPressed: {value: 0.0},
+  },
+
+  vertexShader: /* glsl */ `
+  varying vec2 vTexCoord;
+
+  void main() {
+    vTexCoord = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+    // Makes the position slightly closer to avoid z fighting.
+    gl_Position.z -= 0.1;
+  }
+`,
+  fragmentShader: /* glsl */ `
+  precision mediump float;
+
+  uniform sampler2D uDepthTexture;
+  uniform vec3 uColor;
+  uniform float uPressed;
+
+  varying vec2 vTexCoord;
+
+  void main(void) {
+    // Distance from center of quad.
+    highp float dist = distance(vTexCoord, vec2(0.5f, 0.5f));
+    if (dist > 0.45) discard;
+
+    // Get the rate of change of dist on x and y.
+    highp vec2 dist_grad = vec2(dFdx(dist), dFdy(dist));
+    highp float grad_magnitude = length(dist_grad);
+    highp float antialias_dist = max(grad_magnitude, 0.001f);
+
+    // Outer radius is 0.5, but we want to bring it in a few pixels so we have room
+    // for a gradient outward to anti-alias the circle.
+    // These "few pixels" are determined by our derivative calculation above.
+    highp float outerradius = 0.5f - antialias_dist;
+    highp float delta_to_outer = dist - outerradius;
+    highp float clamped_outer_delta = clamp(delta_to_outer, 0.0f, antialias_dist);
+    highp float outer_alpha = 1.0f - (clamped_outer_delta / antialias_dist);
+
+    // #FFFFFF = (1,1,1)
+    // #FFFFFF with 0.5 alpha = (((1,1,1) * 0.5), 0.5)
+    vec4 inner_base_color = vec4(0.5 * uColor, 0.5);
+    vec4 pressed_inner_color = vec4(uColor, 1.0);
+    // #505050 = (0.077,0.077,0.077)
+    // #505050 with 0.7 alpha = (((0.077,0.077,0.077)*0.7), 0.7)
+    const vec4 inner_gradient_color = vec4(0.054, 0.054, 0.054, 1.0);
+    const vec4 outer_ring_color = vec4(0.077, 0.077, 0.077, 1.0);
+    // 0.5 - stoke_width (0.75dp = 0.04 approx)
+    const float gradient_end = 0.46;
+    // 73% of gradient_end
+    const float gradient_start = 0.33;
+    // gradient_end - 130% stoke_width. Additional 30% to account for the down scaling.
+    const float pressed_inner_radius = 0.41;
+
+    vec4 unpressed_inner_color =
+            mix(inner_base_color, inner_gradient_color,
+                    smoothstep(gradient_start, gradient_end, dist));
+    vec4 unpressed_color =
+            mix(unpressed_inner_color, outer_ring_color,
+                    step(gradient_end, dist));
+
+    // Builds a smooth gradient to fade between colors.
+    highp float smooth_distance = antialias_dist * 4.0;
+    float percent_to_inner_rad = max(pressed_inner_radius - dist, 0.0) / pressed_inner_radius;
+    highp float pressed_color_t = 1.0 - percent_to_inner_rad;
+    pressed_color_t -= (1.0 - smooth_distance);
+    pressed_color_t *= (1.0 / smooth_distance);
+    pressed_color_t = clamp(pressed_color_t, 0.0, 1.0);
+    vec4 pressed_color = mix(pressed_inner_color, outer_ring_color, pressed_color_t);
+
+    vec4 final_color = mix(unpressed_color, pressed_color, uPressed);
+    gl_FragColor = final_color * outer_alpha;
+    // Converts to straight alpha.
+    gl_FragColor.rgb = gl_FragColor.rgb / max(gl_FragColor.a, 0.001);
+  }
+`,
+};

--- a/src/placement/FaceCamera.ts
+++ b/src/placement/FaceCamera.ts
@@ -23,6 +23,9 @@ export class FaceCamera extends TransformScript {
   private timer?: THREE.Timer;
   private readonly mode: FaceCameraMode;
   private readonly smoothing: number;
+  private readonly worldPosition = new THREE.Vector3();
+  private readonly cameraPosition = new THREE.Vector3();
+  private readonly parentWorldQuaternion = new THREE.Quaternion();
 
   constructor(options: FaceCameraOptions = {}) {
     super();
@@ -39,10 +42,10 @@ export class FaceCamera extends TransformScript {
     const object = this.parent;
     if (!this.canUpdate || !object || !this.camera || !this.timer) return;
 
-    const worldPosition = object.getWorldPosition(new THREE.Vector3());
-    const cameraPosition = this.camera.getWorldPosition(new THREE.Vector3());
+    const worldPosition = object.getWorldPosition(this.worldPosition);
+    const cameraPosition = this.camera.getWorldPosition(this.cameraPosition);
     const parentWorldQuaternion = object.parent?.getWorldQuaternion(
-      new THREE.Quaternion()
+      this.parentWorldQuaternion
     );
     const targetQuaternion = faceCameraQuaternion(
       worldPosition,

--- a/src/placement/Orbit.ts
+++ b/src/placement/Orbit.ts
@@ -1,0 +1,390 @@
+import * as THREE from 'three';
+
+import {TransformScript} from './TransformScript';
+
+const TAU = Math.PI * 2;
+const EPSILON = 1e-8;
+const X_AXIS = new THREE.Vector3(1, 0, 0);
+const Y_AXIS = new THREE.Vector3(0, 1, 0);
+const Z_AXIS = new THREE.Vector3(0, 0, 1);
+const NEGATIVE_Z_AXIS = new THREE.Vector3(0, 0, -1);
+const WORLD_FRAME = new THREE.Quaternion().setFromRotationMatrix(
+  new THREE.Matrix4().makeBasis(X_AXIS, NEGATIVE_Z_AXIS, Y_AXIS)
+);
+
+export type OrbitPath = 'circular' | 'elliptical';
+export type OrbitFrame = 'world' | 'target' | 'view';
+export type OrbitDirection = 'clockwise' | 'counterclockwise';
+
+export interface OrbitOptions {
+  /** Object at the focus of the orbit. */
+  target: THREE.Object3D;
+  /** Semi-major radius in meters. Defaults to 0.5. */
+  radius?: number;
+  /** Seconds per orbit. Defaults to 20. */
+  period?: number;
+  /** Circular or Kepler-style elliptical motion. Defaults to circular. */
+  path?: OrbitPath;
+  /** Reference frame for the orbital plane. Defaults to world. */
+  frame?: OrbitFrame;
+  /** Ellipse eccentricity in [0, 1). Defaults to 0.2 for ellipses. */
+  eccentricity?: number;
+  /** Initial orbital-plane tilt in radians. Defaults to 0. */
+  inclination?: number;
+  /** Seconds per full rotation of the orbital plane. */
+  precessionPeriod?: number;
+  /** Direction viewed from the positive orbital normal. */
+  direction?: OrbitDirection;
+  /** Minimum gap between captured object bounds in meters. Defaults to 0. */
+  clearance?: number;
+}
+
+/**
+ * Moves its parent around a target focus.
+ *
+ * Bounds are captured during initialization and after `resume()`. Call
+ * `resume()` after changing geometry or scale to refresh overlap avoidance.
+ */
+export class Orbit extends TransformScript {
+  static dependencies = {camera: THREE.Camera, timer: THREE.Timer};
+
+  private camera?: THREE.Camera;
+  private timer?: THREE.Timer;
+  private readonly target: THREE.Object3D;
+  private readonly configuredRadius: number;
+  private readonly period: number;
+  private readonly frame: OrbitFrame;
+  private readonly eccentricity: number;
+  private readonly minorAxisScale: number;
+  private readonly precessionPeriod?: number;
+  private readonly directionSign: number;
+  private readonly clearance: number;
+
+  private semiMajorRadius: number;
+  private meanAnomaly = 0;
+  private precessionAngle = 0;
+
+  private readonly orientation = new THREE.Quaternion();
+  private readonly frameQuaternion = new THREE.Quaternion();
+  private readonly precessionQuaternion = new THREE.Quaternion();
+  private readonly orbitQuaternion = new THREE.Quaternion();
+  private readonly basisMatrix = new THREE.Matrix4();
+  private readonly targetPosition = new THREE.Vector3();
+  private readonly ownerPosition = new THREE.Vector3();
+  private readonly worldPosition = new THREE.Vector3();
+  private readonly orbitOffset = new THREE.Vector3();
+  private readonly normal = new THREE.Vector3();
+  private readonly tangent = new THREE.Vector3();
+  private readonly cameraPosition = new THREE.Vector3();
+  private readonly cameraUp = new THREE.Vector3();
+  private readonly worldQuaternion = new THREE.Quaternion();
+
+  constructor(options: OrbitOptions) {
+    super();
+    if (!options?.target) throw new Error('Orbit requires a target object.');
+
+    this.target = options.target;
+    this.configuredRadius = positive(options.radius ?? 0.5, 'radius');
+    this.semiMajorRadius = this.configuredRadius;
+    this.period = positive(options.period ?? 20, 'period');
+
+    const path = oneOf(
+      options.path ?? 'circular',
+      ['circular', 'elliptical'] as const,
+      'path'
+    );
+    const eccentricity =
+      options.eccentricity ?? (path === 'elliptical' ? 0.2 : 0);
+    if (path === 'circular' && eccentricity !== 0) {
+      throw new Error('Circular Orbit paths require zero eccentricity.');
+    }
+    this.eccentricity = range(eccentricity, 0, 1, 'eccentricity');
+    this.minorAxisScale = Math.sqrt(1 - this.eccentricity ** 2);
+
+    this.frame = oneOf(
+      options.frame ?? 'world',
+      ['world', 'target', 'view'] as const,
+      'frame'
+    );
+    this.precessionPeriod = optionalPositive(
+      options.precessionPeriod,
+      'precessionPeriod'
+    );
+    this.orientation.setFromAxisAngle(
+      X_AXIS,
+      finite(options.inclination ?? 0, 'inclination')
+    );
+
+    const direction = oneOf(
+      options.direction ?? 'counterclockwise',
+      ['clockwise', 'counterclockwise'] as const,
+      'direction'
+    );
+    this.directionSign = direction === 'clockwise' ? -1 : 1;
+    this.clearance = nonnegative(options.clearance ?? 0, 'clearance');
+  }
+
+  init({camera, timer}: {camera: THREE.Camera; timer: THREE.Timer}) {
+    this.camera = camera;
+    this.timer = timer;
+
+    const owner = this.parent;
+    if (!owner) return;
+    if (
+      isAncestorOrSelf(owner, this.target) ||
+      isAncestorOrSelf(this.target, owner)
+    ) {
+      throw new Error(
+        'Orbit target must not be its owner, ancestor, or descendant.'
+      );
+    }
+
+    this.semiMajorRadius = this.configuredRadius;
+    this.applyClearance(owner);
+    this.updateOrbitOrientation();
+  }
+
+  update() {
+    const owner = this.parent;
+    if (!this.canUpdate || !owner || !this.timer) return;
+
+    const delta = this.timer.getDelta();
+    if (!Number.isFinite(delta) || delta <= 0) return;
+
+    this.meanAnomaly = normalizeAngle(
+      this.meanAnomaly + this.directionSign * ((TAU * delta) / this.period)
+    );
+    if (this.precessionPeriod !== undefined) {
+      this.precessionAngle = normalizeAngle(
+        this.precessionAngle + (TAU * delta) / this.precessionPeriod
+      );
+    }
+
+    this.updateOrbitOrientation();
+    this.applyPosition(owner);
+  }
+
+  /** Restarts the orbit from the parent's manipulated position. */
+  protected rebase() {
+    const owner = this.parent;
+    if (!owner) return;
+
+    this.updateOrbitOrientation();
+    owner.getWorldPosition(this.ownerPosition);
+    this.orbitOffset.copy(this.ownerPosition).sub(this.targetPosition);
+    const distance = this.orbitOffset.length();
+
+    if (distance > EPSILON) {
+      this.rebasePlane(this.orbitOffset.multiplyScalar(1 / distance));
+      this.semiMajorRadius = distance / (1 - this.eccentricity);
+      this.meanAnomaly = 0;
+    }
+
+    this.applyClearance(owner);
+    this.updateOrbitOrientation();
+    this.applyPosition(owner);
+  }
+
+  private updateOrbitOrientation() {
+    this.updateFrame();
+    this.precessionQuaternion.setFromAxisAngle(Z_AXIS, this.precessionAngle);
+    this.orbitQuaternion
+      .copy(this.frameQuaternion)
+      .multiply(this.precessionQuaternion)
+      .multiply(this.orientation)
+      .normalize();
+  }
+
+  private updateFrame() {
+    this.target.getWorldPosition(this.targetPosition);
+
+    if (this.frame === 'world') {
+      this.frameQuaternion.copy(WORLD_FRAME);
+      return;
+    }
+
+    if (this.frame === 'target') {
+      this.target
+        .getWorldQuaternion(this.frameQuaternion)
+        .multiply(WORLD_FRAME);
+      return;
+    }
+
+    const camera = this.camera;
+    if (!camera) {
+      this.frameQuaternion.copy(WORLD_FRAME);
+      return;
+    }
+    camera.getWorldPosition(this.cameraPosition);
+    camera.getWorldQuaternion(this.worldQuaternion);
+    this.cameraUp.copy(camera.up).applyQuaternion(this.worldQuaternion);
+    this.basisMatrix.lookAt(
+      this.cameraPosition,
+      this.targetPosition,
+      this.cameraUp
+    );
+    this.frameQuaternion.setFromRotationMatrix(this.basisMatrix);
+  }
+
+  private rebasePlane(direction: THREE.Vector3) {
+    this.normal.copy(Z_AXIS).applyQuaternion(this.orbitQuaternion);
+    projectOntoPlane(this.normal, direction);
+    if (this.normal.lengthSq() <= EPSILON) {
+      this.normal.copy(Y_AXIS);
+      projectOntoPlane(this.normal, direction);
+    }
+    if (this.normal.lengthSq() <= EPSILON) {
+      this.normal.copy(X_AXIS);
+      projectOntoPlane(this.normal, direction);
+    }
+    this.normal.normalize();
+    this.tangent.crossVectors(this.normal, direction).normalize();
+    this.basisMatrix.makeBasis(direction, this.tangent, this.normal);
+    this.orbitQuaternion.setFromRotationMatrix(this.basisMatrix);
+
+    this.orientation
+      .copy(this.frameQuaternion)
+      .multiply(this.precessionQuaternion)
+      .invert()
+      .multiply(this.orbitQuaternion)
+      .normalize();
+  }
+
+  private applyPosition(owner: THREE.Object3D) {
+    const eccentricAnomaly = solveKepler(this.meanAnomaly, this.eccentricity);
+    this.orbitOffset.set(
+      this.semiMajorRadius * (Math.cos(eccentricAnomaly) - this.eccentricity),
+      this.semiMajorRadius * this.minorAxisScale * Math.sin(eccentricAnomaly),
+      0
+    );
+    this.orbitOffset.applyQuaternion(this.orbitQuaternion);
+    this.worldPosition.copy(this.targetPosition).add(this.orbitOffset);
+    owner.parent?.worldToLocal(this.worldPosition);
+    owner.position.copy(this.worldPosition);
+  }
+
+  private applyClearance(owner: THREE.Object3D) {
+    const minimumPeriapsis =
+      worldBoundingRadius(this.target) +
+      worldBoundingRadius(owner) +
+      this.clearance;
+    this.semiMajorRadius = Math.max(
+      this.semiMajorRadius,
+      minimumPeriapsis / (1 - this.eccentricity)
+    );
+  }
+}
+
+function projectOntoPlane(vector: THREE.Vector3, normal: THREE.Vector3) {
+  vector.addScaledVector(normal, -vector.dot(normal));
+}
+
+function worldBoundingRadius(object: THREE.Object3D) {
+  object.updateWorldMatrix(true, true);
+  const bounds = new THREE.Box3().setFromObject(object);
+  if (bounds.isEmpty()) return 0;
+
+  const origin = object.getWorldPosition(new THREE.Vector3());
+  const x = Math.max(
+    Math.abs(bounds.min.x - origin.x),
+    Math.abs(bounds.max.x - origin.x)
+  );
+  const y = Math.max(
+    Math.abs(bounds.min.y - origin.y),
+    Math.abs(bounds.max.y - origin.y)
+  );
+  const z = Math.max(
+    Math.abs(bounds.min.z - origin.z),
+    Math.abs(bounds.max.z - origin.z)
+  );
+  return Math.hypot(x, y, z);
+}
+
+function solveKepler(meanAnomaly: number, eccentricity: number) {
+  if (eccentricity === 0) return meanAnomaly;
+
+  let mean = normalizeAngle(meanAnomaly);
+  if (mean > Math.PI) mean -= TAU;
+
+  let lower = -Math.PI;
+  let upper = Math.PI;
+  let eccentricAnomaly =
+    eccentricity < 0.8 || mean === 0 ? mean : Math.sign(mean) * Math.PI;
+
+  for (let iteration = 0; iteration < 16; iteration += 1) {
+    const error =
+      eccentricAnomaly - eccentricity * Math.sin(eccentricAnomaly) - mean;
+    if (Math.abs(error) <= 1e-12) return eccentricAnomaly;
+    if (error > 0) upper = eccentricAnomaly;
+    else lower = eccentricAnomaly;
+
+    const derivative = 1 - eccentricity * Math.cos(eccentricAnomaly);
+    const next = eccentricAnomaly - error / derivative;
+    eccentricAnomaly =
+      Number.isFinite(next) && next > lower && next < upper
+        ? next
+        : (lower + upper) * 0.5;
+  }
+  return eccentricAnomaly;
+}
+
+function normalizeAngle(angle: number) {
+  const normalized = angle % TAU;
+  return normalized < 0 ? normalized + TAU : normalized;
+}
+
+function finite(value: number, name: string) {
+  if (!Number.isFinite(value)) {
+    throw new Error(`Orbit ${name} must be finite.`);
+  }
+  return value;
+}
+
+function positive(value: number, name: string) {
+  finite(value, name);
+  if (value <= 0) throw new Error(`Orbit ${name} must be greater than zero.`);
+  return value;
+}
+
+function optionalPositive(value: number | undefined, name: string) {
+  return value === undefined ? undefined : positive(value, name);
+}
+
+function nonnegative(value: number, name: string) {
+  finite(value, name);
+  if (value < 0) throw new Error(`Orbit ${name} must be nonnegative.`);
+  return value;
+}
+
+function range(value: number, min: number, max: number, name: string) {
+  finite(value, name);
+  if (value < min || value >= max) {
+    throw new Error(`Orbit ${name} must be in [${min}, ${max}).`);
+  }
+  return value;
+}
+
+function oneOf<T extends string>(
+  value: string,
+  choices: readonly T[],
+  name: string
+): T {
+  if (!choices.includes(value as T)) {
+    throw new Error(`Orbit ${name} must be ${choices.join(' or ')}.`);
+  }
+  return value as T;
+}
+
+function isAncestorOrSelf(
+  object: THREE.Object3D,
+  possibleAncestor: THREE.Object3D
+) {
+  for (
+    let current: THREE.Object3D | null = object;
+    current;
+    current = current.parent
+  ) {
+    if (current === possibleAncestor) return true;
+  }
+  return false;
+}

--- a/src/utils/FaceCameraMath.ts
+++ b/src/utils/FaceCameraMath.ts
@@ -6,6 +6,12 @@ export type FaceCameraMode = 'cylindrical' | 'spherical';
 
 export const DEFAULT_FACE_CAMERA_SMOOTHING = 0.1;
 
+// Reusable instances to avoid creating objects in the render loop.
+const target = new THREE.Vector3();
+const worldQuaternion = new THREE.Quaternion();
+const localQuaternion = new THREE.Quaternion();
+const lookAtMatrix = new THREE.Matrix4();
+
 export function faceCameraSlerpAlpha(
   smoothing: number,
   deltaSeconds: number
@@ -21,13 +27,16 @@ export function faceCameraQuaternion(
   mode: FaceCameraMode = 'cylindrical'
 ): THREE.Quaternion | undefined {
   if (!cameraPosition) return undefined;
-  const target = cameraPosition.clone();
+  target.copy(cameraPosition);
   if (mode === 'cylindrical') target.y = worldPosition.y;
   if (target.distanceToSquared(worldPosition) < 1e-8) return undefined;
 
-  const worldQuaternion = new THREE.Quaternion().setFromRotationMatrix(
-    new THREE.Matrix4().lookAt(target, worldPosition, UP)
+  worldQuaternion.setFromRotationMatrix(
+    lookAtMatrix.lookAt(target, worldPosition, UP)
   );
   if (!parentWorldQuaternion) return worldQuaternion;
-  return parentWorldQuaternion.clone().invert().multiply(worldQuaternion);
+  return localQuaternion
+    .copy(parentWorldQuaternion)
+    .invert()
+    .multiply(worldQuaternion);
 }

--- a/src/xrblocks.ts
+++ b/src/xrblocks.ts
@@ -68,6 +68,7 @@ export * from './physics/PhysicsOptions';
 export * from './placement/FaceCamera';
 export * from './placement/FollowHead';
 export * from './placement/FollowObject';
+export * from './placement/Orbit';
 export {TransformScript} from './placement/TransformScript';
 export * from './placement/VisibilityTransition';
 export * from './simulator/controlModes/SimulatorControlMode';


### PR DESCRIPTION
## Description

**Not tested on device yet.**

This PR adds the new standalone interaction system on top of the lifecycle fixes.

The new module owns hit resolution, selection capture, gaze, touch, reticles, semantic controls, and object manipulation. The existing UI-dependent interaction path remains temporarily so this PR can be reviewed without also including the UI migration.

Stack dependency: `manip-lifecycle`

## Changes

- Add a standalone interaction module.
- Add hit target registration and hit resolution.
- Add selection capture across input sources.
- Add gaze dwell interaction.
- Add direct-touch interaction.
- Add reticle presentation and reticle configuration.
- Add semantic controls and interaction metadata.
- Add object manipulation for translation, rotation, and scaling.
- Add manipulation drivers and shared manipulation math.
- Suspend placement transform scripts while their objects are manipulated.
- Add the `Orbit` transform script.
- Add configurable FaceCamera and reticle rotation smoothing.
- Preserve the allocation-free FaceCamera implementation.
- Fold the formatting-only changes into the interaction implementation.

## Scope boundaries

This PR does not connect Core or Input to the new interaction module.

The following legacy files remain because the existing UI still depends on them:

- `UX`
- `DragManager`
- The old raycaster
- The old reticle
- The old UI-dependent interaction code

The runtime cutover and deletion of those files occur in the next PR.