### PR TITLE
Lifecycle Updates for Core + Scripts

### DIFF
--- a/docs/docs/manual/Core.mdx
+++ b/docs/docs/manual/Core.mdx
@@ -115,9 +115,11 @@ The [`ScreenshotSynthesizer`](/api/classes/ScreenshotSynthesizer) captures visua
 const dataUrl = await xb.core.screenshotSynthesizer.getScreenshot(true);
 ```
 
-### 6. Script lifecycle
+### 6. Scripts Manager
 
-Core drives the lifecycle hooks (`init`, `update`, `dispose`, and select/hover events) on all registered [`Script`](Scripts.md) components through its internal script lifecycle manager.
+The [`ScriptsManager`](/api/classes/ScriptsManager) drives lifecycle hooks
+(`init`, `update`, `dispose`, and select/hover events) on all registered
+[`Script`](Scripts.md) components.
 
 It iterates over all script-enabled `THREE.Object3D` nodes in the active scene graph on every tick of the main loop to run their update callbacks.
 

--- a/docs/docs/manual/Core.mdx
+++ b/docs/docs/manual/Core.mdx
@@ -115,9 +115,9 @@ The [`ScreenshotSynthesizer`](/api/classes/ScreenshotSynthesizer) captures visua
 const dataUrl = await xb.core.screenshotSynthesizer.getScreenshot(true);
 ```
 
-### 6. Scripts Manager
+### 6. Script lifecycle
 
-The [`ScriptsManager`](/api/classes/ScriptsManager) drives the lifecycle hooks (`init`, `update`, `dispose`, and select/hover events) on all registered [`Script`](Scripts.md) components.
+Core drives the lifecycle hooks (`init`, `update`, `dispose`, and select/hover events) on all registered [`Script`](Scripts.md) components through its internal script lifecycle manager.
 
 It iterates over all script-enabled `THREE.Object3D` nodes in the active scene graph on every tick of the main loop to run their update callbacks.
 

--- a/docs/docs/manual/Inputs.md
+++ b/docs/docs/manual/Inputs.md
@@ -6,7 +6,7 @@ title: Input & Controllers
 ## Input
 
 The [`Input`](/api/classes/Input) object at `xb.core.input` provides access to
-controllers and their raycast results. [`intersectionsForController`](/api/classes/Input#intersectionforcontroller) is a
+controllers and their raycast results. [`intersectionsForController`](/api/classes/Input#intersectionsforcontroller) is a
 `Map`, keyed by controller object. Results are updated by the input system as the controller points and selects.
 
 For example, to detect which item is selected:
@@ -15,7 +15,8 @@ For example, to detect which item is selected:
 export class ItemSelectionScript extends xb.Script {
   onSelectStart(event) {
     const controller = event.target;
-    const intersections = xb.core.input.intersectionsForController(controller);
+    const intersections =
+      xb.core.input.intersectionsForController.get(controller) ?? [];
     if (intersections.length > 0) {
       console.log('Item selected:', intersections[0].object);
     }

--- a/src/addons/netblocks/src/core/enableNet.test.ts
+++ b/src/addons/netblocks/src/core/enableNet.test.ts
@@ -1,18 +1,15 @@
 import {describe, expect, it, vi} from 'vitest';
 
-// `enableNet()` reads `xb.core.scene` and `xb.core.scriptsManager`. Mock
-// just enough of xrblocks to exercise the registration path without
+// Mock just enough of xrblocks to exercise the scene registration path without
 // booting a real xrblocks Core (and without an AudioContext, which jsdom
 // can't satisfy).
 const mocks = vi.hoisted(() => {
   const fakeScene = {add: (..._args: unknown[]) => {}};
-  const fakeScriptsManager = {initScript: (..._args: unknown[]) => {}};
   const fakeCore: {
     scene: typeof fakeScene;
-    scriptsManager: typeof fakeScriptsManager;
     net?: unknown;
-  } = {scene: fakeScene, scriptsManager: fakeScriptsManager};
-  return {fakeScene, fakeScriptsManager, fakeCore};
+  } = {scene: fakeScene};
+  return {fakeScene, fakeCore};
 });
 
 vi.mock('xrblocks', async () => {
@@ -30,13 +27,11 @@ describe('enableNet()', () => {
   it('creates a NetCore, adds it to the scene, and registers it', () => {
     mocks.fakeCore.net = undefined;
     const sceneAdd = vi.spyOn(mocks.fakeScene, 'add');
-    const initScript = vi.spyOn(mocks.fakeScriptsManager, 'initScript');
 
     const net = enableNet();
 
     expect(net).toBeInstanceOf(NetCore);
     expect(sceneAdd).toHaveBeenCalledTimes(1);
-    expect(initScript).toHaveBeenCalledTimes(1);
     expect(mocks.fakeCore.net).toBe(net);
   });
 

--- a/src/addons/netblocks/src/core/enableNet.ts
+++ b/src/addons/netblocks/src/core/enableNet.ts
@@ -29,7 +29,7 @@ declare module 'xrblocks' {
 /**
  * Register the netblocks addon with the running xrblocks core. Idempotent —
  * calling it again returns the existing NetCore. Must be called after
- * `xb.init()` so `xb.core.scene` and `xb.core.scriptsManager` are ready.
+ * `xb.init()` so `xb.core.scene` is ready.
  *
  * After this call:
  * - `xb.core.net` holds the NetCore instance.
@@ -50,7 +50,6 @@ export function enableNet(): NetCore {
   const net = new NetCore(xb.core.scene);
   const driver = new NetCoreScript(net);
   xb.core.scene.add(driver);
-  void xb.core.scriptsManager.initScript(driver);
   xb.core.net = net;
   return net;
 }

--- a/src/addons/remote-control/RemoteControl.ts
+++ b/src/addons/remote-control/RemoteControl.ts
@@ -22,7 +22,6 @@ import {
 } from './WebSocketRemoteControlTransport';
 
 export type RemoteControlOptions = WebSocketRemoteControlTransportOptions & {
-  embodiedControl?: EmbodiedControl;
   embodiedOptions?: EmbodiedControlOptions;
   tools?: Record<string, RemoteControlToolHandler>;
 };
@@ -41,7 +40,6 @@ export class RemoteControl extends Script {
   };
 
   editorIcon = 'settings_remote';
-  embodiedControl: EmbodiedControl;
   transport?: WebSocketRemoteControlTransport;
 
   dependencies!: {
@@ -52,6 +50,8 @@ export class RemoteControl extends Script {
   };
 
   private tools = new Map<string, RegisteredTool>();
+  private readonly embodiedControl: EmbodiedControl;
+  private simulatorReadyAnnounced = false;
 
   static configureOptions(options = new Options()) {
     return (
@@ -63,8 +63,8 @@ export class RemoteControl extends Script {
 
   constructor(private options: RemoteControlOptions = {}) {
     super();
-    this.embodiedControl =
-      options.embodiedControl ?? new EmbodiedControl(options.embodiedOptions);
+    this.embodiedControl = new EmbodiedControl(options.embodiedOptions);
+    this.add(this.embodiedControl);
 
     for (const [name, handler] of Object.entries(options.tools ?? {})) {
       this.registerTool(name, handler);
@@ -78,10 +78,6 @@ export class RemoteControl extends Script {
     camera: THREE.Camera;
   }) {
     this.dependencies = dependencies;
-    if (!this.embodiedControl.executor) {
-      this.embodiedControl.init(dependencies);
-    }
-
     this.registerBuiltInTools();
     this.transport = new WebSocketRemoteControlTransport(
       {
@@ -93,19 +89,18 @@ export class RemoteControl extends Script {
       (request) => this.handleRequest(request)
     );
     this.transport.connect();
+    if (dependencies.core.simulatorRunning) {
+      void this.announceSimulatorReady();
+    }
   }
 
   dispose() {
     this.transport?.disconnect();
+    this.transport = undefined;
   }
 
   override onSimulatorStarted() {
-    if (
-      !this.dependencies.core.scriptsManager.scripts.has(this.embodiedControl)
-    ) {
-      this.embodiedControl.onSimulatorStarted();
-    }
-    this.transport?.announceSimulatorReady();
+    void this.announceSimulatorReady();
   }
 
   registerTool(
@@ -180,6 +175,13 @@ export class RemoteControl extends Script {
         });
       }
     }
+  }
+
+  private async announceSimulatorReady() {
+    await this.embodiedControl.ready;
+    if (this.simulatorReadyAnnounced || !this.transport) return;
+    this.simulatorReadyAnnounced = true;
+    this.transport.announceSimulatorReady();
   }
 
   private resolveTarget(

--- a/src/addons/testing/TestRunner.ts
+++ b/src/addons/testing/TestRunner.ts
@@ -67,7 +67,9 @@ export class TestRunner {
   }
 
   static async create(config: TestRunnerConfig = {}): Promise<TestRunner> {
-    const core = Core.instance || new Core();
+    await Core.instance?.dispose();
+    Core.instance = undefined;
+    const core = new Core();
     const options = config.options || new Options();
 
     options.enableSimulator = true;

--- a/src/addons/testing/TestRunner.ts
+++ b/src/addons/testing/TestRunner.ts
@@ -4,8 +4,8 @@ import {
   Core,
   Options,
   Script,
+  ScriptsManagerEventType,
   type Constructor,
-  type ScriptError,
 } from 'xrblocks';
 import {
   EmbodiedControl,
@@ -28,7 +28,16 @@ export class TestRunner {
   readonly actions: EmbodiedControl;
 
   private caughtErrors: Error[] = [];
-  private readonly unsubscribeScriptErrors: () => void;
+  private readonly handleScriptException = (event: {
+    error: Error;
+    scriptName: string;
+    context: string;
+  }) => {
+    const error =
+      event.error ||
+      new Error(`Exception in script: ${event.scriptName} (${event.context})`);
+    this.caughtErrors.push(error);
+  };
 
   private constructor(core: Core, embodiedControl: EmbodiedControl) {
     this.core = core;
@@ -36,14 +45,10 @@ export class TestRunner {
     this.scene = core.scene;
     this.camera = core.camera;
 
-    this.unsubscribeScriptErrors = core.onScriptError((event: ScriptError) => {
-      const error =
-        event.error ||
-        new Error(
-          `Exception in script: ${event.scriptName} (${event.context})`
-        );
-      this.caughtErrors.push(error);
-    });
+    core.scriptsManager.addEventListener(
+      ScriptsManagerEventType.EXCEPTION,
+      this.handleScriptException
+    );
 
     // Set up the dynamic actions proxy.
     this.actions = new Proxy(this.embodiedControl, {
@@ -152,7 +157,10 @@ export class TestRunner {
     } catch (error) {
       firstError = error;
     }
-    this.unsubscribeScriptErrors();
+    this.core.scriptsManager.removeEventListener(
+      ScriptsManagerEventType.EXCEPTION,
+      this.handleScriptException
+    );
     try {
       await this.core.dispose();
     } catch (error) {

--- a/src/addons/testing/TestRunner.ts
+++ b/src/addons/testing/TestRunner.ts
@@ -4,8 +4,8 @@ import {
   Core,
   Options,
   Script,
-  ScriptsManagerEventType,
   type Constructor,
+  type ScriptError,
 } from 'xrblocks';
 import {
   EmbodiedControl,
@@ -28,11 +28,7 @@ export class TestRunner {
   readonly actions: EmbodiedControl;
 
   private caughtErrors: Error[] = [];
-  private boundExceptionListener: (event: {
-    error: Error;
-    scriptName: string;
-    context: string;
-  }) => void;
+  private readonly unsubscribeScriptErrors: () => void;
 
   private constructor(core: Core, embodiedControl: EmbodiedControl) {
     this.core = core;
@@ -40,24 +36,14 @@ export class TestRunner {
     this.scene = core.scene;
     this.camera = core.camera;
 
-    this.boundExceptionListener = (event: {
-      error: Error;
-      scriptName: string;
-      context: string;
-    }) => {
+    this.unsubscribeScriptErrors = core.onScriptError((event: ScriptError) => {
       const error =
         event.error ||
         new Error(
           `Exception in script: ${event.scriptName} (${event.context})`
         );
       this.caughtErrors.push(error);
-    };
-
-    // Hook error handling
-    core.scriptsManager.addEventListener(
-      ScriptsManagerEventType.EXCEPTION,
-      this.boundExceptionListener
-    );
+    });
 
     // Set up the dynamic actions proxy.
     this.actions = new Proxy(this.embodiedControl, {
@@ -111,6 +97,7 @@ export class TestRunner {
     };
     const embodiedControl = new EmbodiedControl(embodiedOptions);
     core.scene.add(embodiedControl);
+    const runner = new TestRunner(core, embodiedControl);
 
     await core.init(options);
 
@@ -138,7 +125,6 @@ export class TestRunner {
     core.camera.updateMatrixWorld(true);
     core.camera.matrixWorldInverse.copy(core.camera.matrixWorld).invert();
 
-    const runner = new TestRunner(core, embodiedControl);
     runner.checkErrors();
     return runner;
   }
@@ -156,77 +142,21 @@ export class TestRunner {
     return script;
   }
 
-  /**
-   * Destroys the test runner, cleans up the scene, window events, and resets mocks.
-   */
+  /** Disposes the Core lifetime owned by this runner. */
   async destroy(): Promise<void> {
-    this.checkErrors();
-
-    // Remove exception listener
-    this.core.scriptsManager.removeEventListener(
-      ScriptsManagerEventType.EXCEPTION,
-      this.boundExceptionListener
-    );
-
-    const coreInternal = this.core as unknown as {
-      onWindowResize?: EventListenerOrEventListenerObject;
-    };
-    if (coreInternal.onWindowResize) {
-      window.removeEventListener('resize', coreInternal.onWindowResize);
+    let firstError: unknown;
+    try {
+      this.checkErrors();
+    } catch (error) {
+      firstError = error;
     }
-
-    this.core.scene.clear();
-    await this.core.scriptsManager.syncScriptsWithScene(this.core.scene);
-    this.core.scene.add(this.core.xrSystemsGroup);
-
-    // Clear Input lists and maps to prevent duplicate controller registration across tests.
-    const input = this.core.input;
-    input.controllers.length = 0;
-    input.controllerGrips.length = 0;
-    input.hands.length = 0;
-    input.leftController = undefined;
-    input.rightController = undefined;
-    input.intersectionsForController.clear();
-    input.activeControllers.clear();
-    input.listeners.clear();
-
-    const depth = this.core.depth;
-    depth.view.length = 0;
-    depth.cpuDepthData.length = 0;
-    depth.gpuDepthData.length = 0;
-    depth.depthArray.length = 0;
-
-    const coreWritable = this.core as unknown as {
-      effects?: unknown;
-      renderer?: unknown;
-    };
-    coreWritable.effects = undefined;
-
-    const registryInternal = this.core.registry as unknown as {
-      instances: Map<unknown, unknown>;
-    };
-    registryInternal.instances.clear();
-    this.core.registry.register(this.core.registry);
-    this.core.registry.register(this.core, Core);
-    this.core.registry.register(this.core.scene, THREE.Scene);
-    this.core.registry.register(this.core.camera, THREE.Camera);
-    this.core.registry.register(this.core.timer, THREE.Timer);
-    this.core.registry.register(this.core.input);
-    this.core.registry.register(this.core.user);
-    this.core.registry.register(this.core.ui);
-    this.core.registry.register(this.core.sound);
-    this.core.registry.register(this.core.dragManager);
-    this.core.registry.register(this.core.simulator);
-    this.core.registry.register(this.core.scriptsManager);
-    this.core.registry.register(this.core.depth);
-    this.core.registry.register(this.core.world);
-    this.core.registry.register(this.core.xrSystemsGroup);
-
-    if (this.core.renderer) {
-      this.core.renderer.dispose();
-      this.core.renderer.domElement.remove();
-      coreWritable.renderer = undefined;
+    this.unsubscribeScriptErrors();
+    try {
+      await this.core.dispose();
+    } catch (error) {
+      firstError ??= error;
     }
+    if (firstError !== undefined) throw firstError;
   }
 
   private checkErrors() {

--- a/src/addons/testing/example.test.ts
+++ b/src/addons/testing/example.test.ts
@@ -1,7 +1,7 @@
 import {describe, it, expect} from 'vitest';
 import {TestRunner} from './TestRunner';
 import * as THREE from 'three';
-import {Script, type SelectEvent, TextButton, Options, core} from 'xrblocks';
+import {Core, Script, type SelectEvent, TextButton, Options} from 'xrblocks';
 
 class SimpleRotationScript extends Script {
   speed = 1.0;
@@ -125,7 +125,7 @@ describe('TestRunner functional examples', () => {
     button.onTriggered = () => {
       game.spawnItem();
     };
-    button.position.set(0, core.user.height, -core.user.height);
+    button.position.set(0, 1.6, -1.6);
 
     const runner = await TestRunner.create({
       scripts: [game, button],
@@ -147,11 +147,15 @@ describe('TestRunner functional examples', () => {
 
   it('should run Example 5: End-to-End Heuristic Gesture Recognition', async () => {
     class TestGestureScript extends Script {
+      static dependencies = {core: Core};
+
       pinchDetected = false;
+      private core?: Core;
       private _onGestureStart?: (event: Event) => void;
       private _onGestureEnd?: (event: Event) => void;
 
-      override init() {
+      override init({core}: {core: Core}) {
+        this.core = core;
         const gestures = core.gestureRecognition;
         if (!gestures) return;
 
@@ -173,7 +177,7 @@ describe('TestRunner functional examples', () => {
       }
 
       override dispose() {
-        const gestures = core.gestureRecognition;
+        const gestures = this.core?.gestureRecognition;
         if (gestures) {
           if (this._onGestureStart) {
             gestures.removeEventListener('gesturestart', this._onGestureStart);

--- a/src/core/Core.test.ts
+++ b/src/core/Core.test.ts
@@ -41,9 +41,9 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
   let core: Core;
   let consoleErrorSpy: MockInstance;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // Reset Core singleton to ensure fresh state for each test
-    Core.instance?.dispose();
+    await Core.instance?.dispose();
     Core.instance = undefined;
     core = new Core();
     core.options = new Options();
@@ -82,6 +82,7 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
       const script1 = {
         name: 'Script1',
         ux: {reset: vi.fn()},
+        dispose: vi.fn(),
         update: vi.fn().mockImplementation(() => {
           throw new Error('Script1 crashed');
         }),
@@ -90,6 +91,7 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
       const script2 = {
         name: 'Script2',
         ux: {reset: vi.fn()},
+        dispose: vi.fn(),
         update: vi.fn(),
       } as unknown as Script;
 
@@ -141,6 +143,7 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
 
       const script1 = {
         name: 'Script1',
+        dispose: vi.fn(),
         update: vi.fn().mockImplementation(() => {
           throw new Error('Script1 crashed');
         }),
@@ -148,6 +151,7 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
 
       const script2 = {
         name: 'Script2',
+        dispose: vi.fn(),
         update: vi.fn(),
       } as unknown as Script;
 
@@ -184,6 +188,7 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
             throw new Error('UX reset crashed');
           }),
         },
+        dispose: vi.fn(),
         onSelecting: vi.fn().mockImplementation(() => {
           throw new Error('onSelecting crashed');
         }),
@@ -196,6 +201,7 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
       const script2 = {
         name: 'Script2',
         ux: {reset: vi.fn()},
+        dispose: vi.fn(),
         onSelecting: vi.fn(),
         onSqueezing: vi.fn(),
         update: vi.fn(),
@@ -250,6 +256,7 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
     it('should catch and emit exceptions inside callSelectStart without crashing other scripts', () => {
       const script1 = {
         name: 'Script1',
+        dispose: vi.fn(),
         onSelectStart: vi.fn().mockImplementation(() => {
           throw new Error('SelectStart error');
         }),
@@ -257,6 +264,7 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
 
       const script2 = {
         name: 'Script2',
+        dispose: vi.fn(),
         onSelectStart: vi.fn(),
       } as unknown as Script;
 
@@ -294,6 +302,7 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
 
       const script1 = {
         name: 'Script1',
+        dispose: vi.fn(),
         physicsStep: vi.fn().mockImplementation(() => {
           throw new Error('physicsStep crashed');
         }),
@@ -301,6 +310,7 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
 
       const script2 = {
         name: 'Script2',
+        dispose: vi.fn(),
         physicsStep: vi.fn(),
       } as unknown as Script;
 
@@ -339,6 +349,7 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
 
       const script1 = {
         name: 'Script1',
+        dispose: vi.fn(),
         physicsStep: vi.fn().mockImplementation(() => {
           throw new Error('physicsStep crashed');
         }),
@@ -346,6 +357,7 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
 
       const script2 = {
         name: 'Script2',
+        dispose: vi.fn(),
         physicsStep: vi.fn(),
       } as unknown as Script;
 

--- a/src/core/Core.test.ts
+++ b/src/core/Core.test.ts
@@ -12,7 +12,10 @@ vi.hoisted(() => {
 import {Core} from './Core';
 import {Options} from './Options';
 import {Script} from './Script';
-import {ScriptsManager} from './components/ScriptsManager';
+import {
+  ScriptsManager,
+  ScriptsManagerEventType,
+} from './components/ScriptsManager';
 
 function scripts(core: Core): ScriptsManager {
   return (core as unknown as {scriptsManager: ScriptsManager}).scriptsManager;
@@ -83,14 +86,17 @@ describe('Core lifecycle', () => {
     await disposal;
   });
 
-  it('reports script callback errors through Core', async () => {
+  it('reports script callback errors through ScriptsManager events', async () => {
     const script = new Script();
     vi.spyOn(script, 'update').mockImplementation(() => {
       throw new Error('update failed');
     });
     vi.spyOn(console, 'error').mockImplementation(() => {});
     const listener = vi.fn();
-    core.onScriptError(listener);
+    core.scriptsManager.addEventListener(
+      ScriptsManagerEventType.EXCEPTION,
+      listener
+    );
     await scripts(core).initScript(script);
 
     scripts(core).update(0, {} as XRFrame);

--- a/src/core/Core.test.ts
+++ b/src/core/Core.test.ts
@@ -1,417 +1,105 @@
-import {
-  describe,
-  it,
-  expect,
-  vi,
-  beforeEach,
-  afterEach,
-  MockInstance,
-} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
-// Stub AudioContext globally before importing any modules that rely on THREE.AudioListener.
-// Use plain JS functions rather than vi.fn() to prevent vi.restoreAllMocks() from clearing the mock implementation.
 vi.hoisted(() => {
   vi.stubGlobal('AudioContext', function () {
     return {
-      createGain: function () {
-        return {
-          connect: function () {},
-        };
-      },
+      createGain: () => ({connect: () => {}}),
       destination: {},
     };
   });
 });
 
-import * as THREE from 'three';
 import {Core} from './Core';
 import {Options} from './Options';
-import {Script, SelectEvent} from './Script';
-import {Controller} from '../input/Controller';
-import {Physics} from '../physics/Physics';
-import {
-  ScriptsManagerEventType,
-  ScriptsManagerEventMap,
-} from './components/ScriptsManager';
+import {Script} from './Script';
+import {ScriptsManager} from './components/ScriptsManager';
 
-type ExceptionEvent =
-  ScriptsManagerEventMap[ScriptsManagerEventType.EXCEPTION] & {type: string};
+function scripts(core: Core): ScriptsManager {
+  return (core as unknown as {scriptsManager: ScriptsManager}).scriptsManager;
+}
 
-describe('Core and ScriptsManager exception handling via EventDispatcher', () => {
+describe('Core lifecycle', () => {
   let core: Core;
-  let consoleErrorSpy: MockInstance;
 
   beforeEach(async () => {
-    // Reset Core singleton to ensure fresh state for each test
     await Core.instance?.dispose();
     Core.instance = undefined;
     core = new Core();
     core.options = new Options();
-
-    // Mock core dependencies/methods to isolate update and physics loops
-    core.renderer = {
-      render: vi.fn(),
-      xr: {
-        enabled: false,
-        getDepthSensingMesh: vi.fn(),
-        setReferenceSpaceType: vi.fn(),
-      },
-    } as unknown as THREE.WebGLRenderer;
-    core.depth.update = vi.fn();
-    core.input.update = vi.fn();
-    core.scriptsManager.syncScriptsWithScene = vi.fn();
-    core.waitFrame.onFrame = vi.fn();
-    core.screenshotSynthesizer.onAfterRender = vi.fn();
-
-    // Spy on console.error
-    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  describe('catchScriptExceptions defaults to true', () => {
-    it('should have catchScriptExceptions enabled by default', () => {
-      expect(core.options.catchScriptExceptions).toBe(true);
-    });
-  });
-
-  describe('update loop via ScriptsManager', () => {
-    it('should catch script exceptions, emit exception event, and continue updating other scripts when enabled', () => {
-      const script1 = {
-        name: 'Script1',
-        ux: {reset: vi.fn()},
-        dispose: vi.fn(),
-        update: vi.fn().mockImplementation(() => {
-          throw new Error('Script1 crashed');
-        }),
-      } as unknown as Script;
-
-      const script2 = {
-        name: 'Script2',
-        ux: {reset: vi.fn()},
-        dispose: vi.fn(),
-        update: vi.fn(),
-      } as unknown as Script;
-
-      core.scriptsManager.scripts = new Set([script1, script2]);
-
-      const events: ExceptionEvent[] = [];
-      core.scriptsManager.addEventListener(
-        ScriptsManagerEventType.EXCEPTION,
-        (event) => {
-          events.push(event);
-        }
-      );
-
-      expect(() => {
-        (
-          core as unknown as {update: (time: number, frame: XRFrame) => void}
-        ).update(1000, {} as XRFrame);
-      }).not.toThrow();
-
-      // Both scripts had their UX reset
-      expect(script1.ux.reset).toHaveBeenCalled();
-      expect(script2.ux.reset).toHaveBeenCalled();
-
-      // Both updates were attempted
-      expect(script1.update).toHaveBeenCalled();
-      expect(script2.update).toHaveBeenCalled();
-
-      // console.error was called with the error details
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining('An error occurred in script Script1 [update]'),
-        expect.any(Error)
-      );
-
-      // EXCEPTION event is dispatched with correct payload
-      expect(events.length).toBe(1);
-      expect(events[0]).toEqual(
-        expect.objectContaining({
-          type: ScriptsManagerEventType.EXCEPTION,
-          scriptName: 'Script1',
-          context: 'update',
-          error: expect.any(Error),
-          timestamp: expect.any(Number),
+  it('shares one initialization and treats disposal as terminal', async () => {
+    let finishInitialization: (() => void) | undefined;
+    vi.spyOn(
+      core as unknown as {initialize(options: Options): Promise<void>},
+      'initialize'
+    ).mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishInitialization = resolve;
         })
-      );
-    });
+    );
 
-    it('should propagate script exceptions immediately and NOT emit exception event when disabled', () => {
-      core.scriptsManager.catchExceptions = false;
+    const first = core.init(core.options);
+    const second = core.init(core.options);
+    expect(second).toBe(first);
 
-      const script1 = {
-        name: 'Script1',
-        dispose: vi.fn(),
-        update: vi.fn().mockImplementation(() => {
-          throw new Error('Script1 crashed');
-        }),
-      } as unknown as Script;
+    await vi.waitFor(() => expect(finishInitialization).toBeDefined());
+    finishInitialization?.();
+    await first;
 
-      const script2 = {
-        name: 'Script2',
-        dispose: vi.fn(),
-        update: vi.fn(),
-      } as unknown as Script;
-
-      core.scriptsManager.scripts = new Set([script1, script2]);
-
-      const events: ExceptionEvent[] = [];
-      core.scriptsManager.addEventListener(
-        ScriptsManagerEventType.EXCEPTION,
-        (event) => {
-          events.push(event);
-        }
-      );
-
-      expect(() => {
-        (
-          core as unknown as {update: (time: number, frame: XRFrame) => void}
-        ).update(1000, {} as XRFrame);
-      }).toThrow('Script1 crashed');
-
-      // script2.update should not be called since script1.update threw and stopped the loop
-      expect(script1.update).toHaveBeenCalled();
-      expect(script2.update).not.toHaveBeenCalled();
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
-
-      // EXCEPTION event is not emitted
-      expect(events.length).toBe(0);
-    });
-
-    it('should catch and emit individual events for exceptions in UX reset, onSelecting, and onSqueezing', () => {
-      const script1 = {
-        name: 'Script1',
-        ux: {
-          reset: vi.fn().mockImplementation(() => {
-            throw new Error('UX reset crashed');
-          }),
-        },
-        dispose: vi.fn(),
-        onSelecting: vi.fn().mockImplementation(() => {
-          throw new Error('onSelecting crashed');
-        }),
-        onSqueezing: vi.fn().mockImplementation(() => {
-          throw new Error('onSqueezing crashed');
-        }),
-        update: vi.fn(),
-      } as unknown as Script;
-
-      const script2 = {
-        name: 'Script2',
-        ux: {reset: vi.fn()},
-        dispose: vi.fn(),
-        onSelecting: vi.fn(),
-        onSqueezing: vi.fn(),
-        update: vi.fn(),
-      } as unknown as Script;
-
-      core.scriptsManager.scripts = new Set([script1, script2]);
-
-      // Set up mock controllers to trigger selection and squeezing callbacks
-      core.input.controllers = [
-        {
-          userData: {
-            selected: true,
-            squeezing: true,
-          },
-        },
-      ] as unknown as Controller[];
-
-      const events: ExceptionEvent[] = [];
-      core.scriptsManager.addEventListener(
-        ScriptsManagerEventType.EXCEPTION,
-        (event) => {
-          events.push(event);
-        }
-      );
-
-      expect(() => {
-        (
-          core as unknown as {update: (time: number, frame: XRFrame) => void}
-        ).update(1000, {} as XRFrame);
-      }).not.toThrow();
-
-      // script2 calls should still execute successfully
-      expect(script2.ux.reset).toHaveBeenCalled();
-      expect(script2.onSelecting).toHaveBeenCalled();
-      expect(script2.onSqueezing).toHaveBeenCalled();
-      expect(script2.update).toHaveBeenCalled();
-
-      // console.error is called three times
-      expect(consoleErrorSpy).toHaveBeenCalledTimes(3);
-
-      // Three events are dispatched
-      expect(events.length).toBe(3);
-      expect(events.map((e) => e.context)).toEqual([
-        'ux.reset',
-        'onSelecting',
-        'onSqueezing',
-      ]);
-    });
+    const firstDisposal = core.dispose();
+    expect(core.dispose()).toBe(firstDisposal);
+    await firstDisposal;
+    await expect(core.init(core.options)).rejects.toThrow(
+      'Core cannot initialize after disposal has completed.'
+    );
   });
 
-  describe('event callbacks robustness', () => {
-    it('should catch and emit exceptions inside callSelectStart without crashing other scripts', () => {
-      const script1 = {
-        name: 'Script1',
-        dispose: vi.fn(),
-        onSelectStart: vi.fn().mockImplementation(() => {
-          throw new Error('SelectStart error');
-        }),
-      } as unknown as Script;
+  it('stops initialization when disposal starts', async () => {
+    let finishInitialization: (() => void) | undefined;
+    vi.spyOn(
+      core as unknown as {initialize(options: Options): Promise<void>},
+      'initialize'
+    ).mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishInitialization = resolve;
+        })
+    );
 
-      const script2 = {
-        name: 'Script2',
-        dispose: vi.fn(),
-        onSelectStart: vi.fn(),
-      } as unknown as Script;
+    const initialization = core.init(core.options);
+    await vi.waitFor(() => expect(finishInitialization).toBeDefined());
+    const disposal = core.dispose();
+    finishInitialization?.();
 
-      core.scriptsManager.scripts = new Set([script1, script2]);
-
-      const events: ExceptionEvent[] = [];
-      core.scriptsManager.addEventListener(
-        ScriptsManagerEventType.EXCEPTION,
-        (event) => {
-          events.push(event);
-        }
-      );
-
-      expect(() => {
-        core.scriptsManager.callSelectStart({} as unknown as SelectEvent);
-      }).not.toThrow();
-
-      expect(script1.onSelectStart).toHaveBeenCalled();
-      expect(script2.onSelectStart).toHaveBeenCalled();
-
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[onSelectStart]'),
-        expect.any(Error)
-      );
-      expect(events.length).toBe(1);
-      expect(events[0].context).toBe('onSelectStart');
-    });
+    await expect(initialization).rejects.toThrow(
+      'Core initialization stopped because Core is disposing.'
+    );
+    await disposal;
   });
 
-  describe('physics step', () => {
-    it('should catch and emit physicsStep exceptions without crashing physics simulation', () => {
-      core.physics = {
-        physicsStep: vi.fn(),
-      } as unknown as Physics;
-
-      const script1 = {
-        name: 'Script1',
-        dispose: vi.fn(),
-        physicsStep: vi.fn().mockImplementation(() => {
-          throw new Error('physicsStep crashed');
-        }),
-      } as unknown as Script;
-
-      const script2 = {
-        name: 'Script2',
-        dispose: vi.fn(),
-        physicsStep: vi.fn(),
-      } as unknown as Script;
-
-      core.scriptsManager.scripts = new Set([script1, script2]);
-
-      const events: ExceptionEvent[] = [];
-      core.scriptsManager.addEventListener(
-        ScriptsManagerEventType.EXCEPTION,
-        (event) => {
-          events.push(event);
-        }
-      );
-
-      expect(() => {
-        (core as unknown as {physicsStep: () => void}).physicsStep();
-      }).not.toThrow();
-
-      expect(script1.physicsStep).toHaveBeenCalled();
-      expect(script2.physicsStep).toHaveBeenCalled();
-
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'An error occurred in script Script1 [physicsStep]'
-        ),
-        expect.any(Error)
-      );
-      expect(events.length).toBe(1);
-      expect(events[0].context).toBe('physicsStep');
+  it('reports script callback errors through Core', async () => {
+    const script = new Script();
+    vi.spyOn(script, 'update').mockImplementation(() => {
+      throw new Error('update failed');
     });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const listener = vi.fn();
+    core.onScriptError(listener);
+    await scripts(core).initScript(script);
 
-    it('should propagate physicsStep exceptions immediately when disabled', () => {
-      core.scriptsManager.catchExceptions = false;
-      core.physics = {
-        physicsStep: vi.fn(),
-      } as unknown as Physics;
+    scripts(core).update(0, {} as XRFrame);
 
-      const script1 = {
-        name: 'Script1',
-        dispose: vi.fn(),
-        physicsStep: vi.fn().mockImplementation(() => {
-          throw new Error('physicsStep crashed');
-        }),
-      } as unknown as Script;
-
-      const script2 = {
-        name: 'Script2',
-        dispose: vi.fn(),
-        physicsStep: vi.fn(),
-      } as unknown as Script;
-
-      core.scriptsManager.scripts = new Set([script1, script2]);
-
-      const events: ExceptionEvent[] = [];
-      core.scriptsManager.addEventListener(
-        ScriptsManagerEventType.EXCEPTION,
-        (event) => {
-          events.push(event);
-        }
-      );
-
-      expect(() => {
-        (core as unknown as {physicsStep: () => void}).physicsStep();
-      }).toThrow('physicsStep crashed');
-
-      expect(script1.physicsStep).toHaveBeenCalled();
-      expect(script2.physicsStep).not.toHaveBeenCalled();
-      expect(events.length).toBe(0);
-    });
-  });
-
-  describe('simulator startup', () => {
-    it('shares one in-flight simulator start and ignores later starts once running', async () => {
-      let finishInit: (() => void) | undefined;
-      core.scriptsManager.initScript = vi.fn(
-        () =>
-          new Promise<void>((resolve) => {
-            finishInit = resolve;
-          })
-      );
-      core.scriptsManager.onSimulatorStarted = vi.fn();
-
-      const startSimulator = (
-        core as unknown as {startSimulator: () => Promise<void>}
-      ).startSimulator;
-
-      const firstStart = startSimulator();
-      const secondStart = startSimulator();
-
-      expect(core.scriptsManager.initScript).toHaveBeenCalledTimes(1);
-      expect(core.simulatorRunning).toBe(false);
-
-      finishInit?.();
-      await Promise.all([firstStart, secondStart]);
-
-      expect(core.simulatorRunning).toBe(true);
-      expect(core.scriptsManager.onSimulatorStarted).toHaveBeenCalledTimes(1);
-
-      await startSimulator();
-
-      expect(core.scriptsManager.initScript).toHaveBeenCalledTimes(1);
-      expect(core.scriptsManager.onSimulatorStarted).toHaveBeenCalledTimes(1);
-    });
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: 'update',
+        error: expect.objectContaining({message: 'update failed'}),
+      })
+    );
   });
 });

--- a/src/core/Core.test.ts
+++ b/src/core/Core.test.ts
@@ -141,7 +141,6 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
 
       const script1 = {
         name: 'Script1',
-        ux: {reset: vi.fn()},
         update: vi.fn().mockImplementation(() => {
           throw new Error('Script1 crashed');
         }),
@@ -149,7 +148,6 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
 
       const script2 = {
         name: 'Script2',
-        ux: {reset: vi.fn()},
         update: vi.fn(),
       } as unknown as Script;
 

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -51,6 +51,13 @@ import {User} from './User';
 import {PermissionsManager} from './components/PermissionsManager';
 import {XRSystems} from './components/XRSystems';
 
+type CoreLifecycleState =
+  | 'new'
+  | 'initializing'
+  | 'running'
+  | 'disposing'
+  | 'disposed';
+
 /**
  * Core is the central engine of the XR Blocks framework, acting as a
  * singleton manager for all XR subsystems. Its primary goal is to abstract
@@ -108,6 +115,8 @@ export class Core {
   /** Manages drag-and-drop interactions. */
   dragManager = new DragManager();
   private physicsInterval?: ReturnType<typeof setInterval>;
+  private lifecycleState: CoreLifecycleState = 'new';
+  private initializationPromise?: Promise<void>;
   private disposalPromise?: Promise<void>;
 
   /** Manages real-world understanding: planes, meshes, objects, and sounds. */
@@ -252,6 +261,9 @@ export class Core {
 
   dispose(): Promise<void> {
     if (this.disposalPromise) return this.disposalPromise;
+    if (this.lifecycleState === 'disposed') return Promise.resolve();
+
+    this.lifecycleState = 'disposing';
 
     if (this.physicsInterval !== undefined) {
       clearInterval(this.physicsInterval);
@@ -283,6 +295,7 @@ export class Core {
       }
     }
 
+    this.lifecycleState = 'disposed';
     if (firstError !== undefined) throw firstError;
   }
 
@@ -293,14 +306,54 @@ export class Core {
    * @param options - Configuration options for the
    * session.
    */
-  async init(options = new Options()) {
+  init(options = new Options()): Promise<void> {
+    if (
+      this.lifecycleState === 'initializing' ||
+      this.lifecycleState === 'running'
+    ) {
+      return this.initializationPromise!;
+    }
+    if (
+      this.lifecycleState === 'disposing' ||
+      this.lifecycleState === 'disposed'
+    ) {
+      return Promise.reject(
+        new Error(
+          `Core cannot initialize after disposal has ${
+            this.lifecycleState === 'disposing' ? 'started' : 'completed'
+          }.`
+        )
+      );
+    }
+
+    this.lifecycleState = 'initializing';
+    this.initializationPromise = Promise.resolve().then(() =>
+      this.runInitialization(options)
+    );
+    return this.initializationPromise;
+  }
+
+  private async runInitialization(options: Options): Promise<void> {
     try {
       await this.initialize(options);
-      markDebugReady(this);
     } catch (error) {
       markDebugFailed(this, error);
+      if (this.lifecycleState === 'initializing') {
+        try {
+          await this.dispose();
+        } catch (cleanupError) {
+          console.error(
+            'Core cleanup failed after initialization failed.',
+            cleanupError
+          );
+        }
+      }
       throw error;
     }
+
+    this.assertInitializing();
+    this.lifecycleState = 'running';
+    markDebugReady(this);
   }
 
   private async initialize(options: Options) {
@@ -464,6 +517,7 @@ export class Core {
       this.physics = new Physics();
       this.registry.register(this.physics);
       await this.physics.init({physicsOptions: options.physics});
+      this.assertInitializing();
 
       if (options.depth.enabled) {
         this.depth.depthMesh?.initRapierPhysics(
@@ -518,6 +572,7 @@ export class Core {
     );
 
     await this.webXRSessionManager.initialize();
+    this.assertInitializing();
 
     // Sets up postprocessing effects.
     if (options.usePostprocessing) {
@@ -531,9 +586,11 @@ export class Core {
       this.xrSystemsGroup.add(this.ai);
       // Manually init the script in case other scripts rely on it.
       await this.scriptsManager.initScript(this.ai);
+      this.assertInitializing();
     }
 
     await this.scriptsManager.syncScriptsWithScene(this.scene);
+    this.assertInitializing();
 
     this.renderer.setAnimationLoop(this.update);
 
@@ -550,6 +607,7 @@ export class Core {
 
     if (shouldAutostartSimulator) {
       await this.startSimulator();
+      this.assertInitializing();
     }
 
     if (!loadingSpinnerManager.isLoading) {
@@ -652,13 +710,16 @@ export class Core {
    * @param session - The newly started WebXR session.
    */
   private async onXRSessionStarted(session: XRSession) {
+    if (!this.isLifecycleActive()) return;
     if (this.options.deviceCamera?.enabled) {
       await this.deviceCamera!.init();
+      if (!this.isLifecycleActive()) return;
     }
     this.scriptsManager.onXRSessionStarted(session);
   }
 
   private startSimulator = async () => {
+    this.assertLifecycleActive('start the simulator');
     if (this.simulatorRunning) return;
     if (this.startingSimulator) return this.startingSimulator;
 
@@ -666,6 +727,7 @@ export class Core {
       this.xrButton?.domElement.remove();
       this.xrSystemsGroup.add(this.simulator);
       await this.scriptsManager.initScript(this.simulator);
+      this.assertLifecycleActive('finish simulator startup');
       this.onSimulatorStarted();
     })();
 
@@ -681,8 +743,30 @@ export class Core {
    * scripts.
    */
   private onXRSessionEnded = () => {
+    if (!this.isLifecycleActive()) return;
     this.scriptsManager.onXRSessionEnded();
   };
+
+  private isLifecycleActive(): boolean {
+    return (
+      this.lifecycleState === 'initializing' ||
+      this.lifecycleState === 'running'
+    );
+  }
+
+  private assertInitializing(): void {
+    if (this.lifecycleState === 'initializing') return;
+    throw new Error(
+      `Core initialization stopped because Core is ${this.lifecycleState}.`
+    );
+  }
+
+  private assertLifecycleActive(operation: string): void {
+    if (this.isLifecycleActive()) return;
+    throw new Error(
+      `Core cannot ${operation} while it is ${this.lifecycleState}.`
+    );
+  }
 
   /**
    * Lifecycle callback executed when the desktop simulator starts. Notifies

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -35,7 +35,7 @@ import {MeshDetectionOptions} from '../world/mesh/MeshDetectionOptions';
 import {Registry} from './components/Registry';
 import {ScreenshotSynthesizer} from './components/ScreenshotSynthesizer';
 import {SimulationTimer} from './components/SimulationTimer';
-import {type ScriptError, ScriptsManager} from './components/ScriptsManager';
+import {ScriptsManager} from './components/ScriptsManager';
 import {WaitFrame} from './components/WaitFrame';
 import {
   WebXRSessionEventType,
@@ -57,9 +57,6 @@ type CoreLifecycleState =
   | 'running'
   | 'disposing'
   | 'disposed';
-
-export type ScriptErrorListener = (event: ScriptError) => void;
-export type {ScriptError};
 
 /**
  * Core is the central engine of the XR Blocks framework, acting as a
@@ -163,18 +160,12 @@ export class Core {
   gestureRecognition?: GestureRecognition;
   transition?: XRTransition;
   currentFrame?: XRFrame;
-  private readonly scriptErrorListeners = new Set<ScriptErrorListener>();
-  private readonly scriptsManager = new ScriptsManager(
-    async (script: Script) => {
-      await callInitWithDependencyInjection(script, this.registry, this);
-      if (this.physics) {
-        await script.initPhysics(this.physics);
-      }
-    },
-    (event) => {
-      for (const listener of this.scriptErrorListeners) listener(event);
+  scriptsManager = new ScriptsManager(async (script: Script) => {
+    await callInitWithDependencyInjection(script, this.registry, this);
+    if (this.physics) {
+      await script.initPhysics(this.physics);
     }
-  );
+  });
   renderSceneOverride?: (
     renderer: THREE.WebGLRenderer,
     scene: THREE.Scene,
@@ -271,16 +262,11 @@ export class Core {
     this.registry.register(this.dragManager);
     this.registry.register(this.simulator);
     this.registry.register(this.simulator.navMesh);
+    this.registry.register(this.scriptsManager);
     this.registry.register(this.depth);
     this.registry.register(this.world);
     this.registry.register(this.context);
     this.registry.register(this.xrSystemsGroup);
-  }
-
-  /** Observes errors reported by Script lifecycle and callback execution. */
-  onScriptError(listener: ScriptErrorListener): () => void {
-    this.scriptErrorListeners.add(listener);
-    return () => this.scriptErrorListeners.delete(listener);
   }
 
   dispose(): Promise<void> {
@@ -313,7 +299,6 @@ export class Core {
       },
       () => this.disposeWebXRSessionManager(),
       () => this.scriptsManager.dispose(),
-      () => this.scriptErrorListeners.clear(),
       () => {
         this.simulatorRunning = false;
       },

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -107,6 +107,8 @@ export class Core {
 
   /** Manages drag-and-drop interactions. */
   dragManager = new DragManager();
+  private physicsInterval?: ReturnType<typeof setInterval>;
+  private disposalPromise?: Promise<void>;
 
   /** Manages real-world understanding: planes, meshes, objects, and sounds. */
   world = new World();
@@ -248,9 +250,40 @@ export class Core {
     this.registry.register(this.xrSystemsGroup);
   }
 
-  dispose() {
-    this.input.dispose();
+  dispose(): Promise<void> {
+    if (this.disposalPromise) return this.disposalPromise;
+
+    if (this.physicsInterval !== undefined) {
+      clearInterval(this.physicsInterval);
+      this.physicsInterval = undefined;
+    }
+    if (typeof this._renderer?.setAnimationLoop === 'function') {
+      this._renderer.setAnimationLoop(null);
+    }
     window.removeEventListener('resize', this.onWindowResize);
+
+    const scriptsDisposal = this.scriptsManager.dispose();
+    this.disposalPromise = this.finishDisposal(scriptsDisposal);
+    return this.disposalPromise;
+  }
+
+  private async finishDisposal(scriptsDisposal: Promise<void>): Promise<void> {
+    let firstError: unknown;
+    try {
+      await scriptsDisposal;
+    } catch (error: unknown) {
+      firstError = error;
+    }
+
+    for (const dispose of [() => this.input.dispose()]) {
+      try {
+        dispose();
+      } catch (error: unknown) {
+        firstError ??= error;
+      }
+    }
+
+    if (firstError !== undefined) throw firstError;
   }
 
   /**
@@ -505,7 +538,10 @@ export class Core {
     this.renderer.setAnimationLoop(this.update);
 
     if (this.physics) {
-      setInterval(this.physicsStep, 1000 * this.physics.timestep);
+      this.physicsInterval = setInterval(
+        this.physicsStep,
+        1000 * this.physics.timestep
+      );
     }
 
     if (this.options.reticles.enabled) {

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -35,7 +35,7 @@ import {MeshDetectionOptions} from '../world/mesh/MeshDetectionOptions';
 import {Registry} from './components/Registry';
 import {ScreenshotSynthesizer} from './components/ScreenshotSynthesizer';
 import {SimulationTimer} from './components/SimulationTimer';
-import {ScriptsManager} from './components/ScriptsManager';
+import {type ScriptError, ScriptsManager} from './components/ScriptsManager';
 import {WaitFrame} from './components/WaitFrame';
 import {
   WebXRSessionEventType,
@@ -57,6 +57,9 @@ type CoreLifecycleState =
   | 'running'
   | 'disposing'
   | 'disposed';
+
+export type ScriptErrorListener = (event: ScriptError) => void;
+export type {ScriptError};
 
 /**
  * Core is the central engine of the XR Blocks framework, acting as a
@@ -115,6 +118,7 @@ export class Core {
   /** Manages drag-and-drop interactions. */
   dragManager = new DragManager();
   private physicsInterval?: ReturnType<typeof setInterval>;
+  private rendererContainer?: HTMLDivElement;
   private lifecycleState: CoreLifecycleState = 'new';
   private initializationPromise?: Promise<void>;
   private disposalPromise?: Promise<void>;
@@ -129,10 +133,19 @@ export class Core {
   textureLoader = new THREE.TextureLoader();
 
   private webXRSettings: XRSessionInit = {};
+  private shouldAutostartSimulator = false;
 
   /** Whether the XR simulator is currently active. */
   simulatorRunning = false;
   private startingSimulator?: Promise<void>;
+  private onWebXRSessionStarted = (event: {session: XRSession}) => {
+    void this.onXRSessionStarted(event.session);
+  };
+  private onWebXRUnsupported = () => {
+    if (!this.options.enableSimulator) return;
+    this.xrButton?.domElement.remove();
+    this.shouldAutostartSimulator = true;
+  };
 
   private _isPaused = false;
   private isSteppingFrame = false;
@@ -150,12 +163,18 @@ export class Core {
   gestureRecognition?: GestureRecognition;
   transition?: XRTransition;
   currentFrame?: XRFrame;
-  scriptsManager = new ScriptsManager(async (script: Script) => {
-    await callInitWithDependencyInjection(script, this.registry, this);
-    if (this.physics) {
-      await script.initPhysics(this.physics);
+  private readonly scriptErrorListeners = new Set<ScriptErrorListener>();
+  private readonly scriptsManager = new ScriptsManager(
+    async (script: Script) => {
+      await callInitWithDependencyInjection(script, this.registry, this);
+      if (this.physics) {
+        await script.initPhysics(this.physics);
+      }
+    },
+    (event) => {
+      for (const listener of this.scriptErrorListeners) listener(event);
     }
-  });
+  );
   renderSceneOverride?: (
     renderer: THREE.WebGLRenderer,
     scene: THREE.Scene,
@@ -252,11 +271,16 @@ export class Core {
     this.registry.register(this.dragManager);
     this.registry.register(this.simulator);
     this.registry.register(this.simulator.navMesh);
-    this.registry.register(this.scriptsManager);
     this.registry.register(this.depth);
     this.registry.register(this.world);
     this.registry.register(this.context);
     this.registry.register(this.xrSystemsGroup);
+  }
+
+  /** Observes errors reported by Script lifecycle and callback execution. */
+  onScriptError(listener: ScriptErrorListener): () => void {
+    this.scriptErrorListeners.add(listener);
+    return () => this.scriptErrorListeners.delete(listener);
   }
 
   dispose(): Promise<void> {
@@ -264,32 +288,65 @@ export class Core {
     if (this.lifecycleState === 'disposed') return Promise.resolve();
 
     this.lifecycleState = 'disposing';
-
-    if (this.physicsInterval !== undefined) {
-      clearInterval(this.physicsInterval);
-      this.physicsInterval = undefined;
-    }
-    if (typeof this._renderer?.setAnimationLoop === 'function') {
-      this._renderer.setAnimationLoop(null);
-    }
-    window.removeEventListener('resize', this.onWindowResize);
-
-    const scriptsDisposal = this.scriptsManager.dispose();
-    this.disposalPromise = this.finishDisposal(scriptsDisposal);
+    this.disposalPromise = this.finishDisposal();
     return this.disposalPromise;
   }
 
-  private async finishDisposal(scriptsDisposal: Promise<void>): Promise<void> {
+  private async finishDisposal(): Promise<void> {
     let firstError: unknown;
-    try {
-      await scriptsDisposal;
-    } catch (error: unknown) {
-      firstError = error;
-    }
+    const cleanups: Array<() => void | Promise<void>> = [
+      () => {
+        if (this.physicsInterval === undefined) return;
+        clearInterval(this.physicsInterval);
+        this.physicsInterval = undefined;
+      },
+      () => {
+        if (typeof this._renderer?.setAnimationLoop === 'function') {
+          this._renderer.setAnimationLoop(null);
+        }
+      },
+      () => window.removeEventListener('resize', this.onWindowResize),
+      () => {
+        const button = this.xrButton;
+        this.xrButton = undefined;
+        button?.dispose();
+      },
+      () => this.disposeWebXRSessionManager(),
+      () => this.scriptsManager.dispose(),
+      () => this.scriptErrorListeners.clear(),
+      () => {
+        this.simulatorRunning = false;
+      },
+      () => this.input.dispose(),
+      () => {
+        const camera = this.deviceCamera;
+        this.deviceCamera = undefined;
+        camera?.dispose();
+      },
+      () => {
+        const effects = this.effects;
+        this.effects = undefined;
+        effects?.dispose();
+      },
+      () => {
+        const physics = this.physics;
+        this.physics = undefined;
+        physics?.dispose();
+      },
+      () => {
+        const renderer = this._renderer;
+        this._renderer = undefined;
+        renderer?.dispose();
+      },
+      () => {
+        this.rendererContainer?.remove();
+        this.rendererContainer = undefined;
+      },
+    ];
 
-    for (const dispose of [() => this.input.dispose()]) {
+    for (const cleanup of cleanups) {
       try {
-        dispose();
+        await cleanup();
       } catch (error: unknown) {
         firstError ??= error;
       }
@@ -297,6 +354,25 @@ export class Core {
 
     this.lifecycleState = 'disposed';
     if (firstError !== undefined) throw firstError;
+  }
+
+  private async disposeWebXRSessionManager(): Promise<void> {
+    const manager = this.webXRSessionManager;
+    if (!manager) return;
+    this.webXRSessionManager = undefined;
+    manager.removeEventListener(
+      WebXRSessionEventType.SESSION_START,
+      this.onWebXRSessionStarted
+    );
+    manager.removeEventListener(
+      WebXRSessionEventType.SESSION_END,
+      this.onXRSessionEnded
+    );
+    manager.removeEventListener(
+      WebXRSessionEventType.UNSUPPORTED,
+      this.onWebXRUnsupported
+    );
+    await manager.dispose();
   }
 
   /**
@@ -419,9 +495,9 @@ export class Core {
     window.addEventListener('resize', this.onWindowResize);
 
     if (!options.canvas) {
-      const xrContainer = document.createElement('div');
-      document.body.appendChild(xrContainer);
-      xrContainer.appendChild(this.renderer.domElement);
+      this.rendererContainer = document.createElement('div');
+      document.body.appendChild(this.rendererContainer);
+      this.rendererContainer.appendChild(this.renderer.domElement);
     }
 
     this.options = options;
@@ -534,7 +610,7 @@ export class Core {
     );
     this.webXRSessionManager.addEventListener(
       WebXRSessionEventType.SESSION_START,
-      (event) => this.onXRSessionStarted(event.session)
+      this.onWebXRSessionStarted
     );
     this.webXRSessionManager.addEventListener(
       WebXRSessionEventType.SESSION_END,
@@ -542,9 +618,9 @@ export class Core {
     );
 
     // Sets up xrButton.
-    let shouldAutostartSimulator =
+    this.shouldAutostartSimulator =
       this.options.xrButton.alwaysAutostartSimulator;
-    if (!shouldAutostartSimulator && options.xrButton.enabled) {
+    if (!this.shouldAutostartSimulator && options.xrButton.enabled) {
       this.xrButton = new XRButton(
         this.webXRSessionManager,
         this.permissionsManager,
@@ -563,12 +639,7 @@ export class Core {
 
     this.webXRSessionManager.addEventListener(
       WebXRSessionEventType.UNSUPPORTED,
-      () => {
-        if (this.options.enableSimulator) {
-          this.xrButton?.domElement.remove();
-          shouldAutostartSimulator = true;
-        }
-      }
+      this.onWebXRUnsupported
     );
 
     await this.webXRSessionManager.initialize();
@@ -605,7 +676,7 @@ export class Core {
       this.input.addReticles();
     }
 
-    if (shouldAutostartSimulator) {
+    if (this.shouldAutostartSimulator) {
       await this.startSimulator();
       this.assertInitializing();
     }
@@ -724,7 +795,8 @@ export class Core {
     if (this.startingSimulator) return this.startingSimulator;
 
     this.startingSimulator = (async () => {
-      this.xrButton?.domElement.remove();
+      this.xrButton?.dispose();
+      this.xrButton = undefined;
       this.xrSystemsGroup.add(this.simulator);
       await this.scriptsManager.initScript(this.simulator);
       this.assertLifecycleActive('finish simulator startup');

--- a/src/core/Script.ts
+++ b/src/core/Script.ts
@@ -5,6 +5,7 @@ import type {Physics} from '../physics/Physics';
 import type {Injectable} from '../utils/DependencyInjection';
 import type {Constructor} from '../utils/Types';
 import {UX} from '../ux/UX';
+import {markDefaultScriptMethods} from './ScriptHooks';
 
 export interface SelectEvent {
   target: Controller;
@@ -49,7 +50,7 @@ export interface KeyEvent {
 export function ScriptMixin<TBase extends Constructor<THREE.Object3D>>(
   base: TBase
 ) {
-  return class extends base implements Injectable {
+  class MixedScript extends base implements Injectable {
     ux = new UX(this);
     isXRScript = true;
 
@@ -194,7 +195,10 @@ export function ScriptMixin<TBase extends Constructor<THREE.Object3D>>(
      * Called when the script is removed from the scene. Opposite of init.
      */
     dispose() {}
-  };
+  }
+
+  markDefaultScriptMethods(MixedScript.prototype);
+  return MixedScript;
 }
 
 /**

--- a/src/core/ScriptHooks.ts
+++ b/src/core/ScriptHooks.ts
@@ -1,0 +1,15 @@
+const defaultScriptMethods = new WeakSet<object>();
+
+/** Records the no-op methods supplied by one ScriptMixin base class. */
+export function markDefaultScriptMethods(prototype: object): void {
+  for (const name of Object.getOwnPropertyNames(prototype)) {
+    if (name === 'constructor') continue;
+    const method = Reflect.get(prototype, name);
+    if (typeof method === 'function') defaultScriptMethods.add(method);
+  }
+}
+
+/** Returns whether a Script method is supplied by ScriptMixin unchanged. */
+export function isDefaultScriptMethod(method: unknown): boolean {
+  return typeof method !== 'function' || defaultScriptMethods.has(method);
+}

--- a/src/core/components/ScriptsManager.test.ts
+++ b/src/core/components/ScriptsManager.test.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import {describe, expect, it, vi} from 'vitest';
 
 import {Script} from '../Script';
-import {ScriptsManager} from './ScriptsManager';
+import {ScriptsManager, ScriptsManagerEventType} from './ScriptsManager';
 
 describe('ScriptsManager lifecycle', () => {
   it('disposes active and pending script generations once', async () => {
@@ -72,8 +72,9 @@ describe('ScriptsManager lifecycle', () => {
   });
 
   it('isolates callback errors unless propagation is requested', () => {
+    const manager = new ScriptsManager(async () => {});
     const reportError = vi.fn();
-    const manager = new ScriptsManager(async () => {}, reportError);
+    manager.addEventListener(ScriptsManagerEventType.EXCEPTION, reportError);
     const first = new Script();
     const second = new Script();
     const visited: Script[] = [];
@@ -96,5 +97,24 @@ describe('ScriptsManager lifecycle', () => {
         throw new Error('callback failed again');
       })
     ).toThrow('callback failed again');
+  });
+
+  it('shares initialization and rejects initialization failures', async () => {
+    let rejectInitialization: ((error: Error) => void) | undefined;
+    const manager = new ScriptsManager(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectInitialization = reject;
+        })
+    );
+    const script = new Script();
+
+    const first = manager.initScript(script);
+    const second = manager.initScript(script);
+    expect(second).toBe(first);
+
+    await vi.waitFor(() => expect(rejectInitialization).toBeDefined());
+    rejectInitialization?.(new Error('initialization failed'));
+    await expect(first).rejects.toThrow('initialization failed');
   });
 });

--- a/src/core/components/ScriptsManager.test.ts
+++ b/src/core/components/ScriptsManager.test.ts
@@ -1,0 +1,100 @@
+import * as THREE from 'three';
+import {describe, expect, it, vi} from 'vitest';
+
+import {Script} from '../Script';
+import {ScriptsManager} from './ScriptsManager';
+
+describe('ScriptsManager lifecycle', () => {
+  it('disposes active and pending script generations once', async () => {
+    let finishPending: (() => void) | undefined;
+    const active = new Script();
+    const pending = new Script();
+    const manager = new ScriptsManager((script) =>
+      script === active
+        ? Promise.resolve()
+        : new Promise<void>((resolve) => {
+            finishPending = resolve;
+          })
+    );
+    const disposeActive = vi.spyOn(active, 'dispose');
+    const disposePending = vi.spyOn(pending, 'dispose');
+
+    await manager.initScript(active);
+    const initialization = manager.initScript(pending);
+    await vi.waitFor(() => expect(finishPending).toBeDefined());
+
+    const disposal = manager.dispose();
+    expect(manager.dispose()).toBe(disposal);
+    await vi.waitFor(() => expect(disposeActive).toHaveBeenCalledOnce());
+    expect(disposeActive).toHaveBeenCalledOnce();
+    expect(disposePending).not.toHaveBeenCalled();
+
+    finishPending?.();
+    await Promise.all([initialization, disposal]);
+    expect(disposePending).toHaveBeenCalledOnce();
+    await expect(manager.initScript(new Script())).rejects.toThrow(
+      'ScriptsManager has been disposed.'
+    );
+  });
+
+  it('disposes a stale initialization before reconnecting', async () => {
+    const resolvers: Array<() => void> = [];
+    const initialize = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+    const manager = new ScriptsManager(initialize);
+    const scene = new THREE.Scene();
+    const script = new Script();
+    const dispose = vi.spyOn(script, 'dispose');
+    const update = vi.spyOn(script, 'update');
+
+    scene.add(script);
+    const firstSync = manager.syncScriptsWithScene(scene);
+    await vi.waitFor(() => expect(resolvers).toHaveLength(1));
+    scene.remove(script);
+    const removalSync = manager.syncScriptsWithScene(scene);
+    scene.add(script);
+    const reconnectSync = manager.syncScriptsWithScene(scene);
+
+    resolvers[0]();
+    await vi.waitFor(() => expect(initialize).toHaveBeenCalledTimes(2));
+    expect(dispose).toHaveBeenCalledOnce();
+    manager.update(0, {} as XRFrame);
+    expect(update).not.toHaveBeenCalled();
+
+    resolvers[1]();
+    await Promise.all([firstSync, removalSync, reconnectSync]);
+    manager.update(0, {} as XRFrame);
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  it('isolates callback errors unless propagation is requested', () => {
+    const reportError = vi.fn();
+    const manager = new ScriptsManager(async () => {}, reportError);
+    const first = new Script();
+    const second = new Script();
+    const visited: Script[] = [];
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(
+      manager.callTargeted([first, second], 'update', (script) => {
+        if (script === first) throw new Error('callback failed');
+        visited.push(script);
+      })
+    ).toBe(false);
+    expect(visited).toEqual([second]);
+    expect(reportError).toHaveBeenCalledWith(
+      expect.objectContaining({context: 'update'})
+    );
+
+    manager.catchExceptions = false;
+    expect(() =>
+      manager.callTargeted([first], 'update', () => {
+        throw new Error('callback failed again');
+      })
+    ).toThrow('callback failed again');
+  });
+});

--- a/src/core/components/ScriptsManager.ts
+++ b/src/core/components/ScriptsManager.ts
@@ -6,6 +6,19 @@ import {isDefaultScriptMethod} from '../ScriptHooks';
 
 type MaybeScript = THREE.Object3D & {isXRScript?: boolean};
 
+export enum ScriptsManagerEventType {
+  EXCEPTION = 'exception',
+}
+
+export type ScriptsManagerEventMap = THREE.Object3DEventMap & {
+  [ScriptsManagerEventType.EXCEPTION]: {
+    scriptName: string;
+    context: string;
+    error: Error;
+    timestamp: number;
+  };
+};
+
 type GlobalScriptHook =
   | 'update'
   | 'physicsStep'
@@ -50,14 +63,7 @@ const GLOBAL_HOOKS = Object.freeze([
 const SCRIPT_READY = Promise.resolve();
 const NO_SCRIPT_CHANGES = Promise.resolve<PromiseSettledResult<void>[]>([]);
 
-export interface ScriptError {
-  readonly scriptName: string;
-  readonly context: string;
-  readonly error: Error;
-  readonly timestamp: number;
-}
-
-export class ScriptsManager {
+export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap> {
   private readonly activeScripts = new Set<Script>();
   private readonly hookScripts = new Map<GlobalScriptHook, Set<Script>>();
   private readonly pendingInitializations = new Map<
@@ -76,9 +82,10 @@ export class ScriptsManager {
   afterDispose?: (script: Script) => void;
 
   constructor(
-    private readonly initScriptFunction: (script: Script) => Promise<void>,
-    private readonly onScriptError?: (event: ScriptError) => void
-  ) {}
+    private readonly initScriptFunction: (script: Script) => Promise<void>
+  ) {
+    super();
+  }
 
   private handleException(error: Error, script: Script, context: string) {
     console.error(
@@ -88,7 +95,8 @@ export class ScriptsManager {
       error
     );
 
-    this.onScriptError?.({
+    this.dispatchEvent({
+      type: ScriptsManagerEventType.EXCEPTION,
       scriptName: script.name || script.constructor.name,
       context,
       error,
@@ -157,14 +165,15 @@ export class ScriptsManager {
     entry: PendingInitialization
   ): Promise<void> {
     let failed = false;
+    let initializationError: unknown;
     try {
       try {
         await this.initScriptFunction(entry.script);
       } catch (error: unknown) {
         failed = true;
+        initializationError = error;
         if (entry.connection === 'connected') {
           this.failedScripts.add(entry.script);
-          this.handleScriptError(error, entry.script, 'init');
         }
       }
 
@@ -183,6 +192,12 @@ export class ScriptsManager {
 
     if (entry.connection === 'reconnected') {
       await this.initScript(entry.script);
+      return;
+    }
+    if (initializationError !== undefined) {
+      throw initializationError instanceof Error
+        ? initializationError
+        : new Error(String(initializationError));
     }
   }
 

--- a/src/core/components/ScriptsManager.ts
+++ b/src/core/components/ScriptsManager.ts
@@ -73,6 +73,8 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
 
   /** Whether to catch all exceptions thrown by developer scripts. */
   catchExceptions = true;
+  beforeDispose?: (script: Script) => void;
+  afterDispose?: (script: Script) => void;
 
   constructor(private initScriptFunction: (script: Script) => Promise<void>) {
     super();
@@ -201,11 +203,26 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
   }
 
   private disposeScript(script: Script): void {
-    try {
-      script.dispose();
-    } catch (error: unknown) {
-      this.handleScriptError(error, script, 'dispose');
-    }
+    let firstError: Error | undefined;
+    const run = (context: string, callback: () => void): void => {
+      try {
+        callback();
+      } catch (error: unknown) {
+        const normalizedError =
+          error instanceof Error ? error : new Error(String(error));
+        if (this.catchExceptions) {
+          this.handleException(normalizedError, script, context);
+        } else {
+          firstError ??= normalizedError;
+        }
+      }
+    };
+
+    run('beforeDispose', () => this.beforeDispose?.(script));
+    run('dispose', () => script.dispose());
+    run('afterDispose', () => this.afterDispose?.(script));
+
+    if (firstError) throw firstError;
   }
 
   private checkScript = (object: THREE.Object3D): void => {

--- a/src/core/components/ScriptsManager.ts
+++ b/src/core/components/ScriptsManager.ts
@@ -47,21 +47,18 @@ const GLOBAL_HOOKS = Object.freeze([
   'onSimulatorStarted',
 ] as const satisfies readonly GlobalScriptHook[]);
 
-export enum ScriptsManagerEventType {
-  EXCEPTION = 'exception',
+const SCRIPT_READY = Promise.resolve();
+const NO_SCRIPT_CHANGES = Promise.resolve<PromiseSettledResult<void>[]>([]);
+
+export interface ScriptError {
+  readonly scriptName: string;
+  readonly context: string;
+  readonly error: Error;
+  readonly timestamp: number;
 }
 
-export type ScriptsManagerEventMap = THREE.Object3DEventMap & {
-  [ScriptsManagerEventType.EXCEPTION]: {
-    scriptName: string;
-    context: string;
-    error: Error;
-    timestamp: number;
-  };
-};
-
-export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap> {
-  private activeScripts = new Set<Script>();
+export class ScriptsManager {
+  private readonly activeScripts = new Set<Script>();
   private readonly hookScripts = new Map<GlobalScriptHook, Set<Script>>();
   private readonly pendingInitializations = new Map<
     Script,
@@ -78,19 +75,10 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
   beforeDispose?: (script: Script) => void;
   afterDispose?: (script: Script) => void;
 
-  constructor(private initScriptFunction: (script: Script) => Promise<void>) {
-    super();
-  }
-
-  /** The set of all currently initialized scripts. */
-  get scripts(): Set<Script> {
-    return this.activeScripts;
-  }
-
-  set scripts(scripts: Set<Script>) {
-    this.activeScripts = scripts;
-    this.rebuildHookIndex();
-  }
+  constructor(
+    private readonly initScriptFunction: (script: Script) => Promise<void>,
+    private readonly onScriptError?: (event: ScriptError) => void
+  ) {}
 
   private handleException(error: Error, script: Script, context: string) {
     console.error(
@@ -100,8 +88,7 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
       error
     );
 
-    this.dispatchEvent({
-      type: ScriptsManagerEventType.EXCEPTION,
+    this.onScriptError?.({
       scriptName: script.name || script.constructor.name,
       context,
       error,
@@ -120,18 +107,24 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
     this.handleException(normalizedError, script, context);
   }
 
-  private callScripts(
+  callTargeted(
     scripts: Iterable<Script>,
     context: string,
-    callback: (script: Script) => void
-  ): void {
+    callback: (script: Script) => boolean | void
+  ): boolean {
     for (const script of scripts) {
       try {
-        callback(script);
+        if (callback(script) === true) return true;
       } catch (error: unknown) {
         this.handleScriptError(error, script, context);
       }
     }
+    return false;
+  }
+
+  /** Reports an asynchronous subsystem error against its owning Script. */
+  reportError(error: unknown, script: Script, context: string): void {
+    this.handleScriptError(error, script, context);
   }
 
   /** Initializes a script. Concurrent calls share one initialization. */
@@ -139,8 +132,8 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
     if (this.disposed) {
       return Promise.reject(new Error('ScriptsManager has been disposed.'));
     }
-    if (this.activeScripts.has(script)) return Promise.resolve();
-    if (this.failedScripts.has(script)) return Promise.resolve();
+    if (this.activeScripts.has(script)) return SCRIPT_READY;
+    if (this.failedScripts.has(script)) return SCRIPT_READY;
 
     const pending = this.pendingInitializations.get(script);
     if (pending) {
@@ -152,12 +145,10 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
 
     const entry: PendingInitialization = {
       script,
-      promise: Promise.resolve(),
+      promise: SCRIPT_READY,
       connection: 'connected',
     };
-    entry.promise = Promise.resolve().then(() =>
-      this.finishInitialization(entry)
-    );
+    entry.promise = SCRIPT_READY.then(() => this.finishInitialization(entry));
     this.pendingInitializations.set(script, entry);
     return entry.promise;
   }
@@ -281,8 +272,10 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
   private checkScript = (object: THREE.Object3D): void => {
     if (!(object as MaybeScript).isXRScript) return;
     const script = object as Script;
-    this.syncPromises.push(this.initScript(script));
     this.seenScripts.add(script);
+    if (!this.activeScripts.has(script) && !this.failedScripts.has(script)) {
+      this.syncPromises.push(this.initScript(script));
+    }
   };
 
   syncScriptsWithScene(
@@ -311,11 +304,13 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
       }
     }
 
-    return Promise.allSettled(this.syncPromises);
+    return this.syncPromises.length === 0
+      ? NO_SCRIPT_CHANGES
+      : Promise.allSettled(this.syncPromises);
   }
 
   resetUX = (): void => {
-    this.callScripts(this.activeScripts, 'ux.reset', (script) =>
+    this.callTargeted(this.activeScripts, 'ux.reset', (script) =>
       script.ux.reset()
     );
   };
@@ -393,7 +388,7 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
     callback: (script: Script) => void
   ): void {
     const scripts = this.hookScripts.get(hook);
-    if (scripts) this.callScripts(scripts, hook, callback);
+    if (scripts) this.callTargeted(scripts, hook, callback);
   }
 
   private getHookSet(hook: GlobalScriptHook): Set<Script> {
@@ -417,8 +412,4 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
     for (const scripts of this.hookScripts.values()) scripts.delete(script);
   }
 
-  private rebuildHookIndex(): void {
-    this.hookScripts.clear();
-    for (const script of this.activeScripts) this.indexScript(script);
-  }
 }

--- a/src/core/components/ScriptsManager.ts
+++ b/src/core/components/ScriptsManager.ts
@@ -26,9 +26,7 @@ type GlobalScriptHook =
 interface PendingInitialization {
   readonly script: Script;
   promise: Promise<void>;
-  canceled: boolean;
-  restartRequested: boolean;
-  restartPromise?: Promise<void>;
+  connection: 'connected' | 'disconnected' | 'reconnected';
 }
 
 const GLOBAL_HOOKS = Object.freeze([
@@ -64,13 +62,13 @@ export type ScriptsManagerEventMap = THREE.Object3DEventMap & {
 
 export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap> {
   private activeScripts = new Set<Script>();
-  private indexedScripts = new Set<Script>();
   private readonly hookScripts = new Map<GlobalScriptHook, Set<Script>>();
   private readonly pendingInitializations = new Map<
     Script,
     PendingInitialization
   >();
   private readonly seenScripts = new Set<Script>();
+  private readonly failedScripts = new Set<Script>();
   private readonly syncPromises: Promise<void>[] = [];
 
   /** Whether to catch all exceptions thrown by developer scripts. */
@@ -135,27 +133,20 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
   /** Initializes a script. Concurrent calls share one initialization. */
   initScript(script: Script): Promise<void> {
     if (this.activeScripts.has(script)) return Promise.resolve();
+    if (this.failedScripts.has(script)) return Promise.resolve();
 
     const pending = this.pendingInitializations.get(script);
     if (pending) {
-      if (!pending.canceled) return pending.promise;
-      pending.restartRequested = true;
-      pending.restartPromise ??= pending.promise.then(
-        () =>
-          pending.restartRequested
-            ? this.initScript(script)
-            : Promise.resolve(),
-        () =>
-          pending.restartRequested ? this.initScript(script) : Promise.resolve()
-      );
-      return pending.restartPromise;
+      if (pending.connection === 'disconnected') {
+        pending.connection = 'reconnected';
+      }
+      return pending.promise;
     }
 
     const entry: PendingInitialization = {
       script,
       promise: Promise.resolve(),
-      canceled: false,
-      restartRequested: false,
+      connection: 'connected',
     };
     entry.promise = Promise.resolve().then(() =>
       this.finishInitialization(entry)
@@ -167,24 +158,33 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
   private async finishInitialization(
     entry: PendingInitialization
   ): Promise<void> {
+    let failed = false;
     try {
       try {
         await this.initScriptFunction(entry.script);
       } catch (error: unknown) {
-        this.handleScriptError(error, entry.script, 'init');
-        return;
+        failed = true;
+        if (entry.connection === 'connected') {
+          this.failedScripts.add(entry.script);
+          this.handleScriptError(error, entry.script, 'init');
+        }
       }
 
-      if (entry.canceled) {
+      if (entry.connection !== 'connected') {
         this.disposeScript(entry.script);
-        return;
+      } else if (!failed) {
+        this.activeScripts.add(entry.script);
+        this.failedScripts.delete(entry.script);
+        this.indexScript(entry.script);
       }
-      this.activeScripts.add(entry.script);
-      this.indexScript(entry.script);
     } finally {
       if (this.pendingInitializations.get(entry.script) === entry) {
         this.pendingInitializations.delete(entry.script);
       }
+    }
+
+    if (entry.connection === 'reconnected') {
+      await this.initScript(entry.script);
     }
   }
 
@@ -192,8 +192,7 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
   uninitScript(script: Script): void {
     const pending = this.pendingInitializations.get(script);
     if (pending) {
-      pending.canceled = true;
-      pending.restartRequested = false;
+      pending.connection = 'disconnected';
       return;
     }
     if (!this.activeScripts.delete(script)) return;
@@ -231,6 +230,12 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
       const pending = this.pendingInitializations.get(script);
       if (pending) this.syncPromises.push(pending.promise);
       this.uninitScript(script);
+    }
+    for (const script of [...this.failedScripts]) {
+      if (!this.seenScripts.has(script)) {
+        this.failedScripts.delete(script);
+        this.disposeScript(script);
+      }
     }
 
     return Promise.allSettled(this.syncPromises);
@@ -314,7 +319,6 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
     hook: GlobalScriptHook,
     callback: (script: Script) => void
   ): void {
-    this.ensureHookIndex();
     const scripts = this.hookScripts.get(hook);
     if (scripts) this.callScripts(scripts, hook, callback);
   }
@@ -329,7 +333,6 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
   }
 
   private indexScript(script: Script): void {
-    this.indexedScripts.add(script);
     for (const hook of GLOBAL_HOOKS) {
       if (!isDefaultScriptMethod(Reflect.get(script, hook))) {
         this.getHookSet(hook).add(script);
@@ -338,22 +341,11 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
   }
 
   private unindexScript(script: Script): void {
-    this.indexedScripts.delete(script);
     for (const scripts of this.hookScripts.values()) scripts.delete(script);
   }
 
   private rebuildHookIndex(): void {
-    this.indexedScripts.clear();
     this.hookScripts.clear();
     for (const script of this.activeScripts) this.indexScript(script);
-  }
-
-  private ensureHookIndex(): void {
-    if (
-      this.indexedScripts.size !== this.activeScripts.size ||
-      [...this.activeScripts].some((script) => !this.indexedScripts.has(script))
-    ) {
-      this.rebuildHookIndex();
-    }
   }
 }

--- a/src/core/components/ScriptsManager.ts
+++ b/src/core/components/ScriptsManager.ts
@@ -70,6 +70,8 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
   private readonly seenScripts = new Set<Script>();
   private readonly failedScripts = new Set<Script>();
   private readonly syncPromises: Promise<void>[] = [];
+  private disposed = false;
+  private disposalPromise?: Promise<void>;
 
   /** Whether to catch all exceptions thrown by developer scripts. */
   catchExceptions = true;
@@ -134,6 +136,9 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
 
   /** Initializes a script. Concurrent calls share one initialization. */
   initScript(script: Script): Promise<void> {
+    if (this.disposed) {
+      return Promise.reject(new Error('ScriptsManager has been disposed.'));
+    }
     if (this.activeScripts.has(script)) return Promise.resolve();
     if (this.failedScripts.has(script)) return Promise.resolve();
 
@@ -202,6 +207,54 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
     this.disposeScript(script);
   }
 
+  /** Disposes every Script generation and prevents further initialization. */
+  dispose(): Promise<void> {
+    if (this.disposalPromise) return this.disposalPromise;
+
+    this.disposed = true;
+    for (const pending of this.pendingInitializations.values()) {
+      pending.connection = 'disconnected';
+    }
+
+    const scripts = new Set([...this.activeScripts, ...this.failedScripts]);
+    const pending = [...this.pendingInitializations.values()].map(
+      (entry) => entry.promise
+    );
+    this.activeScripts.clear();
+    this.failedScripts.clear();
+    this.hookScripts.clear();
+    this.seenScripts.clear();
+    this.interactionCandidates.clear();
+    this.syncPromises.length = 0;
+
+    this.disposalPromise = Promise.resolve().then(() =>
+      this.finishDisposal(scripts, pending)
+    );
+    return this.disposalPromise;
+  }
+
+  private async finishDisposal(
+    scripts: ReadonlySet<Script>,
+    pending: readonly Promise<void>[]
+  ): Promise<void> {
+    let firstError: unknown;
+    for (const script of scripts) {
+      try {
+        this.disposeScript(script);
+      } catch (error: unknown) {
+        firstError ??= error;
+      }
+    }
+
+    const pendingResults = await Promise.allSettled(pending);
+    for (const result of pendingResults) {
+      if (result.status === 'rejected') firstError ??= result.reason;
+    }
+    this.pendingInitializations.clear();
+
+    if (firstError !== undefined) throw firstError;
+  }
+
   private disposeScript(script: Script): void {
     let firstError: Error | undefined;
     const run = (context: string, callback: () => void): void => {
@@ -235,6 +288,9 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
   syncScriptsWithScene(
     scene: THREE.Scene
   ): Promise<PromiseSettledResult<void>[]> {
+    if (this.disposed) {
+      return Promise.reject(new Error('ScriptsManager has been disposed.'));
+    }
     this.seenScripts.clear();
     this.syncPromises.length = 0;
     scene.traverse(this.checkScript);

--- a/src/core/components/ScriptsManager.ts
+++ b/src/core/components/ScriptsManager.ts
@@ -215,7 +215,6 @@ export class ScriptsManager {
     this.failedScripts.clear();
     this.hookScripts.clear();
     this.seenScripts.clear();
-    this.interactionCandidates.clear();
     this.syncPromises.length = 0;
 
     this.disposalPromise = Promise.resolve().then(() =>
@@ -411,5 +410,4 @@ export class ScriptsManager {
   private unindexScript(script: Script): void {
     for (const scripts of this.hookScripts.values()) scripts.delete(script);
   }
-
 }

--- a/src/core/components/ScriptsManager.ts
+++ b/src/core/components/ScriptsManager.ts
@@ -2,8 +2,52 @@ import * as THREE from 'three';
 
 import type {Controller} from '../../input/Controller';
 import {KeyEvent, Script, SelectEvent} from '../Script';
+import {isDefaultScriptMethod} from '../ScriptHooks';
 
 type MaybeScript = THREE.Object3D & {isXRScript?: boolean};
+
+type GlobalScriptHook =
+  | 'update'
+  | 'physicsStep'
+  | 'onSelectStart'
+  | 'onSelectEnd'
+  | 'onSelect'
+  | 'onSelecting'
+  | 'onSqueezeStart'
+  | 'onSqueezeEnd'
+  | 'onSqueeze'
+  | 'onSqueezing'
+  | 'onKeyDown'
+  | 'onKeyUp'
+  | 'onXRSessionStarted'
+  | 'onXRSessionEnded'
+  | 'onSimulatorStarted';
+
+interface PendingInitialization {
+  readonly script: Script;
+  promise: Promise<void>;
+  canceled: boolean;
+  restartRequested: boolean;
+  restartPromise?: Promise<void>;
+}
+
+const GLOBAL_HOOKS = Object.freeze([
+  'update',
+  'physicsStep',
+  'onSelectStart',
+  'onSelectEnd',
+  'onSelect',
+  'onSelecting',
+  'onSqueezeStart',
+  'onSqueezeEnd',
+  'onSqueeze',
+  'onSqueezing',
+  'onKeyDown',
+  'onKeyUp',
+  'onXRSessionStarted',
+  'onXRSessionEnded',
+  'onSimulatorStarted',
+] as const satisfies readonly GlobalScriptHook[]);
 
 export enum ScriptsManagerEventType {
   EXCEPTION = 'exception',
@@ -19,20 +63,31 @@ export type ScriptsManagerEventMap = THREE.Object3DEventMap & {
 };
 
 export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap> {
-  /** The set of all currently initialized scripts. */
-  scripts = new Set<Script>();
-
-  /** The set of scripts currently being initialized. */
-  private initializingScripts = new Set<Script>();
-
-  private seenScripts = new Set<Script>();
-  private syncPromises: Promise<void>[] = [];
+  private activeScripts = new Set<Script>();
+  private indexedScripts = new Set<Script>();
+  private readonly hookScripts = new Map<GlobalScriptHook, Set<Script>>();
+  private readonly pendingInitializations = new Map<
+    Script,
+    PendingInitialization
+  >();
+  private readonly seenScripts = new Set<Script>();
+  private readonly syncPromises: Promise<void>[] = [];
 
   /** Whether to catch all exceptions thrown by developer scripts. */
   catchExceptions = true;
 
   constructor(private initScriptFunction: (script: Script) => Promise<void>) {
     super();
+  }
+
+  /** The set of all currently initialized scripts. */
+  get scripts(): Set<Script> {
+    return this.activeScripts;
+  }
+
+  set scripts(scripts: Set<Script>) {
+    this.activeScripts = scripts;
+    this.rebuildHookIndex();
   }
 
   private handleException(error: Error, script: Script, context: string) {
@@ -52,373 +107,253 @@ export class ScriptsManager extends THREE.EventDispatcher<ScriptsManagerEventMap
     });
   }
 
-  /**
-   * Initializes a script and adds it to the set of scripts which will receive
-   * callbacks. This will be called automatically by Core when a script is found
-   * in the scene but can also be called manually.
-   * @param script - The script to initialize
-   * @returns A promise which resolves when the script is initialized.
-   */
-  async initScript(script: Script) {
-    if (this.scripts.has(script) || this.initializingScripts.has(script)) {
-      return;
-    }
-    this.initializingScripts.add(script);
-    await this.initScriptFunction(script);
-    this.scripts.add(script);
-    this.initializingScripts.delete(script);
+  private handleScriptError(
+    error: unknown,
+    script: Script,
+    context: string
+  ): void {
+    const normalizedError =
+      error instanceof Error ? error : new Error(String(error));
+    if (!this.catchExceptions) throw normalizedError;
+    this.handleException(normalizedError, script, context);
   }
 
-  /**
-   * Uninitializes a script calling dispose and removes it from the set of
-   * scripts which will receive callbacks.
-   * @param script - The script to uninitialize.
-   */
-  uninitScript(script: Script) {
-    if (!this.scripts.has(script)) {
-      return;
+  private callScripts(
+    scripts: Iterable<Script>,
+    context: string,
+    callback: (script: Script) => void
+  ): void {
+    for (const script of scripts) {
+      try {
+        callback(script);
+      } catch (error: unknown) {
+        this.handleScriptError(error, script, context);
+      }
     }
-    script.dispose();
-    this.scripts.delete(script);
-    this.initializingScripts.delete(script);
   }
 
-  /**
-   * Helper for scene traversal to avoid closure allocation.
-   */
-  private checkScript = (obj: THREE.Object3D) => {
-    if ((obj as MaybeScript).isXRScript) {
-      const script = obj as Script;
-      this.syncPromises.push(this.initScript(script));
-      this.seenScripts.add(script);
+  /** Initializes a script. Concurrent calls share one initialization. */
+  initScript(script: Script): Promise<void> {
+    if (this.activeScripts.has(script)) return Promise.resolve();
+
+    const pending = this.pendingInitializations.get(script);
+    if (pending) {
+      if (!pending.canceled) return pending.promise;
+      pending.restartRequested = true;
+      pending.restartPromise ??= pending.promise.then(
+        () =>
+          pending.restartRequested
+            ? this.initScript(script)
+            : Promise.resolve(),
+        () =>
+          pending.restartRequested ? this.initScript(script) : Promise.resolve()
+      );
+      return pending.restartPromise;
     }
+
+    const entry: PendingInitialization = {
+      script,
+      promise: Promise.resolve(),
+      canceled: false,
+      restartRequested: false,
+    };
+    entry.promise = Promise.resolve().then(() =>
+      this.finishInitialization(entry)
+    );
+    this.pendingInitializations.set(script, entry);
+    return entry.promise;
+  }
+
+  private async finishInitialization(
+    entry: PendingInitialization
+  ): Promise<void> {
+    try {
+      try {
+        await this.initScriptFunction(entry.script);
+      } catch (error: unknown) {
+        this.handleScriptError(error, entry.script, 'init');
+        return;
+      }
+
+      if (entry.canceled) {
+        this.disposeScript(entry.script);
+        return;
+      }
+      this.activeScripts.add(entry.script);
+      this.indexScript(entry.script);
+    } finally {
+      if (this.pendingInitializations.get(entry.script) === entry) {
+        this.pendingInitializations.delete(entry.script);
+      }
+    }
+  }
+
+  /** Uninitializes a script and prevents a pending generation from activating. */
+  uninitScript(script: Script): void {
+    const pending = this.pendingInitializations.get(script);
+    if (pending) {
+      pending.canceled = true;
+      pending.restartRequested = false;
+      return;
+    }
+    if (!this.activeScripts.delete(script)) return;
+    this.unindexScript(script);
+    this.disposeScript(script);
+  }
+
+  private disposeScript(script: Script): void {
+    try {
+      script.dispose();
+    } catch (error: unknown) {
+      this.handleScriptError(error, script, 'dispose');
+    }
+  }
+
+  private checkScript = (object: THREE.Object3D): void => {
+    if (!(object as MaybeScript).isXRScript) return;
+    const script = object as Script;
+    this.syncPromises.push(this.initScript(script));
+    this.seenScripts.add(script);
   };
 
-  /**
-   * Finds all scripts in the scene and initializes them or uninitailizes them.
-   * Returns a promise which resolves when all new scripts are finished
-   * initalizing.
-   * @param scene - The main scene which is used to find scripts.
-   */
   syncScriptsWithScene(
     scene: THREE.Scene
   ): Promise<PromiseSettledResult<void>[]> {
     this.seenScripts.clear();
     this.syncPromises.length = 0;
-
     scene.traverse(this.checkScript);
 
-    // Delete missing scripts.
-    for (const script of this.scripts) {
-      if (!this.seenScripts.has(script)) {
-        this.uninitScript(script);
-      }
+    for (const script of this.activeScripts) {
+      if (!this.seenScripts.has(script)) this.uninitScript(script);
+    }
+    for (const script of this.pendingInitializations.keys()) {
+      if (this.seenScripts.has(script)) continue;
+      const pending = this.pendingInitializations.get(script);
+      if (pending) this.syncPromises.push(pending.promise);
+      this.uninitScript(script);
     }
 
     return Promise.allSettled(this.syncPromises);
   }
 
-  resetUX = () => {
-    const catchExceptions = this.catchExceptions;
-    for (const script of this.scripts) {
-      if (catchExceptions) {
-        try {
-          script.ux.reset();
-        } catch (error: unknown) {
-          this.handleException(
-            error instanceof Error ? error : new Error(String(error)),
-            script,
-            'ux.reset'
-          );
-        }
-      } else {
-        script.ux.reset();
-      }
-    }
+  resetUX = (): void => {
+    this.callScripts(this.activeScripts, 'ux.reset', (script) =>
+      script.ux.reset()
+    );
   };
 
-  callSelecting = (controller: Controller) => {
-    const catchExceptions = this.catchExceptions;
-    for (const script of this.scripts) {
-      if (catchExceptions) {
-        try {
-          script.onSelecting({target: controller});
-        } catch (error: unknown) {
-          this.handleException(
-            error instanceof Error ? error : new Error(String(error)),
-            script,
-            'onSelecting'
-          );
-        }
-      } else {
-        script.onSelecting({target: controller});
-      }
-    }
+  callSelecting = (controller: Controller): void => {
+    this.callHook('onSelecting', (script) =>
+      script.onSelecting({target: controller})
+    );
   };
 
-  callSqueezing = (controller: Controller) => {
-    const catchExceptions = this.catchExceptions;
-    for (const script of this.scripts) {
-      if (catchExceptions) {
-        try {
-          script.onSqueezing({target: controller});
-        } catch (error: unknown) {
-          this.handleException(
-            error instanceof Error ? error : new Error(String(error)),
-            script,
-            'onSqueezing'
-          );
-        }
-      } else {
-        script.onSqueezing({target: controller});
-      }
-    }
+  callSqueezing = (controller: Controller): void => {
+    this.callHook('onSqueezing', (script) =>
+      script.onSqueezing({target: controller})
+    );
   };
 
-  update = (time: number, frame: XRFrame) => {
-    const catchExceptions = this.catchExceptions;
-    for (const script of this.scripts) {
-      if (catchExceptions) {
-        try {
-          script.update(time, frame);
-        } catch (error: unknown) {
-          this.handleException(
-            error instanceof Error ? error : new Error(String(error)),
-            script,
-            'update'
-          );
-        }
-      } else {
-        script.update(time, frame);
-      }
-    }
+  update = (time: number, frame: XRFrame): void => {
+    this.callHook('update', (script) => script.update(time, frame));
   };
 
-  physicsStep = () => {
-    const catchExceptions = this.catchExceptions;
-    for (const script of this.scripts) {
-      if (catchExceptions) {
-        try {
-          script.physicsStep();
-        } catch (error: unknown) {
-          this.handleException(
-            error instanceof Error ? error : new Error(String(error)),
-            script,
-            'physicsStep'
-          );
-        }
-      } else {
-        script.physicsStep();
-      }
-    }
+  physicsStep = (): void => {
+    this.callHook('physicsStep', (script) => script.physicsStep());
   };
 
-  callSelectStart = (event: SelectEvent) => {
-    const catchExceptions = this.catchExceptions;
-    for (const script of this.scripts) {
-      if (catchExceptions) {
-        try {
-          script.onSelectStart(event);
-        } catch (error: unknown) {
-          this.handleException(
-            error instanceof Error ? error : new Error(String(error)),
-            script,
-            'onSelectStart'
-          );
-        }
-      } else {
-        script.onSelectStart(event);
-      }
-    }
+  callSelectStart = (event: SelectEvent): void => {
+    this.callHook('onSelectStart', (script) => script.onSelectStart(event));
   };
 
-  callSelectEnd = (event: SelectEvent) => {
-    const catchExceptions = this.catchExceptions;
-    for (const script of this.scripts) {
-      if (catchExceptions) {
-        try {
-          script.onSelectEnd(event);
-        } catch (error: unknown) {
-          this.handleException(
-            error instanceof Error ? error : new Error(String(error)),
-            script,
-            'onSelectEnd'
-          );
-        }
-      } else {
-        script.onSelectEnd(event);
-      }
-    }
+  callSelectEnd = (event: SelectEvent): void => {
+    this.callHook('onSelectEnd', (script) => script.onSelectEnd(event));
   };
 
-  callSelect = (event: SelectEvent) => {
-    const catchExceptions = this.catchExceptions;
-    for (const script of this.scripts) {
-      if (catchExceptions) {
-        try {
-          script.onSelect(event);
-        } catch (error: unknown) {
-          this.handleException(
-            error instanceof Error ? error : new Error(String(error)),
-            script,
-            'onSelect'
-          );
-        }
-      } else {
-        script.onSelect(event);
-      }
-    }
+  callSelect = (event: SelectEvent): void => {
+    this.callHook('onSelect', (script) => script.onSelect(event));
   };
 
-  callSqueezeStart = (event: SelectEvent) => {
-    const catchExceptions = this.catchExceptions;
-    for (const script of this.scripts) {
-      if (catchExceptions) {
-        try {
-          script.onSqueezeStart(event);
-        } catch (error: unknown) {
-          this.handleException(
-            error instanceof Error ? error : new Error(String(error)),
-            script,
-            'onSqueezeStart'
-          );
-        }
-      } else {
-        script.onSqueezeStart(event);
-      }
-    }
+  callSqueezeStart = (event: SelectEvent): void => {
+    this.callHook('onSqueezeStart', (script) => script.onSqueezeStart(event));
   };
 
-  callSqueezeEnd = (event: SelectEvent) => {
-    const catchExceptions = this.catchExceptions;
-    for (const script of this.scripts) {
-      if (catchExceptions) {
-        try {
-          script.onSqueezeEnd(event);
-        } catch (error: unknown) {
-          this.handleException(
-            error instanceof Error ? error : new Error(String(error)),
-            script,
-            'onSqueezeEnd'
-          );
-        }
-      } else {
-        script.onSqueezeEnd(event);
-      }
-    }
+  callSqueezeEnd = (event: SelectEvent): void => {
+    this.callHook('onSqueezeEnd', (script) => script.onSqueezeEnd(event));
   };
 
-  callSqueeze = (event: SelectEvent) => {
-    const catchExceptions = this.catchExceptions;
-    for (const script of this.scripts) {
-      if (catchExceptions) {
-        try {
-          script.onSqueeze(event);
-        } catch (error: unknown) {
-          this.handleException(
-            error instanceof Error ? error : new Error(String(error)),
-            script,
-            'onSqueeze'
-          );
-        }
-      } else {
-        script.onSqueeze(event);
-      }
-    }
+  callSqueeze = (event: SelectEvent): void => {
+    this.callHook('onSqueeze', (script) => script.onSqueeze(event));
   };
 
-  callKeyDown = (event: KeyEvent) => {
-    const catchExceptions = this.catchExceptions;
-    for (const script of this.scripts) {
-      if (catchExceptions) {
-        try {
-          script.onKeyDown(event);
-        } catch (error: unknown) {
-          this.handleException(
-            error instanceof Error ? error : new Error(String(error)),
-            script,
-            'onKeyDown'
-          );
-        }
-      } else {
-        script.onKeyDown(event);
-      }
-    }
+  callKeyDown = (event: KeyEvent): void => {
+    this.callHook('onKeyDown', (script) => script.onKeyDown(event));
   };
 
-  callKeyUp = (event: KeyEvent) => {
-    const catchExceptions = this.catchExceptions;
-    for (const script of this.scripts) {
-      if (catchExceptions) {
-        try {
-          script.onKeyUp(event);
-        } catch (error: unknown) {
-          this.handleException(
-            error instanceof Error ? error : new Error(String(error)),
-            script,
-            'onKeyUp'
-          );
-        }
-      } else {
-        script.onKeyUp(event);
-      }
-    }
+  callKeyUp = (event: KeyEvent): void => {
+    this.callHook('onKeyUp', (script) => script.onKeyUp(event));
   };
 
-  onXRSessionStarted = (session: XRSession) => {
-    const catchExceptions = this.catchExceptions;
-    for (const script of this.scripts) {
-      if (catchExceptions) {
-        try {
-          script.onXRSessionStarted(session);
-        } catch (error: unknown) {
-          this.handleException(
-            error instanceof Error ? error : new Error(String(error)),
-            script,
-            'onXRSessionStarted'
-          );
-        }
-      } else {
-        script.onXRSessionStarted(session);
-      }
-    }
+  onXRSessionStarted = (session: XRSession): void => {
+    this.callHook('onXRSessionStarted', (script) =>
+      script.onXRSessionStarted(session)
+    );
   };
 
-  onXRSessionEnded = () => {
-    const catchExceptions = this.catchExceptions;
-    for (const script of this.scripts) {
-      if (catchExceptions) {
-        try {
-          script.onXRSessionEnded();
-        } catch (error: unknown) {
-          this.handleException(
-            error instanceof Error ? error : new Error(String(error)),
-            script,
-            'onXRSessionEnded'
-          );
-        }
-      } else {
-        script.onXRSessionEnded();
-      }
-    }
+  onXRSessionEnded = (): void => {
+    this.callHook('onXRSessionEnded', (script) => script.onXRSessionEnded());
   };
 
-  onSimulatorStarted = () => {
-    const catchExceptions = this.catchExceptions;
-    for (const script of this.scripts) {
-      if (catchExceptions) {
-        try {
-          script.onSimulatorStarted();
-        } catch (error: unknown) {
-          this.handleException(
-            error instanceof Error ? error : new Error(String(error)),
-            script,
-            'onSimulatorStarted'
-          );
-        }
-      } else {
-        script.onSimulatorStarted();
+  onSimulatorStarted = (): void => {
+    this.callHook('onSimulatorStarted', (script) =>
+      script.onSimulatorStarted()
+    );
+  };
+
+  private callHook(
+    hook: GlobalScriptHook,
+    callback: (script: Script) => void
+  ): void {
+    this.ensureHookIndex();
+    const scripts = this.hookScripts.get(hook);
+    if (scripts) this.callScripts(scripts, hook, callback);
+  }
+
+  private getHookSet(hook: GlobalScriptHook): Set<Script> {
+    let scripts = this.hookScripts.get(hook);
+    if (!scripts) {
+      scripts = new Set<Script>();
+      this.hookScripts.set(hook, scripts);
+    }
+    return scripts;
+  }
+
+  private indexScript(script: Script): void {
+    this.indexedScripts.add(script);
+    for (const hook of GLOBAL_HOOKS) {
+      if (!isDefaultScriptMethod(Reflect.get(script, hook))) {
+        this.getHookSet(hook).add(script);
       }
     }
-  };
+  }
+
+  private unindexScript(script: Script): void {
+    this.indexedScripts.delete(script);
+    for (const scripts of this.hookScripts.values()) scripts.delete(script);
+  }
+
+  private rebuildHookIndex(): void {
+    this.indexedScripts.clear();
+    this.hookScripts.clear();
+    for (const script of this.activeScripts) this.indexScript(script);
+  }
+
+  private ensureHookIndex(): void {
+    if (
+      this.indexedScripts.size !== this.activeScripts.size ||
+      [...this.activeScripts].some((script) => !this.indexedScripts.has(script))
+    ) {
+      this.rebuildHookIndex();
+    }
+  }
 }

--- a/src/core/components/WebXRSessionManager.ts
+++ b/src/core/components/WebXRSessionManager.ts
@@ -24,6 +24,8 @@ export class WebXRSessionManager extends THREE.EventDispatcher<WebXRSessionManag
   private sessionOptions?: XRSessionInit;
   private xrModeSupported?: boolean;
   private waitingForXRSession = false;
+  private disposed = false;
+  private disposalPromise?: Promise<void>;
 
   constructor(
     private renderer: THREE.WebGLRenderer,
@@ -51,11 +53,14 @@ export class WebXRSessionManager extends THREE.EventDispatcher<WebXRSessionManag
       modeSupported =
         (await navigator.xr!.isSessionSupported(this.mode)) || false;
     } catch (e) {
+      if (this.disposed) return;
       console.error('Error getting isSessionSupported', e);
       this.xrModeSupported = false;
       this.dispatchEvent({type: WebXRSessionEventType.UNSUPPORTED});
       return;
     }
+
+    if (this.disposed) return;
 
     if (modeSupported) {
       this.xrModeSupported = true;
@@ -92,7 +97,9 @@ export class WebXRSessionManager extends THREE.EventDispatcher<WebXRSessionManag
    * Ends the WebXR session.
    */
   public startSession() {
-    if (this.xrModeSupported === undefined) {
+    if (this.disposed) {
+      throw new Error('WebXRSessionManager has been disposed');
+    } else if (this.xrModeSupported === undefined) {
       throw new Error('Initialize not yet complete');
     } else if (!this.xrModeSupported) {
       throw new Error('WebXR not supported');
@@ -123,12 +130,17 @@ export class WebXRSessionManager extends THREE.EventDispatcher<WebXRSessionManag
   /**
    * Ends the WebXR session.
    */
-  public endSession() {
-    if (!this.currentSession) {
+  public async endSession(): Promise<void> {
+    const session = this.currentSession;
+    if (!session) {
       throw new Error('No session to end');
     }
-    this.currentSession.end();
-    this.currentSession = undefined;
+    try {
+      await session.end();
+    } finally {
+      session.removeEventListener('end', this.onSessionEndedInternal);
+      if (this.currentSession === session) this.currentSession = undefined;
+    }
   }
 
   /**
@@ -145,8 +157,22 @@ export class WebXRSessionManager extends THREE.EventDispatcher<WebXRSessionManag
 
   /** Internal callback for when a session successfully starts. */
   private onSessionStartedInternal = async (session: XRSession) => {
+    if (this.disposed) {
+      await session.end();
+      return;
+    }
     session.addEventListener('end', this.onSessionEndedInternal);
-    await this.renderer.xr.setSession(session);
+    try {
+      await this.renderer.xr.setSession(session);
+    } catch (error) {
+      session.removeEventListener('end', this.onSessionEndedInternal);
+      throw error;
+    }
+    if (this.disposed) {
+      session.removeEventListener('end', this.onSessionEndedInternal);
+      await session.end();
+      return;
+    }
     this.currentSession = session;
 
     // Fire the 'sessionstart' event with the session in the data payload
@@ -158,13 +184,20 @@ export class WebXRSessionManager extends THREE.EventDispatcher<WebXRSessionManag
 
   /** Internal callback for when the session ends. */
   private onSessionEndedInternal = () => {
-    // Fire the 'sessionend' event
-    this.dispatchEvent({type: WebXRSessionEventType.SESSION_END});
-
-    this.currentSession?.removeEventListener(
-      'end',
-      this.onSessionEndedInternal
-    );
+    const session = this.currentSession;
+    session?.removeEventListener('end', this.onSessionEndedInternal);
     this.currentSession = undefined;
+    if (!this.disposed) {
+      this.dispatchEvent({type: WebXRSessionEventType.SESSION_END});
+    }
   };
+
+  dispose(): Promise<void> {
+    if (this.disposalPromise) return this.disposalPromise;
+    this.disposed = true;
+    this.disposalPromise = this.currentSession
+      ? this.endSession()
+      : Promise.resolve();
+    return this.disposalPromise;
+  }
 }

--- a/src/core/components/XRButton.ts
+++ b/src/core/components/XRButton.ts
@@ -11,6 +11,7 @@ export class XRButton {
   public domElement = document.createElement('div');
   public simulatorButtonElement = document.createElement('button');
   public xrButtonElement = document.createElement('button');
+  private disposed = false;
 
   constructor(
     private sessionManager: WebXRSessionManager,
@@ -40,20 +41,26 @@ export class XRButton {
 
     this.sessionManager.addEventListener(
       WebXRSessionEventType.UNSUPPORTED,
-      this.showXRNotSupported.bind(this)
+      this.onUnsupported
     );
-    this.sessionManager.addEventListener(WebXRSessionEventType.READY, () =>
-      this.onSessionReady()
+    this.sessionManager.addEventListener(
+      WebXRSessionEventType.READY,
+      this.onReady
     );
     this.sessionManager.addEventListener(
       WebXRSessionEventType.SESSION_START,
-      () => this.onSessionStarted()
+      this.onSessionStart
     );
     this.sessionManager.addEventListener(
       WebXRSessionEventType.SESSION_END,
-      this.onSessionEnded.bind(this)
+      this.onSessionEnd
     );
   }
+
+  private onUnsupported = () => this.showXRNotSupported();
+  private onReady = () => this.onSessionReady();
+  private onSessionStart = () => this.onSessionStarted();
+  private onSessionEnd = () => this.onSessionEnded();
 
   private createSimulatorButton() {
     this.simulatorButtonElement.classList.add(XRBUTTON_CLASS);
@@ -106,6 +113,7 @@ export class XRButton {
           allowVideoFallback: allowsVideoFallback,
         })
         .then((result) => {
+          if (this.disposed) return;
           if (result.granted) {
             this.sessionManager.startSession();
           } else {
@@ -123,9 +131,36 @@ export class XRButton {
 
   private async onSessionStarted() {
     this.xrButtonElement.innerHTML = this.endText;
+    this.xrButtonElement.onclick = () => {
+      void this.sessionManager.endSession();
+    };
   }
 
   private onSessionEnded() {
-    this.xrButtonElement.innerHTML = this.startText;
+    this.onSessionReady();
+  }
+
+  dispose() {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.sessionManager.removeEventListener(
+      WebXRSessionEventType.UNSUPPORTED,
+      this.onUnsupported
+    );
+    this.sessionManager.removeEventListener(
+      WebXRSessionEventType.READY,
+      this.onReady
+    );
+    this.sessionManager.removeEventListener(
+      WebXRSessionEventType.SESSION_START,
+      this.onSessionStart
+    );
+    this.sessionManager.removeEventListener(
+      WebXRSessionEventType.SESSION_END,
+      this.onSessionEnd
+    );
+    this.simulatorButtonElement.onclick = null;
+    this.xrButtonElement.onclick = null;
+    this.domElement.remove();
   }
 }

--- a/src/core/components/XREffects.ts
+++ b/src/core/components/XREffects.ts
@@ -192,4 +192,30 @@ export class XREffects {
     renderer.xr.enabled = xrEnabled;
     renderer.xr.isPresenting = xrIsPresenting;
   }
+
+  dispose() {
+    let firstError: unknown;
+    for (const target of this.renderTargets) {
+      for (const dispose of [
+        () => target.depthTexture?.dispose(),
+        () => target.dispose(),
+      ]) {
+        try {
+          dispose();
+        } catch (error: unknown) {
+          firstError ??= error;
+        }
+      }
+    }
+    this.renderTargets.length = 0;
+    for (const pass of this.passes) {
+      try {
+        pass.dispose();
+      } catch (error: unknown) {
+        firstError ??= error;
+      }
+    }
+    this.passes.length = 0;
+    if (firstError !== undefined) throw firstError;
+  }
 }

--- a/src/singletons.ts
+++ b/src/singletons.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 
 import {Core} from './core/Core';
 import {Options} from './core/Options';
+import {Script} from './core/Script';
 import {checkThreeVersion} from './utils/VersionCheck';
 
 checkThreeVersion();
@@ -99,6 +100,14 @@ export function add(...object: THREE.Object3D[]) {
  */
 export function init(options: Options = new Options()) {
   return core.init(options);
+}
+
+/**
+ * Manually initializes a Script and resolves after its dependencies and
+ * lifecycle initialization are complete.
+ */
+export function initScript(script: Script) {
+  return core.scriptsManager.initScript(script);
 }
 
 /**

--- a/src/singletons.ts
+++ b/src/singletons.ts
@@ -2,7 +2,6 @@ import * as THREE from 'three';
 
 import {Core} from './core/Core';
 import {Options} from './core/Options';
-import {Script} from './core/Script';
 import {checkThreeVersion} from './utils/VersionCheck';
 
 checkThreeVersion();
@@ -100,26 +99,6 @@ export function add(...object: THREE.Object3D[]) {
  */
 export function init(options: Options = new Options()) {
   return core.init(options);
-}
-
-/**
- * A shortcut for `core.scriptsManager.initScript()`. Manually initializes a
- * script and its dependencies.
- * @param script - The script to initialize.
- * @see {@link ScriptsManager.initScript}
- */
-export function initScript(script: Script) {
-  return core.scriptsManager.initScript(script);
-}
-
-/**
- * A shortcut for `core.scriptsManager.uninitScript()`. Disposes of a script
- * and removes it from the update loop.
- * @param script - The script to uninitialize.
- * @see {@link ScriptsManager.uninitScript}
- */
-export function uninitScript(script: Script) {
-  return core.scriptsManager.uninitScript(script);
 }
 
 /**

--- a/src/singletons.ts
+++ b/src/singletons.ts
@@ -9,7 +9,8 @@ checkThreeVersion();
 
 /**
  * The global singleton instance of Core, serving as the main entry point
- * for the entire XR system.
+ * for the entire XR system. This binding is stable for the module lifetime;
+ * disposing Core is terminal.
  */
 export const core = new Core();
 

--- a/src/xrblocks.ts
+++ b/src/xrblocks.ts
@@ -20,7 +20,6 @@ export * from './context/shared/SemanticTypes';
 export * from './core/components/Raycaster';
 export * from './core/components/Registry';
 export * from './core/components/ScreenshotSynthesizer';
-export * from './core/components/ScriptsManager';
 export * from './core/components/WaitFrame';
 export * from './core/components/XRButton';
 export * from './core/components/XREffects';

--- a/src/xrblocks.ts
+++ b/src/xrblocks.ts
@@ -20,6 +20,7 @@ export * from './context/shared/SemanticTypes';
 export * from './core/components/Raycaster';
 export * from './core/components/Registry';
 export * from './core/components/ScreenshotSynthesizer';
+export * from './core/components/ScriptsManager';
 export * from './core/components/WaitFrame';
 export * from './core/components/XRButton';
 export * from './core/components/XREffects';


### PR DESCRIPTION
## Description

**Not tested on device yet.**

This PR improves Core and Script lifecycle reliability. It prevents initialization and disposal races, makes cleanup deterministic, and keeps script lifecycle management internal to Core.

This is the first PR in the stack and targets `dev`, which includes the merged placement work from #475.

## Changes

- Add explicit Core lifecycle states for initialization, running, disposal, and failure cleanup.
- Make `Core.dispose()` asynchronous and idempotent.
- Prevent initialization and disposal from running concurrently.
- Clean up partially initialized resources after an initialization failure.
- Improve tracking of pending, active, failed, removed, and disposed scripts.
- Centralize script callback dispatch and error reporting.
- Add script-error listeners through `Core.onScriptError()`.
- Remove repeated lifecycle allocations and next-frame synchronization delays.
- Make `ScriptsManager` internal to Core.
- Migrate Netblocks, Remote Control, and TestRunner away from direct `ScriptsManager` access.
- Clean up Core-owned resources:
  - XR session listeners
  - XR buttons
  - Render loops
  - Resize listeners
  - Renderer containers
  - WebXR session management
  - Effects and physics timers

Interaction behavior and the existing UI system are unchanged in this PR.

## Public API changes

- `Core.dispose()` now returns a Promise and is idempotent.
- Add the script-error listener interface.
- Remove the public `ScriptsManager` export.
- Remove the public `initScript` and `uninitScript` shortcuts.