### PR TITLE
ci: fix zizmor security audit findings in GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -22,17 +22,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: ⚙️ Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24'
           cache: 'npm'
 
       - name: 📦 Cache Node Modules
         id: cache-node-modules
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: node_modules
           key: ${{ runner.os }}-node-root-${{ hashFiles('package-lock.json') }}
@@ -45,7 +47,7 @@ jobs:
         run: npm run build
 
       - name: 🚀 Deploy to build branch
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@329bcc8f12caed2cefe5a5b80781499a6f3b361b # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm run build
 
       - name: 🚀 Deploy to build branch
-        uses: peaceiris/actions-gh-pages@329bcc8f12caed2cefe5a5b80781499a6f3b361b # v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -15,23 +15,28 @@ on:
       - '.github/workflows/build-check.yml'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24'
           cache: 'npm'
 
       - name: Cache Node Modules
         id: cache-node-modules
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: node_modules
           key: ${{ runner.os }}-node-root-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/docs-build-check.yml
+++ b/.github/workflows/docs-build-check.yml
@@ -13,16 +13,21 @@ on:
       - '.github/workflows/docs-build-check.yml'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-docs:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -32,7 +37,7 @@ jobs:
 
       - name: Cache Root Node Modules
         id: cache-root-modules
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: node_modules
           key: ${{ runner.os }}-node-root-${{ hashFiles('package-lock.json') }}
@@ -43,7 +48,7 @@ jobs:
 
       - name: Cache Docs Node Modules
         id: cache-docs-modules
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: docs/node_modules
           key: ${{ runner.os }}-node-docs-${{ hashFiles('docs/package-lock.json') }}

--- a/.github/workflows/lint-format-check.yml
+++ b/.github/workflows/lint-format-check.yml
@@ -21,23 +21,28 @@ on:
       - '.github/workflows/lint-format-check.yml'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24'
           cache: 'npm'
 
       - name: Cache Node Modules
         id: cache-node-modules
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: node_modules
           key: ${{ runner.os }}-node-root-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,12 +13,16 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,23 +13,28 @@ on:
       - '.github/workflows/test.yml'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24'
           cache: 'npm'
 
       - name: Cache Node Modules
         id: cache-node-modules
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: node_modules
           key: ${{ runner.os }}-node-root-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/update-xrblocks-github-io.yml
+++ b/.github/workflows/update-xrblocks-github-io.yml
@@ -13,13 +13,15 @@ on:
       - "templates/**"
       - "samples/**"
 
+permissions: {}
+
 jobs:
   dispatch-to-xrblocks-github-io:
     if: github.repository == 'google/xrblocks'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger build in xrblocks.github.io
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           token: ${{ secrets.XRBLOCKS_GITHUB_IO_PAT }}
           repository: xrblocks/xrblocks.github.io


### PR DESCRIPTION
- Add explicit least-privilege permissions blocks to workflows
- Pin third-party and official GitHub Actions to SHA commit hashes
- Set persist-credentials: false on checkout steps
- Disable default caching in publish workflow to prevent cache poisoning

TAG=agy
CONV=a7043de3-4652-4ae1-b37e-aa75ef0ef8c2
