### PR TITLE
Object3d device fixes

### DIFF
--- a/demos/objects_3d/README.md
+++ b/demos/objects_3d/README.md
@@ -2,49 +2,115 @@
 
 # 3D Object Boxes
 
-Run the existing 2D object detector, sample the depth mesh inside each
-detection's 2D box, and fit an oriented 3D bounding box around the
-points. No new ML model — just a small PCA on the points the device's
-own depth sensor already gives us.
+Turns 2D object detections plus the depth mesh into oriented 3D bounding boxes,
+using the `objects3d` addon (`Object3DDetector`).
 
-## Why not Objectron / Cube R-CNN / etc
+The integration is three lines:
 
-Most monocular 3D detectors exist because their target platform doesn't
-have depth. xrblocks does (`xb.core.depth`), so we can skip the model
-entirely and use real metric depth + the SDK's existing 2D detector.
+```js
+const detector = new Object3DDetector({showDebugBoxes: true});
+xb.add(detector);
+const objects = await detector.detect();
+```
 
-That gets us:
+Everything else on the page is the debug panel, which exists so the pipeline can
+be diagnosed on a headset where there is no console.
 
-- Categories = whatever the 2D detector recognises (lots, with the
-  Gemini backend), not just shoe / chair / cup / camera.
-- Real metric scale from the headset's depth sensor, not estimated
-  relative depth.
-- Real yaw orientation from PCA on the actual points.
-- Zero model download.
+## Setup
 
-## How the box gets fit
+Needs a Gemini API key. Create `keys.json` in this directory (gitignored):
 
-1. `xb.core.world.objects.runDetection()` returns 2D boxes + a
-   centre-point world position per object.
-2. Sample an 18×18 grid of normalised UVs inside the 2D box and call
-   `xb.core.depth.getVertex(u, v)` for each to get world-space points.
-3. Drop points more than ~1.2 m from the SDK's centre point — that
-   peels off background / foreground bleeding through the box.
-4. PCA in the horizontal plane (XZ) gives the yaw of the dominant
-   axis. Y is left gravity-aligned. Min/max along the rotated axes
-   gives the footprint, min/max world-Y gives the height.
-5. Render as `THREE.LineSegments(EdgesGeometry(BoxGeometry))` rotated
-   to the PCA yaw, with the label floating above.
+```json
+{"gemini": {"apiKey": "YOUR_KEY"}}
+```
 
-## Running
+Then serve the repo (`npm run dev` from the repo root) and open
+`http://localhost:8080/demos/objects_3d/`.
 
-Serve the repo root and open `/demos/objects_3d/`. Press **Detect**
-(in the screen panel or the spatial panel). Works in the simulator and
-on Android XR.
+When this page is embedded in the docs site the key comes from the iframe's
+`?key=` parameter instead, so no `keys.json` is needed there.
 
-## What's next
+To skip the key entirely, switch the detector picker to `mediapipe` (fixed COCO
+class set, no network).
 
-If this lands well, the natural follow-up is a `box3d: true` option
-on `world.objects.runDetection()` so apps can ask for oriented 3D
-boxes alongside the existing 2D box + centre point — same primitive,
-in the SDK rather than each demo redoing it.
+## The debug panel
+
+The same controls exist twice: as a DOM panel for desktop, and as a draggable
+spatial panel for immersive XR, where the DOM is invisible. In XR the panel is
+the only way to trigger a detection — pinch is deliberately not bound, so
+grabbing and dragging the panel cannot fire one by accident.
+
+**Actions** — `detect`, `clear`, and `copy`, which puts the full diagnostics
+record on the clipboard as JSON and logs it to the console.
+
+**Camera rotation offset** (`yaw` / `pitch` / `roll`, ±5° per press) applies
+**live** to the next detection — no reload. This is the knob for nulling out a
+constant calibration error between the SDK's estimated passthrough-camera
+extrinsics and the actual hardware. Also available as `?camYawDeg=-30` etc.
+
+**Toggles that reload the page**, because they must be set before `xb.init()`:
+
+| Control        | Query param         | What it does                                                                                  |
+| -------------- | ------------------- | --------------------------------------------------------------------------------------------- |
+| `matchDepth`   | `?matchDepthView=0` | **On by default.** Ask the platform for view-aligned depth instead of raw depth-sensor frames |
+| `fullResDepth` | `?fullResDepth=1`   | Rebuild the full-resolution depth mesh every frame (see below)                                |
+| `detector`     | `?backend=`         | `gemini` / `mediapipe` / `both`                                                               |
+| `mask`         | `?mask=`            | `slimsam` / `mediapipe`                                                                       |
+
+**Diagnostics**, refreshed after each detection (4 Hz in XR):
+
+| Row             | Why it matters                                                                                                                                                   |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `frame latency` | Age of the captured video frame. Large values mean the pixels predate the pose, which rotates every box by the head motion in between. Under ~150 ms is healthy. |
+| `pose match`    | How close the pose we paired with the frame was to the frame's capture time.                                                                                     |
+| `camera model`  | `device` means the SDK passthrough-camera model; `RENDER (fallback)` means the old, wrong-FOV path — a red flag on device.                                       |
+| `depth remap`   | Whether the platform's view→depth-buffer UV remap is the identity.                                                                                               |
+| `depth vs eye`  | Angle between the depth camera's reported orientation and the left eye's.                                                                                        |
+| `rejections`    | Which sanity gate discarded detections (`farFromRoom` usually means the room-scale defaults need tuning).                                                        |
+| `timings`       | Per-stage wall clock, so you can see whether a slow detect is Gemini, SAM, or geometry.                                                                          |
+
+## Diagnosing a coherent rotation error
+
+If every box from one detection lands rotated by roughly the same angle, run one
+detection while holding your head **perfectly still for ~2 seconds**, then one
+while turning your head:
+
+- **Rotation gone when still** → the captures were pairing fresh tracking poses
+  with stale video frames. The pipeline now waits for a fresh frame and pairs the
+  capture with the pose at the frame's `captureTime`; check `frame latency`.
+- **Rotation identical in both** (same axis, same angle) → a constant
+  calibration error. Null it with the yaw/pitch/roll buttons, then bake the
+  value into `cameraRotationOffset`.
+- **`depth vs eye` is large** → check `matchDepth` is still on (it is by
+  default). Turning it off measurably rotates the boxes on Galaxy XR, which is
+  how we learned the depth mesh — the surface every ray lands on — was the
+  rotated ingredient rather than the RGB camera model.
+
+## Frame rate
+
+The one setting that dominates is `fullResDepth`, off by default. Turning it on
+sets `options.depth.depthMesh.updateFullResolutionGeometry = true`, so every
+depth frame unprojects the full 154×154 grid — ~23.7k vertices, each a
+`Matrix4` transform plus a divide — on the main thread, on top of the 40×40
+downsampled mesh the SDK always maintains. That is ~15× the per-frame vertex
+work for no accuracy gain, because the detector calls
+`depth.updateFullResolutionDepthMesh()` once inside `detect()` anyway, paying
+the cost per detection rather than per frame.
+
+The spatial debug panel costs a little too, since it pulls in uikit/yoga layout
+and MSDF text rendering. Neither setting affects correctness, only frame rate.
+
+## Tuning for a real room
+
+The fitter defaults are tuned for the simulator's cabin scene. On a headset,
+pass bounds that match the real space:
+
+```js
+new Object3DDetector({
+  showDebugBoxes: true,
+  roomHalf: 4, // walls at x/z = ±4 m
+  sceneBounds: {maxXZ: 8, minY: -1, maxY: 5}, // reject boxes outside this
+  maxRayDistance: 12,
+  cameraRotationOffset: {yaw: 0, pitch: 0, roll: 0}, // radians, per-unit calibration
+});
+```

--- a/demos/objects_3d/index.html
+++ b/demos/objects_3d/index.html
@@ -158,7 +158,7 @@
         >
         <label
           >detector
-        <select id="detectorSelect">
+          <select id="detectorSelect">
             <option value="gemini">gemini</option>
             <option value="mediapipe">mediapipe</option>
             <option value="both">both</option>
@@ -166,7 +166,7 @@
         >
         <label
           >mask
-        <select id="maskSelect">
+          <select id="maskSelect">
             <option value="slimsam">slimsam</option>
             <option value="mediapipe">mediapipe</option>
           </select></label
@@ -250,41 +250,41 @@
           yaw: THREE.MathUtils.degToRad(SETTINGS.yawDeg),
           pitch: THREE.MathUtils.degToRad(SETTINGS.pitchDeg),
           roll: THREE.MathUtils.degToRad(SETTINGS.rollDeg),
-            },
+        },
         orientation: {mode: SETTINGS.orient},
-          });
+      });
 
       // -----------------------------------------------------------------
       // Diagnostics formatting, shared by the DOM readout and the XR panel.
       // -----------------------------------------------------------------
       const ms = (v) => (v == null ? '—' : `${v.toFixed(0)} ms`);
       const DIAG_ROWS = [
-              [
+        [
           'frame latency',
           (d) =>
             d.frameLatencyMs == null
               ? 'no captureTime (may be stale)'
               : ms(d.frameLatencyMs),
         ],
-                [
+        [
           'pose match',
           (d) =>
             d.poseMatchErrorMs == null ? 'live pose' : ms(d.poseMatchErrorMs),
-                ],
+        ],
         ['pose ring', (d) => `${d.poseRingSize} poses`],
         [
           'camera model',
           (d) =>
             `${d.usedDeviceCameraModel ? 'device' : 'RENDER (fallback)'}` +
             ` · fov ${d.cameraFovDeg.toFixed(1)}° · aspect ${d.cameraAspect.toFixed(2)}`,
-              ],
+        ],
         [
           'rot offset',
           (d) =>
             `yaw ${d.cameraRotationOffsetDeg.yaw.toFixed(1)}° ` +
             `pitch ${d.cameraRotationOffsetDeg.pitch.toFixed(1)}° ` +
             `roll ${d.cameraRotationOffsetDeg.roll.toFixed(1)}°`,
-            ],
+        ],
         ['snapshot', (d) => `${d.snapshotWidth}×${d.snapshotHeight}`],
         [
           'depth remap',
@@ -333,7 +333,7 @@
                       `${y.label}:${y.yawDeg.toFixed(0)}°` +
                       `(rel ${y.roomRelativeYawDeg.toFixed(0)}°,` +
                       `${y.confidence.toFixed(2)},${y.method})`
-          )
+                  )
                   .join(' '),
         ],
         [
@@ -347,7 +347,7 @@
             `total ${d.timings.total.toFixed(0)}`,
         ],
         ['error', (d) => d.error ?? 'none'],
-          ];
+      ];
 
       const LABEL_WIDTH = Math.max(...DIAG_ROWS.map(([l]) => l.length)) + 2;
 
@@ -528,10 +528,10 @@
           root.add(
             new UIText('3D OBJECT BOXES · ADDON', {
               fontSize: 18,
-            fontWeight: 'bold',
-            color: '#00f0ff',
-            textAlign: 'center',
-            width: '100%',
+              fontWeight: 'bold',
+              color: '#00f0ff',
+              textAlign: 'center',
+              width: '100%',
             })
           );
           xrStatusText = new UIText(statusEl.textContent, {
@@ -543,9 +543,9 @@
           root.add(xrStatusText);
           root.add(
             new UIPanel({
-            width: '100%',
-            height: 2,
-            fillColor: 'rgba(255, 255, 255, 0.12)',
+              width: '100%',
+              height: 2,
+              fillColor: 'rgba(255, 255, 255, 0.12)',
             })
           );
 
@@ -866,10 +866,10 @@
           const valueText = new UIText(current, {
             fontSize: 11,
             color: current === 'off' ? '#888888' : '#ffffff',
-              fontWeight: 'bold',
-              textAlign: 'center',
-              depthTest: false,
-              renderOrder: 100,
+            fontWeight: 'bold',
+            textAlign: 'center',
+            depthTest: false,
+            renderOrder: 100,
           });
           btn.add(valueText);
           onLabelReady?.(valueText);

--- a/demos/objects_3d/index.html
+++ b/demos/objects_3d/index.html
@@ -50,197 +50,142 @@
         display: flex;
         flex-direction: column;
         gap: 10px;
-        background: rgba(20, 20, 20, 0.85);
+        background: rgba(20, 20, 20, 0.88);
         padding: 14px 18px;
         border-radius: 12px;
         font-family: system-ui, sans-serif;
         color: #eee;
-        max-width: 540px;
-        width: 92%;
+        max-width: 620px;
+      }
+      .panel .row {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        flex-wrap: wrap;
       }
       .panel button {
-        padding: 9px 14px;
+        padding: 8px 13px;
         border-radius: 8px;
         border: 1px solid #444;
         background: #2a2a2a;
         color: white;
         cursor: pointer;
-        font-size: 14px;
+        font-size: 13px;
       }
-      .panel button:hover:not(:disabled) {
+      .panel button:hover {
         background: #3a3a3a;
       }
       .panel button:disabled {
         opacity: 0.4;
         cursor: default;
       }
-      .panel .row {
-        display: flex;
-        gap: 8px;
-        align-items: center;
-      }
-      .panel select {
-        padding: 6px 8px;
-        border-radius: 6px;
-        border: 1px solid #444;
-        background: #2a2a2a;
-        color: white;
-        font-size: 12px;
-        cursor: pointer;
-      }
       .panel label {
-        font-size: 11px;
+        font-size: 12px;
         color: #aaa;
+        display: flex;
+        gap: 6px;
+        align-items: center;
       }
       .panel .status {
         font-size: 12px;
-        color: #aaa;
+        color: #9ad;
       }
-      .key-overlay {
-        position: fixed;
-        inset: 0;
-        background: rgba(0, 0, 0, 0.85);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        z-index: 999;
-        font-family: system-ui, sans-serif;
+      .panel .hint {
+        font-size: 11px;
+        color: #777;
       }
-      .key-card {
-        background: #1a1a1a;
-        color: #eee;
-        padding: 24px;
-        border-radius: 12px;
-        max-width: 420px;
-        width: 92%;
-      }
-      .key-card h2 {
-        margin: 0 0 8px 0;
-      }
-      .key-card p {
-        font-size: 13px;
-        color: #bbb;
+      #diagnostics {
+        font-family: ui-monospace, Menlo, Consolas, monospace;
+        font-size: 11px;
         line-height: 1.5;
-      }
-      .key-card a {
-        color: #4cd964;
-      }
-      .key-card input {
-        width: 100%;
-        box-sizing: border-box;
-        padding: 10px;
-        font-size: 14px;
-        background: #2a2a2a;
-        border: 1px solid #444;
-        color: white;
+        color: #bbb;
+        background: rgba(0, 0, 0, 0.35);
         border-radius: 8px;
-        margin: 10px 0;
-      }
-      .key-card button {
-        padding: 10px 16px;
-        background: #4cd964;
-        border: none;
-        border-radius: 8px;
-        color: #000;
-        font-weight: 600;
-        cursor: pointer;
+        padding: 8px 10px;
+        margin: 0;
+        max-height: 220px;
+        overflow-y: auto;
+        white-space: pre;
       }
     </style>
   </head>
   <body>
-    <div id="keyOverlay" class="key-overlay" style="display: none">
-      <div class="key-card">
-        <h2>Gemini API key</h2>
-        <p>
-          This demo uses Gemini for open-vocabulary object detection (so it can
-          find lamps, plants, anything you ask for — not just the 80 COCO
-          classes). Get a free key from
-          <a
-            href="https://aistudio.google.com/app/apikey"
-            target="_blank"
-            rel="noopener"
-            >aistudio.google.com</a
-          >. The key is saved to localStorage and only sent to Google.
-        </p>
-        <input id="keyInput" type="password" placeholder="AIza..." />
-        <button id="keySave">save and reload</button>
-      </div>
-    </div>
-
-    <script>
-      // Resolve gemini key: ?key= URL param > localStorage > ./keys.json > overlay.
-      (async function () {
-        const STORAGE_KEY = 'gemini-api-key';
-        const params = new URLSearchParams(window.location.search);
-        if (params.has('key')) {
-          window.localStorage.setItem(STORAGE_KEY, params.get('key'));
-          return;
-        }
-        const stored = window.localStorage.getItem(STORAGE_KEY);
-        if (stored) {
-          params.set('key', stored);
-          const newUrl =
-            window.location.pathname +
-            '?' +
-            params.toString() +
-            window.location.hash;
-          window.history.replaceState(null, '', newUrl);
-          return;
-        }
-        try {
-          const res = await fetch('./keys.json', {cache: 'no-store'});
-          if (res.ok) {
-            const k = (await res.json()).key;
-            if (k) {
-              window.localStorage.setItem(STORAGE_KEY, k);
-              params.set('key', k);
-              window.location.search = '?' + params.toString();
-              return;
-            }
-          }
-        } catch (_) {
-          // no keys.json, fall through to overlay
-        }
-        const overlay = document.getElementById('keyOverlay');
-        const input = document.getElementById('keyInput');
-        const save = document.getElementById('keySave');
-        overlay.style.display = 'flex';
-        const submit = () => {
-          const k = input.value.trim();
-          if (!k) return;
-          window.localStorage.setItem(STORAGE_KEY, k);
-          params.set('key', k);
-          window.location.search = '?' + params.toString();
-        };
-        save.addEventListener('click', submit);
-        input.addEventListener('keydown', (e) => {
-          if (e.key === 'Enter') submit();
-        });
-        input.focus();
-      })();
-    </script>
-
     <div class="panel">
       <div class="row">
-        <button id="detect">Detect 3D objects</button>
-        <button id="clear">Clear</button>
+        <button id="detectBtn">Detect</button>
+        <button id="clearBtn">Clear</button>
+        <button id="copyBtn">Copy diagnostics</button>
+        <span class="status" id="status">Ready.</span>
       </div>
       <div class="row">
-        <label for="detectorSelect">detector</label>
+        <label
+          >yaw°
+          <input
+            id="yawInput"
+            type="number"
+            step="1"
+            value="0"
+            style="width: 64px"
+        /></label>
+        <label
+          >pitch°
+          <input
+            id="pitchInput"
+            type="number"
+            step="1"
+            value="0"
+            style="width: 64px"
+        /></label>
+        <label
+          >roll°
+          <input
+            id="rollInput"
+            type="number"
+            step="1"
+            value="0"
+            style="width: 64px"
+        /></label>
+        <button id="resetRotBtn">Reset rotation</button>
+      </div>
+      <div class="row">
+        <label
+          ><input id="matchDepthViewInput" type="checkbox" />
+          matchDepthView</label
+        >
+        <label
+          ><input id="fullResDepthInput" type="checkbox" /> per-frame full-res
+          depth mesh</label
+        >
+        <label
+          >detector
         <select id="detectorSelect">
-          <option value="gemini">gemini (cloud, open-vocab)</option>
-          <option value="mediapipe">mediapipe (on-device, COCO)</option>
-          <option value="both">both (union, can double-up)</option>
-        </select>
-        <label for="maskSelect">mask</label>
+            <option value="gemini">gemini</option>
+            <option value="mediapipe">mediapipe</option>
+            <option value="both">both</option>
+          </select></label
+        >
+        <label
+          >mask
         <select id="maskSelect">
-          <option value="slimsam">slimsam-77 (tight)</option>
-          <option value="segmenter">mediapipe segmenter (loose)</option>
-        </select>
+            <option value="slimsam">slimsam</option>
+            <option value="mediapipe">mediapipe</option>
+          </select></label
+        >
+        <label
+          >orientation
+          <select id="orientSelect">
+            <option value="roomFrame">roomFrame</option>
+            <option value="free">free</option>
+            <option value="cardinal">cardinal (legacy)</option>
+          </select></label
+        >
       </div>
-      <div class="status" id="status">
-        Press detect to fit oriented 3D boxes around things in front of you.
+      <div class="hint">
+        Rotation offsets and orientation mode apply live to the next detect. The
+        two checkboxes and the detector/mask pickers reload the page (they must
+        be set before xb.init).
       </div>
+      <pre id="diagnostics">No detection yet.</pre>
     </div>
 
     <script type="module">
@@ -253,1961 +198,315 @@
         UIPanel,
         UIText,
       } from 'uiblocks';
-      import {
-        FilesetResolver,
-        InteractiveSegmenter,
-      } from '@mediapipe/tasks-vision';
-      import {
-        AutoProcessor,
-        env as transformersEnv,
-        RawImage,
-        SamModel,
-      } from '@huggingface/transformers';
+      import {Object3DDetector} from 'xrblocks/addons/objects3d/index.js';
 
-      // Route Mesh.raycast() through the BVH-accelerated path via the SDK
-      // helper (xb.applyBVH / xb.enableAcceleratedRaycast, added in the
-      // utils/BVHRaycast module) instead of patching the THREE prototypes
-      // inline. Each per-detection sampleDepthInMask fires ~1000
-      // stride-sampled rays at the depth mesh; the stock raycaster is
-      // O(triangles) per ray (full mesh walk), BVH is O(log triangles),
-      // which is the difference between ~3 s of raycast time per Detect
-      // press and ~30 ms. enableAcceleratedRaycast() dynamically imports
-      // three-mesh-bvh (resolved from this demo's importmap) and installs
-      // computeBoundsTree / disposeBoundsTree on BufferGeometry; kick it
-      // off here so it's ready well before the first press. We then call
-      // computeBoundsTree() once per detect on the cloned depth-mesh
-      // geometry (cheap because depth meshes are small) and
-      // disposeBoundsTree() in the finally to release the index.
-      // detect() awaits this promise before building the per-press tree,
-      // so a press that lands before the import resolves waits it out
-      // rather than silently falling back to the stock raycaster.
-      const bvhReady = xb.enableAcceleratedRaycast().catch(() => false);
+      // -----------------------------------------------------------------
+      // Settings. Anything that must be decided before xb.init() lives in
+      // the query string and is changed by reloading; anything the detector
+      // reads per-detect is applied live.
+      // -----------------------------------------------------------------
+      const params = new URLSearchParams(location.search);
+      const num = (name, fallback = 0) => {
+        const v = parseFloat(params.get(name));
+        return Number.isFinite(v) ? v : fallback;
+      };
+      const flag = (name) => params.get(name) === '1';
+      // For flags that default on: only an explicit '0' turns them off.
+      const flagOn = (name) => params.get(name) !== '0';
 
-      // Cache transformers.js model downloads in the browser so repeat runs
-      // don't re-fetch the SAM weights.
-      transformersEnv.allowLocalModels = false;
-
-      // Backend toggles via URL params so you can A/B the demo without an
-      // edit/reload cycle. Examples:
-      //   ?backend=gemini             (open-vocab cloud detector)
-      //   ?backend=mediapipe          (COCO on-device, default)
-      //   ?mask=slimsam               (transformers.js SAM, tighter, default)
-      //   ?mask=segmenter             (MediaPipe InteractiveSegmenter, looser)
-      const _qp = new URLSearchParams(window.location.search);
-      const _backendParam = _qp.get('backend');
-      // Default to 'gemini' for the best out-of-the-box demo: open-vocab
-      // labels with the most fits per single press. 'both' unions Gemini
-      // + MediaPipe but doubles non-overlapping detections (IoU dedupe
-      // only catches near-identical boxes), so it visually adds clutter
-      // without adding accuracy. Falls back to mediapipe via the
-      // selector dropdown if the user has no API key.
-      const DETECT_BACKEND = ['gemini', 'mediapipe', 'both'].includes(
-        _backendParam
-      )
-        ? _backendParam
-        : 'gemini';
-      const MASK_BACKEND =
-        _qp.get('mask') === 'segmenter' ? 'segmenter' : 'slimsam';
-
-      const boxes = new THREE.Group();
-      let xrStatusText = null;
-
-      // Lazy-loaded MediaPipe InteractiveSegmenter. Kept as a fallback for
-      // environments where the SAM path can't load (no WebGPU + no WASM fp16).
-      let _segmenter = null;
-      let _segmenterPromise = null;
-      function getSegmenter() {
-        if (_segmenter) return Promise.resolve(_segmenter);
-        if (_segmenterPromise) return _segmenterPromise;
-        _segmenterPromise = (async () => {
-          const vision = await FilesetResolver.forVisionTasks(
-            'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.34/wasm'
-          );
-          _segmenter = await InteractiveSegmenter.createFromOptions(vision, {
-            baseOptions: {
-              modelAssetPath:
-                'https://storage.googleapis.com/mediapipe-tasks/interactive_segmenter/ptm_512_hdt_ptm_woid.tflite',
-              delegate: 'GPU',
-            },
-            outputCategoryMask: true,
-            outputConfidenceMasks: false,
-          });
-          return _segmenter;
-        })();
-        return _segmenterPromise;
-      }
-
-      // Lazy-loaded SlimSAM-77-uniform via transformers.js. Tighter per-pixel
-      // masks than the MediaPipe segmenter, especially around wall-mounted
-      // objects where MediaPipe spills onto the surrounding wall. Apache-2,
-      // ~14 MB total (encoder + decoder). The encoder runs once per snapshot;
-      // the decoder runs per detection with the 2D bbox as the prompt.
-      const SAM_MODEL_ID = 'Xenova/slimsam-77-uniform';
-      let _sam = null;
-      let _samProc = null;
-      let _samPromise = null;
-      // SAM's ONNX session isn't reentrant: a second sam(...) call before the
-      // previous one resolves trips "Session already started". Detect runs are
-      // serial in the for-loop but multi-frame waits inside sampleDepth can
-      // overlap with later frames in batches with many objects. Serialise
-      // every sam(...) and proc(...) invocation behind a chained promise so
-      // ORT only ever sees one in-flight call.
-      let _samQueue = Promise.resolve();
-      function samSerialize(fn) {
-        const next = _samQueue.then(fn, fn);
-        _samQueue = next.catch(() => {});
-        return next;
-      }
-      function getSam() {
-        if (_sam && _samProc)
-          return Promise.resolve({sam: _sam, proc: _samProc});
-        if (_samPromise) return _samPromise;
-        _samPromise = (async () => {
-          // Prefer webgpu when available; transformers.js falls back to
-          // wasm/cpu transparently if the backend isn't supported.
-          const device =
-            'gpu' in navigator && navigator.gpu ? 'webgpu' : 'wasm';
-          _sam = await SamModel.from_pretrained(SAM_MODEL_ID, {
-            device,
-            dtype: device === 'webgpu' ? 'fp16' : 'fp32',
-          });
-          _samProc = await AutoProcessor.from_pretrained(SAM_MODEL_ID);
-          return {sam: _sam, proc: _samProc};
-        })();
-        return _samPromise;
-      }
-
-      // Run the SAM encoder on a snapshot ImageData once per Detect press.
-      // Subsequent per-detection mask requests reuse the embedding.
-      async function samEncodeSnapshot(snapshot) {
-        return samSerialize(async () => {
-          const {sam, proc} = await getSam();
-          const canvas = document.createElement('canvas');
-          canvas.width = snapshot.width;
-          canvas.height = snapshot.height;
-          canvas.getContext('2d').putImageData(snapshot, 0, 0);
-          const image = await RawImage.fromCanvas(canvas);
-          const image_inputs = await proc(image);
-          const image_embeddings = await sam.get_image_embeddings(image_inputs);
-          return {
-            image,
-            image_inputs,
-            image_embeddings,
-            width: snapshot.width,
-            height: snapshot.height,
-          };
-        });
-      }
-
-      // Per-detection: feed the SAM decoder a single bbox prompt and return
-      // a mask in the same shape sampleDepthInMask() already expects from the
-      // MediaPipe segmenter (width, height, getAsUint8Array() with <128 = fg).
-      async function samMaskFromBbox(samState, box2d) {
-        return samSerialize(async () => {
-          const {sam, proc} = await getSam();
-          const {image, image_embeddings, width, height} = samState;
-          const x1 = box2d.min.x * width;
-          const y1 = box2d.min.y * height;
-          const x2 = box2d.max.x * width;
-          const y2 = box2d.max.y * height;
-          const cx = (x1 + x2) * 0.5;
-          const cy = (y1 + y2) * 0.5;
-          const prompt_inputs = await proc(image, {
-            input_points: [
-              [
-                [
-                  [cx, cy],
-                  [x1, y1],
-                  [x2, y2],
-                ],
-              ],
-            ],
-            input_labels: [[[1, 2, 3]]],
-          });
-          const out = await sam({
-            ...prompt_inputs,
-            image_embeddings,
-          });
-          const masks = await proc.post_process_masks(
-            out.pred_masks,
-            prompt_inputs.original_sizes,
-            prompt_inputs.reshaped_input_sizes
-          );
-          const t = masks[0];
-          const dataBool = t.data;
-          const H = t.dims[t.dims.length - 2];
-          const W = t.dims[t.dims.length - 1];
-          const planeStride = H * W;
-          const numChannels = Math.max(
-            1,
-            Math.floor(dataBool.length / planeStride)
-          );
-          const ious = out.iou_scores?.data;
-          const bx1 = Math.max(0, Math.floor(x1 * (W / width)));
-          const by1 = Math.max(0, Math.floor(y1 * (H / height)));
-          const bx2 = Math.min(W, Math.ceil(x2 * (W / width)));
-          const by2 = Math.min(H, Math.ceil(y2 * (H / height)));
-          let best = 0;
-          let bestScore = -Infinity;
-          for (let c = 0; c < numChannels; c++) {
-            const off = c * planeStride;
-            let inside = 0;
-            let total = 0;
-            for (let y = 0; y < H; y++) {
-              const row = off + y * W;
-              const yIn = y >= by1 && y < by2;
-              for (let x = 0; x < W; x++) {
-                if (dataBool[row + x]) {
-                  total++;
-                  if (yIn && x >= bx1 && x < bx2) inside++;
-                }
-              }
-            }
-            if (total === 0) continue;
-            const containment = inside / total;
-            const iou = ious ? ious[c] : 0;
-            const score = containment + 0.05 * iou;
-            if (score > bestScore) {
-              bestScore = score;
-              best = c;
-            }
-          }
-          const offset = best * planeStride;
-          const buf = new Uint8Array(planeStride);
-          for (let i = 0; i < planeStride; i++) {
-            buf[i] = dataBool[offset + i] ? 0 : 255;
-          }
-          return {
-            width: W,
-            height: H,
-            getAsUint8Array: () => buf,
-            close: () => {},
-          };
-        });
-      }
-
-      // MediaPipe InteractiveSegmenter mask path. Takes the snapshot ImageData
-      // + a 2D bbox, prompts the segmenter with the bbox centre as a keypoint,
-      // and returns a mask in the same shape sampleDepthInMask expects.
-      // Used when ?mask=segmenter — looser than SAM but no model download.
-      async function segmenterMaskFromSnapshot(snapshot, box2d) {
-        const seg = await getSegmenter();
-        const canvas = document.createElement('canvas');
-        canvas.width = snapshot.width;
-        canvas.height = snapshot.height;
-        canvas.getContext('2d').putImageData(snapshot, 0, 0);
-        const cx = (box2d.min.x + box2d.max.x) * 0.5;
-        const cy = (box2d.min.y + box2d.max.y) * 0.5;
-        return await new Promise((resolve, reject) => {
-          try {
-            seg.segment(canvas, {keypoint: {x: cx, y: cy}}, (result) =>
-              resolve(result.categoryMask)
-            );
-          } catch (e) {
-            reject(e);
-          }
-        });
-      }
-
-      // Raycast each foreground mask pixel against the world-positioned depth
-      // mesh. Mask is iterated only inside the bbox region with a stride to
-      // keep raycast count reasonable. Foreground convention: Magic Touch
-      // returns 0 for the selected object, non-zero for background, so we
-      // accept pixels with value < 128.
-      const _raycaster = new THREE.Raycaster();
-      const _ndc = new THREE.Vector2();
-      function sampleDepthInMask(
-        mask,
-        box2d,
-        stride = 6,
-        maxDistance = 12,
-        cameraOverride = null,
-        meshOverride = null,
-        snapAspect = null
-      ) {
-        const points = [];
-        // Prefer snapshot-time camera + depth-mesh passed in over the live
-        // ones. Reading `xb.core.camera` or the live depth mesh here would
-        // race the render loop: the camera moves with mouse-look / head
-        // pose, and the depth mesh re-poses every frame to track the
-        // current camera. Raycasting frozen rays into a re-posed mesh
-        // produces a systematic offset between the snapshot pixels and
-        // the world-space hit, which is what shows up as boxes that
-        // hover next to objects instead of hugging them.
-        const camera = cameraOverride || xb.core.camera;
-        const mesh = meshOverride || xb.core.depth?.depthMesh;
-        if (!camera || !mesh) return points;
-        const sa = snapAspect ?? camera.userData?.snapAspect ?? camera.aspect;
-        const mw = mask.width;
-        const mh = mask.height;
-        const arr = mask.getAsUint8Array();
-        const xMin = Math.max(0, Math.floor(box2d.min.x * mw));
-        const xMax = Math.min(mw, Math.ceil(box2d.max.x * mw));
-        const yMin = Math.max(0, Math.floor(box2d.min.y * mh));
-        const yMax = Math.min(mh, Math.ceil(box2d.max.y * mh));
-        let fg = 0;
-        for (let py = yMin; py < yMax; py += stride) {
-          for (let px = xMin; px < xMax; px += stride) {
-            if (arr[py * mw + px] >= 128) continue;
-            fg++;
-            const u = (px + 0.5) / mw;
-            const v = (py + 0.5) / mh;
-            uvToNdc(u, v, sa, camera.aspect, _ndc);
-            _raycaster.setFromCamera(_ndc, camera);
-            const hits = _raycaster.intersectObject(mesh, false);
-            // Cap depth distance: ray can shoot through a window or open
-            // doorway to far background (trees outside the simulator room
-            // sit ~20 m out, well beyond any plausible indoor object). Drop
-            // hits past `maxDistance` so they don't blow up the OBB extents.
-            if (hits.length > 0 && hits[0].distance <= maxDistance) {
-              points.push(hits[0].point.clone());
-            }
-          }
-        }
-        return {points, foregroundPixels: fg};
-      }
-
-      // Cast a single ray through the 2D bbox centre using the *frozen*
-      // camera + depth-mesh snapshot to get the world-space anchor that
-      // actually matches the snapshot pixels we masked. The SDK provides
-      // obj.position, but it's computed against the SDK's own internal
-      // camera snapshot taken inside runDetection (milliseconds after
-      // our snapshot), so any live-camera drift in that gap shifts the
-      // anchor and visibly offsets the box. Returns null if the ray
-      // misses the mesh; callers fall back to the SDK anchor.
-      function anchorFromBboxCenter(box2d, camera, mesh, snapAspect = null) {
-        if (!box2d || !camera || !mesh) return null;
-        const sa = snapAspect ?? camera.userData?.snapAspect ?? camera.aspect;
-        const cx = (box2d.min.x + box2d.max.x) * 0.5;
-        const cy = (box2d.min.y + box2d.max.y) * 0.5;
-        uvToNdc(cx, cy, sa, camera.aspect, _ndc);
-        _raycaster.setFromCamera(_ndc, camera);
-        const hits = _raycaster.intersectObject(mesh, false);
-        return hits.length > 0 ? hits[0].point.clone() : null;
-      }
-
-      // Convert a snapshot uv coordinate ([0,1] left-right, top-bottom) to
-      // camera NDC. The simulator (and any source that center-crops the
-      // renderer to a different aspect than the camera) gives us a snapshot
-      // that only covers part of the camera's frustum. Mapping (u, v) ->
-      // (u*2-1, (1-v)*2-1) assumes the snapshot fills the full frustum,
-      // which is only true when their aspects match. The correction:
-      // when snap is narrower than camera the snapshot covers the full
-      // vertical FOV but only (snap_aspect / cam_aspect) of the horizontal
-      // FOV, and vice versa. Without this, every bbox-derived raycast is
-      // pulled outward along the mismatched axis and lands on the wrong
-      // world point.
-      function uvToNdc(u, v, snapAspect, camAspect, out) {
-        const sa = snapAspect ?? camAspect;
-        let sx = 1;
-        let sy = 1;
-        if (sa < camAspect) {
-          sx = sa / camAspect;
-        } else {
-          sy = camAspect / sa;
-        }
-        out.set((u * 2 - 1) * sx, ((1 - v) * 2 - 1) * sy);
-        return out;
-      }
-
-      // Clone the live depth mesh into a static snapshot mesh that won't
-      // re-pose during the Detect window. Mirrors the SDK's internal
-      // `getDepthMeshSnapshot` (src/world/objects/ObjectDetector.ts) so
-      // every per-detection raycast hits the exact mesh state the
-      // snapshot pixels correspond to.
-      function snapshotDepthMesh() {
-        const live = xb.core.depth?.depthMesh;
-        if (!live || !live.geometry) return null;
-        const clonedGeom = live.geometry.clone();
-        clonedGeom.computeBoundingSphere();
-        clonedGeom.computeBoundingBox();
-        // Build a BVH index on the cloned geometry. This is the speedup
-        // that turns per-press depth raycasts from ~3 s into ~30 ms for a
-        // typical ~10 k-triangle depth mesh. The index is disposed in the
-        // detect() finally block along with the geometry. Guarded in case
-        // enableAcceleratedRaycast() hasn't resolved yet: raycasts still
-        // work without the BVH, just slower.
-        if (clonedGeom.computeBoundsTree) clonedGeom.computeBoundsTree();
-        const snap = new THREE.Mesh(
-          clonedGeom,
-          new THREE.MeshBasicMaterial({visible: false})
-        );
-        live.getWorldPosition(snap.position);
-        live.getWorldQuaternion(snap.quaternion);
-        live.getWorldScale(snap.scale);
-        snap.updateMatrixWorld(true);
-        return snap;
-      }
-
-      // Multi-frame averaging wrapper. Each call to sampleDepthInMask reads
-      // the depth mesh's current vertex buffer; in the simulator the buffer
-      // is regenerated every frame from the live render, so successive calls
-      // across requestAnimationFrame ticks give independent depth samples for
-      // the same rays. Accumulating points across N frames before fitting
-      // pushes the OBB centroid toward the depth-stable mean of the surface
-      // and reduces the single-frame bias that's visible as box drift when
-      // the user orbits.
-      function nextFrame() {
-        return new Promise((r) => requestAnimationFrame(() => r()));
-      }
-      async function sampleDepthInMaskAcrossFrames(
-        mask,
-        box2d,
-        stride = 6,
-        frames = 3,
-        cameraOverride = null,
-        meshOverride = null,
-        snapAspect = null
-      ) {
-        // With a frozen camera + depth-mesh snapshot, multi-frame averaging
-        // is unnecessary and counterproductive: the snapshot already gives
-        // us a stable mesh state, and successive frames of the *live* mesh
-        // would only re-introduce the drift we just fixed. Take a single
-        // sample when overrides are provided, fall back to multi-frame
-        // accumulation only when neither override is set.
-        if (cameraOverride || meshOverride) {
-          const {points, foregroundPixels} = sampleDepthInMask(
-            mask,
-            box2d,
-            stride,
-            12,
-            cameraOverride,
-            meshOverride,
-            snapAspect
-          );
-          return {points, foregroundPixels};
-        }
-        const all = [];
-        let totalFg = 0;
-        for (let i = 0; i < frames; i++) {
-          if (i > 0) await nextFrame();
-          const {points, foregroundPixels} = sampleDepthInMask(
-            mask,
-            box2d,
-            stride
-          );
-          for (const p of points) all.push(p);
-          totalFg = Math.max(totalFg, foregroundPixels);
-        }
-        return {points: all, foregroundPixels: totalFg};
-      }
-
-      // Floor-plane estimate from the live depth mesh. Walks a stride sample
-      // of the mesh's vertex positions, lifts to world space, and takes the
-      // 5th percentile of Y. Robust to a few stray vertices near 0 because
-      // we use a percentile, and cheap because we stride sample. Cached once
-      // per Detect press so per-object snapping is O(1).
-      function estimateFloorY() {
-        const mesh = xb.core.depth?.depthMesh;
-        if (!mesh || !mesh.geometry) return null;
-        const pos = mesh.geometry.attributes.position;
-        if (!pos || !pos.count) return null;
-        mesh.updateMatrixWorld();
-        const ys = [];
-        const p = new THREE.Vector3();
-        const stride = Math.max(1, Math.floor(pos.count / 4000));
-        for (let i = 0; i < pos.count; i += stride) {
-          p.fromBufferAttribute(pos, i).applyMatrix4(mesh.matrixWorld);
-          if (Number.isFinite(p.y)) ys.push(p.y);
-        }
-        if (ys.length < 10) return null;
-        ys.sort((a, b) => a - b);
-        return ys[Math.floor(ys.length * 0.05)];
-      }
-
-      // If the OBB bottom dips below the estimated floor by more than `slack`,
-      // pin the bottom edge to the floor and keep the top fixed. For floor-
-      // sitting furniture this stops the box clipping through the ground
-      // (which is the most jarring visual artifact when orbiting the demo).
-      // Spatial fusion of OBBs across Detect presses, so each new viewpoint
-      // refines existing boxes instead of stacking duplicate boxes for the
-      // same physical object. Match an incoming OBB to an existing one when:
-      //   - same category bucket (small cup never merges with a couch), and
-      //   - centroid distance is within `merge_radius` (sum of half-sizes,
-      //     i.e. the new center sits inside an expanded version of the old).
-      // On match: blend the centroid using a running average weighted by
-      // sample count, union the extents to enclose both observations, and
-      // increment the sample counter so further presses converge.
-      function fuseIntoBoxes(newObb, label, cat) {
-        // Use the average of the three half-dims as the merge radius
-        // contribution, not max(...) + 15cm. Max-based grace overcounts
-        // for spherical/cubic small objects (a 30cm pendant lamp gives
-        // 30cm radius, so two lamps spaced under 60cm always merge into
-        // one box even though they're distinct fixtures). Average-based
-        // shrinks the radius for compact objects while keeping it
-        // generous for elongated furniture, which is what fusion needs:
-        // press-again from a different angle of *the same* sofa should
-        // still merge, but two adjacent lamps shouldn't.
-        const half = (s) => (s.x + s.y + s.z) / 6;
-        for (const g of boxes.children) {
-          const u = g.userData || {};
-          if (u.cat !== cat) continue;
-          const dx = u.center.x - newObb.center.x;
-          const dy = u.center.y - newObb.center.y;
-          const dz = u.center.z - newObb.center.z;
-          const dist = Math.hypot(dx, dy, dz);
-          const radius = half(u.size) + half(newObb.size);
-          if (dist > radius) continue;
-          // Match: rebuild this group's box from the merged OBB.
-          const n = (u.samples || 1) + 1;
-          const blendedCenter = new THREE.Vector3(
-            (u.center.x * (n - 1) + newObb.center.x) / n,
-            (u.center.y * (n - 1) + newObb.center.y) / n,
-            (u.center.z * (n - 1) + newObb.center.z) / n
-          );
-          // Union extents in a local frame centered at blendedCenter and
-          // aligned to the existing OBB's yaw. Project BOTH the new OBB's
-          // 8 corners AND the existing OBB's 8 corners into that frame
-          // and expand to enclose them. Seeding with ±existingSize/2 (as
-          // if the existing box were centered at blendedCenter) is
-          // wrong: the existing box is centered at u.center, which is
-          // offset from blendedCenter by the running-mean shift, so the
-          // seed would mis-place the old corners and shrink the fused
-          // box on every press.
-          const cs = Math.cos(u.angle);
-          const sn = Math.sin(u.angle);
-          let umin = Infinity,
-            umax = -Infinity;
-          let vmin = Infinity,
-            vmax = -Infinity;
-          let ymin = Infinity,
-            ymax = -Infinity;
-          function expandFromOBB(centerX, centerY, centerZ, sx, sy, sz, ang) {
-            const ca = Math.cos(ang);
-            const sa = Math.sin(ang);
-            for (const ix of [-1, 1]) {
-              for (const iy of [-1, 1]) {
-                for (const iz of [-1, 1]) {
-                  const lx = (ix * sx) / 2;
-                  const lz = (iz * sz) / 2;
-                  const wx = centerX + lx * ca + lz * sa;
-                  const wz = centerZ - lx * sa + lz * ca;
-                  const wy = centerY + (iy * sy) / 2;
-                  const du =
-                    (wx - blendedCenter.x) * cs - (wz - blendedCenter.z) * sn;
-                  const dv =
-                    (wx - blendedCenter.x) * sn + (wz - blendedCenter.z) * cs;
-                  if (du < umin) umin = du;
-                  if (du > umax) umax = du;
-                  if (dv < vmin) vmin = dv;
-                  if (dv > vmax) vmax = dv;
-                  if (wy < ymin) ymin = wy;
-                  if (wy > ymax) ymax = wy;
-                }
-              }
-            }
-          }
-          expandFromOBB(
-            u.center.x,
-            u.center.y,
-            u.center.z,
-            u.size.x,
-            u.size.y,
-            u.size.z,
-            u.angle
-          );
-          expandFromOBB(
-            newObb.center.x,
-            newObb.center.y,
-            newObb.center.z,
-            newObb.size.x,
-            newObb.size.y,
-            newObb.size.z,
-            newObb.angle
-          );
-          const sizeU = Math.max(0.02, umax - umin);
-          const sizeV = Math.max(0.02, vmax - vmin);
-          const sizeY = Math.max(0.02, ymax - ymin);
-          const uc = (umin + umax) / 2;
-          const vc = (vmin + vmax) / 2;
-          const fusedCenter = new THREE.Vector3(
-            blendedCenter.x + uc * cs + vc * sn,
-            (ymin + ymax) / 2,
-            blendedCenter.z - uc * sn + vc * cs
-          );
-          // Replace the group's geometry / position with the fused OBB.
-          const fusedObb = {
-            center: fusedCenter,
-            size: new THREE.Vector3(sizeU, sizeY, sizeV),
-            angle: u.angle,
-          };
-          rebuildBoxGroupGeometry(g, fusedObb);
-          g.userData.center = fusedCenter;
-          g.userData.size = fusedObb.size;
-          g.userData.samples = n;
-          return true;
-        }
-        return false;
-      }
-
-      // Rebuild a box group's edge geometry in place after fusion, without
-      // re-creating sprites / event listeners. Keeps label visible across
-      // refinement presses.
-      function rebuildBoxGroupGeometry(group, obb) {
-        const newGeom = new THREE.BoxGeometry(
-          obb.size.x,
-          obb.size.y,
-          obb.size.z
-        );
-        const newEdges = new THREE.EdgesGeometry(newGeom);
-        group.traverse((o) => {
-          if (o.isLineSegments) {
-            if (o.geometry) o.geometry.dispose();
-            o.geometry = newEdges.clone();
-          }
-        });
-        newGeom.dispose();
-        newEdges.dispose();
-        group.position.copy(obb.center);
-        group.rotation.y = obb.angle;
-        // Re-place the label above the new top.
-        if (group.userData.label) {
-          group.userData.label.position.set(0, obb.size.y / 2 + 0.06, 0);
-        }
-      }
-
-      function snapBoxToFloor(obb, floorY, slack = 0.05) {
-        if (floorY == null || !obb) return obb;
-        const top = obb.center.y + obb.size.y / 2;
-        const bot = obb.center.y - obb.size.y / 2;
-        if (bot < floorY - slack) {
-          const newSizeY = Math.max(0.02, top - floorY);
-          const newCenterY = floorY + newSizeY / 2;
-          obb.size = new THREE.Vector3(obb.size.x, newSizeY, obb.size.z);
-          obb.center = new THREE.Vector3(
-            obb.center.x,
-            newCenterY,
-            obb.center.z
-          );
-        }
-        return obb;
-      }
-
-      // 2D IoU on detection2DBoundingBox-style {min:{x,y},max:{x,y}} boxes
-      // already normalized to [0,1]. Used by unionDetections to drop
-      // duplicate detections when running both backends.
-      function box2dIoU(a, b) {
-        if (!a || !b) return 0;
-        const ix1 = Math.max(a.min.x, b.min.x);
-        const iy1 = Math.max(a.min.y, b.min.y);
-        const ix2 = Math.min(a.max.x, b.max.x);
-        const iy2 = Math.min(a.max.y, b.max.y);
-        const iw = Math.max(0, ix2 - ix1);
-        const ih = Math.max(0, iy2 - iy1);
-        const inter = iw * ih;
-        const aw = a.max.x - a.min.x;
-        const ah = a.max.y - a.min.y;
-        const bw = b.max.x - b.min.x;
-        const bh = b.max.y - b.min.y;
-        const u = aw * ah + bw * bh - inter;
-        return u > 0 ? inter / u : 0;
-      }
-
-      // Union two detection lists with IoU dedupe. Keeps every item in `a`,
-      // then appends items from `b` whose 2D bbox doesn't overlap any kept
-      // box by more than `iouThresh`. This gives MediaPipe's deterministic
-      // COCO list anchoring with Gemini's open-vocab additions stacked on
-      // top — fewer duplicate boxes labelled "couch" + "sofa" + "loveseat"
-      // for the same object.
-      function unionDetections(a, b, iouThresh = 0.5) {
-        const out = a.slice();
-        for (const it of b) {
-          let dup = false;
-          for (const k of out) {
-            if (
-              box2dIoU(it.detection2DBoundingBox, k.detection2DBoundingBox) >
-              iouThresh
-            ) {
-              dup = true;
-              break;
-            }
-          }
-          if (!dup) out.push(it);
-        }
-        return out;
-      }
-
-      // Label categorisation. Each category gets a different fitting
-      // strategy because the failure modes differ:
-      //   - flat:      mask spillover blows up extents; orientation matters
-      //   - light:     hanging fixtures pick up cord/ceiling, need clustering
-      //   - small:     depth-mesh resolution is coarser than the object
-      //   - furniture: well-defined footprints, mask is reliable
-      const FLAT_LABEL_RE =
-        /\b(art|artwork|painting|picture|poster|photo|photograph|mirror|frame|window|whiteboard|screen|monitor|tv|television|display|door|switch|outlet|socket|thermostat|plug|vent|register)\b/i;
-      const LIGHT_LABEL_RE =
-        /\b(lamp|lamps|lampshade|light|lightbulb|fixture|chandelier|sconce|pendant|lantern|bulb)\b/i;
-      const SMALL_LABEL_RE =
-        /\b(cup|mug|glass|bottle|book|magazine|remote|phone|pen|pencil|bowl|plate|coaster|candle|vase|pot|toy|tissue|controller|keys|wallet|clock)\b/i;
-      const TINY_FLAT_LABEL_RE =
-        /\b(switch|outlet|socket|thermostat|plug|vent|register|knob|handle|doorknob)\b/i;
-      // Architectural surfaces — Gemini sometimes returns these but they aren't
-      // "objects" we want boxes around. "stud"/"board"/"panel" cover
-      // wall-cladding variants; "floorboard" guarded by SURFACE check first.
-      const SURFACE_LABEL_RE =
-        /\b(walls?|floors?|floorboards?|ceilings?|ground|background|surface|stud|studs|panel|panels|panelling|paneling|board|boards|cladding|baseboard|baseboards|skirting|trim|moulding|molding)\b/i;
-      function isSurfaceLabel(label) {
-        if (!label) return false;
-        // A label like "wall-mounted lamp" matches both SURFACE ("wall") and
-        // LIGHT ("lamp"); when the label is clearly a recognised object
-        // category, prefer that over the surface match so the box is built.
-        if (
-          FLAT_LABEL_RE.test(label) ||
-          LIGHT_LABEL_RE.test(label) ||
-          SMALL_LABEL_RE.test(label)
-        ) {
-          return false;
-        }
-        return SURFACE_LABEL_RE.test(label);
-      }
-      function isFlatLabel(label) {
-        return !!label && FLAT_LABEL_RE.test(label);
-      }
-      function isTinyFlatLabel(label) {
-        return !!label && TINY_FLAT_LABEL_RE.test(label);
-      }
-      function categorize(label) {
-        if (!label) return 'furniture';
-        if (FLAT_LABEL_RE.test(label)) return 'flat';
-        if (LIGHT_LABEL_RE.test(label)) return 'light';
-        if (SMALL_LABEL_RE.test(label)) return 'small';
-        return 'furniture';
-      }
-
-      // Drop points more than `radius` metres from `anchor` in 3D. Anchor is
-      // the SDK's depth-raycast through the bbox centre — generally a clean
-      // hit on the object surface, so this 3D ball filter is much more
-      // selective than camera-distance filtering for non-flat objects.
-      function rejectByAnchor(points, anchor, radius) {
-        if (!anchor || points.length < 4) return points;
-        const kept = points.filter((p) => p.distanceTo(anchor) < radius);
-        return kept.length >= 6 ? kept : points;
-      }
-
-      // Estimate a sensible 3D ball radius from the 2D detection extent.
-      // Back-project the 2D bbox onto the plane through `anchor` perpendicular
-      // to the view direction: at that distance, the bbox covers a real-world
-      // quad. Half the quad's diagonal is the smallest ball that contains
-      // every point that could plausibly belong to the object, so use that as
-      // the radius and add a multiplier for headroom (anchor isn't perfectly
-      // at object centre; objects extend a bit forward/back of the plane).
-      //
-      // Falls back to `fallback` when `box2d`, `camera`, or `anchor` is
-      // missing, and clamps to [minR, maxR] to bound runaway tiny / huge
-      // bboxes (a detection covering 80% of the frame is almost always a
-      // false positive that we don't want eating the whole room).
-      function radiusFromBbox(
-        box2d,
-        camera,
-        anchor,
-        {pad = 1.3, minR = 0.2, maxR = 2.0, fallback = 0.8} = {}
-      ) {
-        if (!box2d || !camera || !anchor) return fallback;
-        const dist = camera.position.distanceTo(anchor);
-        if (!isFinite(dist) || dist <= 0) return fallback;
-        const bw = Math.max(0, box2d.max.x - box2d.min.x);
-        const bh = Math.max(0, box2d.max.y - box2d.min.y);
-        if (bw <= 0 || bh <= 0) return fallback;
-        // Vertical world extent of the full frame at this distance.
-        const fovRad = (camera.fov * Math.PI) / 180;
-        const frameH = 2 * dist * Math.tan(fovRad / 2);
-        const frameW = frameH * camera.aspect;
-        // Same aspect correction as uvToNdc: when the snapshot is
-        // center-cropped to a different aspect than the camera (sim's
-        // 512x512 vs 16:9 camera), a bbox of normalized width 0.5
-        // doesn't actually span half the camera's horizontal FOV — it
-        // spans (snap_aspect / cam_aspect) of it when snap is narrower.
-        // Without this correction the radius was ~78% too wide
-        // horizontally and the rejectByAnchor filter kept extra
-        // background / neighbor points that shouldn't belong to the
-        // object. Reads snapAspect from camera.userData where detect()
-        // stashes it; defaults to camera.aspect (no correction) when
-        // unset, which matches the legacy behaviour.
-        const snapAspect = camera.userData?.snapAspect ?? camera.aspect;
-        let sx = 1;
-        let sy = 1;
-        if (snapAspect < camera.aspect) {
-          sx = snapAspect / camera.aspect;
-        } else if (snapAspect > camera.aspect) {
-          sy = camera.aspect / snapAspect;
-        }
-        const worldW = bw * frameW * sx;
-        const worldH = bh * frameH * sy;
-        const halfDiag = 0.5 * Math.hypot(worldW, worldH);
-        return Math.min(maxR, Math.max(minR, pad * halfDiag));
-      }
-
-      // Drop points whose distance-to-camera differs by more than `tol`
-      // metres from the median.
-      function rejectByDepth(points, camera, tol) {
-        if (!camera || points.length < 4) return points;
-        const ds = points.map((p) => p.distanceTo(camera.position));
-        const sorted = ds.slice().sort((a, b) => a - b);
-        const med = sorted[Math.floor(sorted.length / 2)];
-        const kept = points.filter((_, i) => Math.abs(ds[i] - med) < tol);
-        return kept.length >= 6 ? kept : points;
-      }
-
-      // Like rejectByDepth but anchors against the SDK's bbox-centre
-      // raycast hit instead of the median sample distance. Critical when
-      // the SAM mask leaks badly onto the floor or wall: the median
-      // depth then *is* the floor/wall, so a median-based filter keeps
-      // the bleed. The anchor is set from the original 2D bbox centre
-      // and is close to the real object depth even when the mask is
-      // dominated by background pixels. Falls through to the filtered
-      // set when it's small so downstream point-count rejects the
-      // detection instead of silently using the bad points.
-      function rejectByAnchorDepth(points, camera, anchor, tol) {
-        if (!camera || !anchor || points.length < 4) return points;
-        const anchorDist = camera.position.distanceTo(anchor);
-        return points.filter(
-          (p) => Math.abs(p.distanceTo(camera.position) - anchorDist) < tol
-        );
-      }
-
-      // Keep only points within ±dy of the median Y. Used for hanging
-      // fixtures where cord/ceiling stragglers extend vertically but the
-      // lampshade itself is compact in Y.
-      function rejectByY(points, dy) {
-        if (points.length < 4) return points;
-        const ys = points.map((p) => p.y).sort((a, b) => a - b);
-        const med = ys[Math.floor(ys.length / 2)];
-        const kept = points.filter((p) => Math.abs(p.y - med) < dy);
-        return kept.length >= 6 ? kept : points;
-      }
-
-      // RANSAC plane fitter. Picks 3 random points, builds a plane, counts
-      // inliers within `eps`, repeats `iters` times. Returns the plane with
-      // the most inliers, refined: point = inlier centroid, normal kept from
-      // the winning sample. Robust to ~50% outliers (corner spillover etc).
-      function ransacPlane(points, iters = 80, eps = 0.02) {
-        if (points.length < 3) return null;
-        let best = {inliers: [], normal: null, point: null};
-        const ab = new THREE.Vector3();
-        const ac = new THREE.Vector3();
-        const n = new THREE.Vector3();
-        for (let it = 0; it < iters; it++) {
-          const ia = (Math.random() * points.length) | 0;
-          const ib = (Math.random() * points.length) | 0;
-          const ic = (Math.random() * points.length) | 0;
-          if (ia === ib || ib === ic || ia === ic) continue;
-          const a = points[ia],
-            b = points[ib],
-            c = points[ic];
-          ab.subVectors(b, a);
-          ac.subVectors(c, a);
-          n.crossVectors(ab, ac);
-          if (n.lengthSq() < 1e-8) continue;
-          n.normalize();
-          const d = -n.dot(a);
-          let count = 0;
-          for (const p of points) {
-            if (Math.abs(n.dot(p) + d) < eps) count++;
-          }
-          if (count > best.inliers.length) {
-            const inliers = points.filter((p) => Math.abs(n.dot(p) + d) < eps);
-            best = {inliers, normal: n.clone(), point: a};
-          }
-        }
-        if (!best.normal || best.inliers.length < 6) return null;
-        // Refit: centroid of inliers as plane point.
-        const c = new THREE.Vector3();
-        for (const p of best.inliers) c.add(p);
-        c.multiplyScalar(1 / best.inliers.length);
-        return {normal: best.normal, point: c, inliers: best.inliers};
-      }
-
-      // Shoot a ray through normalized image coords (u, v) ∈ [0,1] (top-left
-      // origin) into the scene, intersect with the plane (planePoint,
-      // planeNormal). Returns world-space hit point or null.
-      const _bboxRay = new THREE.Raycaster();
-      const _bboxNdc = new THREE.Vector2();
-      const _diff = new THREE.Vector3();
-      function rayToPlane(u, v, camera, planePoint, planeNormal) {
-        uvToNdc(u, v, camera.userData?.snapAspect, camera.aspect, _bboxNdc);
-        _bboxRay.setFromCamera(_bboxNdc, camera);
-        const denom = _bboxRay.ray.direction.dot(planeNormal);
-        if (Math.abs(denom) < 1e-6) return null;
-        _diff.subVectors(planePoint, _bboxRay.ray.origin);
-        const t = _diff.dot(planeNormal) / denom;
-        if (t <= 0) return null;
-        return _bboxRay.ray.origin
-          .clone()
-          .addScaledVector(_bboxRay.ray.direction, t);
-      }
-
-      // Project the 4 bbox corners onto the plane. Returns {TL, TR, BR, BL}
-      // or null if any corner misses the plane.
-      function projectBboxToPlane(box2d, camera, planePoint, planeNormal) {
-        const TL = rayToPlane(
-          box2d.min.x,
-          box2d.min.y,
-          camera,
-          planePoint,
-          planeNormal
-        );
-        const TR = rayToPlane(
-          box2d.max.x,
-          box2d.min.y,
-          camera,
-          planePoint,
-          planeNormal
-        );
-        const BR = rayToPlane(
-          box2d.max.x,
-          box2d.max.y,
-          camera,
-          planePoint,
-          planeNormal
-        );
-        const BL = rayToPlane(
-          box2d.min.x,
-          box2d.max.y,
-          camera,
-          planePoint,
-          planeNormal
-        );
-        if (!TL || !TR || !BR || !BL) return null;
-        return {TL, TR, BR, BL};
-      }
-
-      // ------- Fitter dispatcher -------
-      // Each fitter returns {center: Vector3, size: Vector3, angle: number}
-      // where `angle` is yaw around world Y. center.y / size.y are world Y.
-      function fitYawOBB(points, opts = {}) {
-        const cat = opts.category || 'furniture';
-        if (cat === 'flat') {
-          if (opts.tinyFlat) {
-            const r = fitTinyFlatOBB(opts);
-            if (r) return r;
-          }
-          const r = fitFlatOBB(points, opts);
-          if (r) return r;
-        }
-        if (cat === 'small') {
-          const r = fitSmallOBB(points, opts);
-          if (r) return r;
-        }
-        if (cat === 'light') {
-          const r = fitLightOBB(points, opts);
-          if (r) return r;
-        }
-        return fitFurnitureOBB(points);
-      }
-
-      // Tiny wall-mounted flats (switches, outlets, thermostats, vents).
-      // Their depth back-projection is unreliable — tiny pixel footprint at
-      // frame edges, depth-mesh artefacts. Instead: cast a ray from the
-      // camera through the bbox centre, extend to a reasonable wall hit, snap
-      // to the nearest cardinal wall plane (±X / ±Z), and project the bbox
-      // corners onto that wall to size the box.
-      const _tfRay = new THREE.Raycaster();
-      const _tfNdc = new THREE.Vector2();
-      function fitTinyFlatOBB(opts) {
-        if (!opts.box2d || !opts.camera) return null;
-        const cam = opts.camera;
-        const cx = (opts.box2d.min.x + opts.box2d.max.x) * 0.5;
-        const cy = (opts.box2d.min.y + opts.box2d.max.y) * 0.5;
-        uvToNdc(cx, cy, cam.userData?.snapAspect, cam.aspect, _tfNdc);
-        _tfRay.setFromCamera(_tfNdc, cam);
-        const o = _tfRay.ray.origin,
-          d = _tfRay.ray.direction;
-        // Use the SDK anchor distance if it looks plausible (within a 6m room),
-        // otherwise pick the closest cardinal wall the ray hits.
-        let anchorOk = false;
-        if (opts.anchor) {
-          const a = opts.anchor;
-          if (
-            Math.abs(a.x) <= 4 &&
-            Math.abs(a.z) <= 4 &&
-            a.y >= -0.5 &&
-            a.y <= 4
-          ) {
-            anchorOk = true;
-          }
-        }
-        // Find nearest cardinal wall hit. Walls assumed at x = ±roomHalf and
-        // z = ±roomHalf with roomHalf=3m (matches the wood-cabin sim).
-        const roomHalf = 3.0;
-        const candidates = [
-          {n: new THREE.Vector3(1, 0, 0), d: -roomHalf}, // x = -3
-          {n: new THREE.Vector3(-1, 0, 0), d: -roomHalf}, // x = +3
-          {n: new THREE.Vector3(0, 0, 1), d: -roomHalf}, // z = -3
-          {n: new THREE.Vector3(0, 0, -1), d: -roomHalf}, // z = +3
-        ];
-        let best = null;
-        for (const c of candidates) {
-          const denom = d.dot(c.n);
-          if (Math.abs(denom) < 1e-4) continue;
-          const num = -(o.dot(c.n) + c.d);
-          const t = num / denom;
-          if (t <= 0.05) continue;
-          const hit = o.clone().addScaledVector(d, t);
-          if (
-            Math.abs(hit.x) > roomHalf + 0.5 ||
-            Math.abs(hit.z) > roomHalf + 0.5
-          )
-            continue;
-          if (!best || t < best.t) best = {t, hit, n: c.n.clone()};
-        }
-        if (!best) return null;
-        // If the SDK anchor is much closer than the wall and looks plausible,
-        // prefer the anchor's depth (handles cabinets, half-walls etc.).
-        let center;
-        let normal = best.n;
-        if (anchorOk) {
-          const camToAnchor = opts.anchor.distanceTo(cam.position);
-          if (camToAnchor < best.t * 0.8) {
-            // Snap anchor onto nearest cardinal-aligned wall plane.
-            const a = opts.anchor;
-            const dx = roomHalf - Math.abs(a.x);
-            const dz = roomHalf - Math.abs(a.z);
-            if (dx < dz) {
-              center = new THREE.Vector3(Math.sign(a.x) * roomHalf, a.y, a.z);
-              normal = new THREE.Vector3(-Math.sign(a.x), 0, 0);
-            } else {
-              center = new THREE.Vector3(a.x, a.y, Math.sign(a.z) * roomHalf);
-              normal = new THREE.Vector3(0, 0, -Math.sign(a.z));
-            }
-          } else {
-            center = best.hit;
-          }
-        } else {
-          center = best.hit;
-        }
-        // Make sure the normal faces the camera so the front face is visible.
-        const toCam = cam.position.clone().sub(center);
-        if (normal.dot(toCam) < 0) normal.multiplyScalar(-1);
-        // Project the bbox corners onto the wall plane to size the box.
-        const corners = projectBboxToPlane(opts.box2d, cam, center, normal);
-        if (!corners) return null;
-        const angle = Math.atan2(normal.x, normal.z);
-        const cs = Math.cos(angle),
-          sn = Math.sin(angle);
-        let umin = Infinity,
-          umax = -Infinity;
-        let ymin = Infinity,
-          ymax = -Infinity;
-        let cxw = 0,
-          czw = 0;
-        for (const c of [corners.TL, corners.TR, corners.BR, corners.BL]) {
-          const u = (c.x - center.x) * cs - (c.z - center.z) * sn;
-          if (u < umin) umin = u;
-          if (u > umax) umax = u;
-          if (c.y < ymin) ymin = c.y;
-          if (c.y > ymax) ymax = c.y;
-          cxw += c.x;
-          czw += c.z;
-        }
-        cxw /= 4;
-        czw /= 4;
-        const sizeU = Math.max(0.04, Math.min(0.4, umax - umin));
-        const sizeY = Math.max(0.04, Math.min(0.4, ymax - ymin));
-        return {
-          center: new THREE.Vector3(cxw, (ymin + ymax) / 2, czw),
-          size: new THREE.Vector3(sizeU, sizeY, 0.04),
-          angle,
-        };
-      }
-
-      // Flat objects (paintings, TVs, windows, mirrors): fit a plane via
-      // RANSAC, then reproject Gemini's clean 2D bbox onto that plane to get
-      // tight extents that are immune to mask spillover.
-      function fitFlatOBB(points, opts) {
-        if (points.length < 6) return null;
-        // Use only points near the SDK anchor — the mask often spills onto
-        // adjacent geometry (TV stand, wall, etc) and pollutes RANSAC.
-        let workingPoints = points;
-        if (opts.anchor) {
-          const filtered = rejectByAnchor(points, opts.anchor, 0.6);
-          if (filtered.length >= 6) workingPoints = filtered;
-        }
-        const plane = ransacPlane(workingPoints, 200, 0.02);
-        if (!plane) return null;
-        // Force normal to be horizontal (gravity-aligned wall) and pointing
-        // toward the camera so the front face is visible.
-        let n = new THREE.Vector3(plane.normal.x, 0, plane.normal.z);
-        if (n.lengthSq() < 1e-6) return null;
-        n.normalize();
-        // Snap to nearest cardinal wall direction (±X or ±Z). Real walls in a
-        // rectangular room are axis-aligned; this prevents RANSAC from picking
-        // a near-degenerate diagonal normal when the painting is small.
-        if (Math.abs(n.x) > Math.abs(n.z)) {
-          n.set(Math.sign(n.x), 0, 0);
-        } else {
-          n.set(0, 0, Math.sign(n.z));
-        }
-        if (opts.camera) {
-          _diff.subVectors(opts.camera.position, plane.point);
-          if (n.dot(_diff) < 0) n.multiplyScalar(-1);
-        }
-        const angle = Math.atan2(n.x, n.z);
-        // Re-fit plane offset to the snapped normal using the median of inlier
-        // projections so the plane sits exactly on the wall surface.
-        const inliers = plane.inliers.length ? plane.inliers : workingPoints;
-        const offsets = inliers.map((p) => p.x * n.x + p.z * n.z);
-        offsets.sort((a, b) => a - b);
-        const offset = offsets[Math.floor(offsets.length / 2)];
-        const planePoint = new THREE.Vector3(n.x * offset, 0, n.z * offset);
-        // Use mask inlier extents — these hug the actual painting/TV pixels,
-        // unlike the 2D bbox which often includes neighboring geometry.
-        // Use 5%/95% percentiles per axis instead of min/max so a handful of
-        // stray mask pixels (typical SAM bleed onto adjacent wall) don't
-        // blow up sizeU / sizeY by 50%.
-        const cs = Math.cos(angle),
-          sn = Math.sin(angle);
-        const us = [];
-        const ys = [];
-        for (const p of inliers) {
-          us.push((p.x - planePoint.x) * cs - (p.z - planePoint.z) * sn);
-          ys.push(p.y);
-        }
-        const pctile = (arr, q) => {
-          const a = arr.slice().sort((x, y) => x - y);
-          return a[
-            Math.max(0, Math.min(a.length - 1, Math.floor(q * a.length)))
-          ];
-        };
-        const umin = pctile(us, 0.05);
-        const umax = pctile(us, 0.95);
-        const ymin = pctile(ys, 0.05);
-        const ymax = pctile(ys, 0.95);
-        const uc = (umin + umax) / 2;
-        const sizeU = Math.max(0.05, umax - umin);
-        const sizeY = Math.max(0.05, ymax - ymin);
-        const center = new THREE.Vector3(
-          planePoint.x + uc * cs,
-          (ymin + ymax) / 2,
-          planePoint.z - uc * sn
-        );
-        return {center, size: new THREE.Vector3(sizeU, sizeY, 0.05), angle};
-      }
-
-      // Small objects (cups, books, controllers): depth-mesh resolution is
-      // worse than the object itself, so mask points are unreliable. Use the
-      // bbox projected through the median depth and trust Gemini's pixel
-      // extents. Camera-facing axis-aligned-ish box.
-      function fitSmallOBB(points, opts) {
-        if (!opts.box2d || !opts.camera || points.length < 3) return null;
-        const camPos = opts.camera.position;
-        // Median camera-distance defines the depth.
-        const ds = points.map((p) => p.distanceTo(camPos));
-        const sorted = ds.slice().sort((a, b) => a - b);
-        const depth = sorted[Math.floor(sorted.length / 2)];
-        // Build a camera-facing plane at the median depth, gravity-aligned.
-        const fwd = new THREE.Vector3(0, 0, -1).applyQuaternion(
-          opts.camera.quaternion
-        );
-        fwd.y = 0;
-        if (fwd.lengthSq() < 1e-6) return null;
-        fwd.normalize();
-        const planePoint = camPos.clone().addScaledVector(fwd, depth);
-        const planeNormal = fwd.clone().multiplyScalar(-1);
-        const corners = projectBboxToPlane(
-          opts.box2d,
-          opts.camera,
-          planePoint,
-          planeNormal
-        );
-        if (!corners) return null;
-        const angle = Math.atan2(planeNormal.x, planeNormal.z);
-        const cs = Math.cos(angle),
-          sn = Math.sin(angle);
-        const all = [corners.TL, corners.TR, corners.BR, corners.BL];
-        let umin = Infinity,
-          umax = -Infinity;
-        let ymin = Infinity,
-          ymax = -Infinity;
-        let cx = 0,
-          cz = 0;
-        for (const c of all) {
-          const u = (c.x - planePoint.x) * cs - (c.z - planePoint.z) * sn;
-          if (u < umin) umin = u;
-          if (u > umax) umax = u;
-          if (c.y < ymin) ymin = c.y;
-          if (c.y > ymax) ymax = c.y;
-          cx += c.x;
-          cz += c.z;
-        }
-        cx /= 4;
-        cz /= 4;
-        const sizeU = Math.max(0.02, umax - umin);
-        const sizeY = Math.max(0.02, ymax - ymin);
-        // Depth (thickness): use mask point depth spread, clamp small.
-        const dmin = sorted[0],
-          dmax = sorted[sorted.length - 1];
-        const sizeV = Math.max(0.05, Math.min(0.4, dmax - dmin));
-        return {
-          center: new THREE.Vector3(cx, (ymin + ymax) / 2, cz),
-          size: new THREE.Vector3(sizeU, sizeY, sizeV),
-          angle,
-        };
-      }
-
-      // Hanging lights / lamps: mask often picks up the cord and bits of
-      // ceiling. Cluster on the densest depth bin (the lampshade) and fit
-      // furniture-style on that subset.
-      function fitLightOBB(points, opts) {
-        if (points.length < 6) return null;
-        // Tight depth filter (5cm) — lampshade is roughly planar in depth.
-        const tight = rejectByDepth(points, opts.camera, 0.1);
-        return fitFurnitureOBB(tight);
-      }
-
-      // Furniture: yaw-constrained PCA in XZ + percentile-clipped extents.
-      // Also widen with the 2D bbox reprojected at anchor depth, since the
-      // depth mask typically only covers the camera-facing face of the
-      // furniture and underestimates the full extent.
-      function fitFurnitureOBB(points) {
-        if (points.length < 6) return null;
-        // Robust centroid: median per-axis to ignore mask spillover outliers.
-        const xs = points.map((p) => p.x).sort((a, b) => a - b);
-        const ys = points.map((p) => p.y).sort((a, b) => a - b);
-        const zs = points.map((p) => p.z).sort((a, b) => a - b);
-        const med = (arr) => arr[Math.floor(arr.length / 2)];
-        let cx = med(xs),
-          cy = med(ys),
-          cz = med(zs);
-        let Sxx = 0,
-          Sxz = 0,
-          Szz = 0;
-        for (const p of points) {
-          const dx = p.x - cx,
-            dz = p.z - cz;
-          Sxx += dx * dx;
-          Sxz += dx * dz;
-          Szz += dz * dz;
-        }
-        let angle = 0.5 * Math.atan2(2 * Sxz, Sxx - Szz);
-        // Snap to nearest cardinal (0/±90/180). Indoor furniture is almost
-        // always wall-aligned, and PCA on partial depth scans of one face is
-        // too noisy to trust the off-axis rotation. The rare genuinely-rotated
-        // chair will be off by a few degrees, which is a good trade.
-        const candidates = [0, Math.PI / 2, -Math.PI / 2, Math.PI, -Math.PI];
-        let bestSnap = angle,
-          bestErr = Infinity;
-        for (const c of candidates) {
-          const err = Math.abs(
-            ((angle - c + Math.PI) % (2 * Math.PI)) - Math.PI
-          );
-          if (err < bestErr) {
-            bestErr = err;
-            bestSnap = c;
-          }
-        }
-        angle = bestSnap;
-        const cs = Math.cos(angle),
-          sn = Math.sin(angle);
-        // Project all points to local axes.
-        const us = [],
-          vs = [],
-          ysProj = [];
-        for (const p of points) {
-          const dx = p.x - cx,
-            dz = p.z - cz;
-          us.push(dx * cs + dz * sn);
-          vs.push(-dx * sn + dz * cs);
-          ysProj.push(p.y);
-        }
-        // Percentile clipping to drop ~5% extreme outliers per axis.
-        const pctile = (arr, p) => {
-          const sorted = arr.slice().sort((a, b) => a - b);
-          return sorted[
-            Math.max(
-              0,
-              Math.min(sorted.length - 1, Math.floor(p * sorted.length))
-            )
-          ];
-        };
-        const umin = pctile(us, 0.05);
-        const umax = pctile(us, 0.95);
-        const vmin = pctile(vs, 0.05);
-        const vmax = pctile(vs, 0.95);
-        const ymin = pctile(ysProj, 0.02);
-        const ymax = pctile(ysProj, 0.98);
-        const uc = (umin + umax) / 2;
-        const vc = (vmin + vmax) / 2;
-        const offX = uc * cs - vc * sn;
-        const offZ = uc * sn + vc * cs;
-        let centerX = cx + offX;
-        let centerY = (ymin + ymax) / 2;
-        let centerZ = cz + offZ;
-        const sizeU = Math.max(0.02, umax - umin);
-        const sizeY = Math.max(0.02, ymax - ymin);
-        const sizeV = Math.max(0.02, vmax - vmin);
-        return {
-          center: new THREE.Vector3(centerX, centerY, centerZ),
-          size: new THREE.Vector3(sizeU, sizeY, sizeV),
-          angle,
-        };
-      }
-
-      // Per-category line colors so categories are visually distinguishable
-      // at a glance: flat (paintings/TV) = orange, furniture = green,
-      // small (cup/remote) = cyan, light = yellow.
-      const CAT_COLOR = {
-        flat: 0xff9f0a,
-        furniture: 0x4cd964,
-        small: 0x64d2ff,
-        light: 0xffd60a,
+      const SETTINGS = {
+        yawDeg: num('camYawDeg'),
+        pitchDeg: num('camPitchDeg'),
+        rollDeg: num('camRollDeg'),
+        // On by default: raw depth-sensor frames need a depth-camera-to-view
+        // remap that measures worse on device. See README.
+        matchDepthView: flagOn('matchDepthView'),
+        // Off by default; the dominant frame-rate cost. See README.
+        fullResDepth: flag('fullResDepth'),
+        detector: params.get('backend') ?? 'gemini',
+        mask: params.get('mask') ?? 'slimsam',
+        // Applies live via setOrientationMode, so unlike the depth toggles
+        // this one never needs a reload.
+        orient: params.get('orient') ?? 'roomFrame',
       };
 
-      function makeLabelSprite(text, lineColor) {
-        // Render the label text into a 2D canvas, wrap it in a sprite so it
-        // billboards automatically. World height is fixed (~0.18 m) so the
-        // text reads at a consistent visual size regardless of box size.
-        const padX = 24;
-        const padY = 14;
-        const fontPx = 64;
-        const measureCanvas = document.createElement('canvas');
-        const measureCtx = measureCanvas.getContext('2d');
-        measureCtx.font = `bold ${fontPx}px sans-serif`;
-        const textW = Math.ceil(measureCtx.measureText(text).width);
-        const w = textW + padX * 2;
-        const h = fontPx + padY * 2;
-        const canvas = document.createElement('canvas');
-        canvas.width = w;
-        canvas.height = h;
-        const ctx = canvas.getContext('2d');
-        // Pill background colored to match the box edges.
-        const r = h / 2;
-        ctx.fillStyle = 'rgba(0,0,0,0.78)';
-        ctx.beginPath();
-        ctx.moveTo(r, 0);
-        ctx.lineTo(w - r, 0);
-        ctx.arc(w - r, r, r, -Math.PI / 2, Math.PI / 2);
-        ctx.lineTo(r, h);
-        ctx.arc(r, r, r, Math.PI / 2, -Math.PI / 2);
-        ctx.closePath();
-        ctx.fill();
-        ctx.strokeStyle = '#' + lineColor.toString(16).padStart(6, '0');
-        ctx.lineWidth = 4;
-        ctx.stroke();
-        ctx.font = `bold ${fontPx}px sans-serif`;
-        ctx.textBaseline = 'middle';
-        ctx.textAlign = 'center';
-        ctx.fillStyle = '#ffffff';
-        ctx.fillText(text, w / 2, h / 2 + 2);
-        const tex = new THREE.CanvasTexture(canvas);
-        tex.anisotropy = 8;
-        tex.minFilter = THREE.LinearFilter;
-        tex.magFilter = THREE.LinearFilter;
-        const mat = new THREE.SpriteMaterial({
-          map: tex,
-          transparent: true,
-          depthTest: false,
-          depthWrite: false,
-        });
-        const sprite = new THREE.Sprite(mat);
-        const targetH = 0.18;
-        const baseW = (targetH * w) / h;
-        sprite.scale.set(baseW, targetH, 1);
-        // Keep the label at roughly constant on-screen size by scaling with
-        // distance to the camera. Without this, the label balloons when the
-        // viewer walks up to an object and shrinks to nothing across the room.
-        // Clamped so labels never disappear and never dominate the frame.
-        const REF_DIST = 2.0;
-        const MIN_MUL = 0.55;
-        const MAX_MUL = 2.0;
-        const _camPos = new THREE.Vector3();
-        const _sprPos = new THREE.Vector3();
-        sprite.onBeforeRender = (renderer, scene, camera) => {
-          camera.getWorldPosition(_camPos);
-          sprite.getWorldPosition(_sprPos);
-          const d = _camPos.distanceTo(_sprPos);
-          let mul = d / REF_DIST;
-          if (mul < MIN_MUL) mul = MIN_MUL;
-          else if (mul > MAX_MUL) mul = MAX_MUL;
-          sprite.scale.set(baseW * mul, targetH * mul, 1);
-        };
-        // The xrblocks raycaster crashes on sprites without a camera reference;
-        // these labels are display-only so disable raycasting on them.
-        sprite.raycast = () => {};
-        return sprite;
-      }
-
-      function buildBoxGroup(obb, label, color = 0x4cd964) {
-        const group = new THREE.Group();
-        const geom = new THREE.BoxGeometry(obb.size.x, obb.size.y, obb.size.z);
-        const edges = new THREE.EdgesGeometry(geom);
-        // Two passes so the box reads clearly even when the object's mesh sits
-        // between the viewer and the back edges:
-        //   1. Faint pass with depthTest off, drawn first (renderOrder 0) so
-        //      occluded edges show through as a hint of where the back of the
-        //      box is.
-        //   2. Solid pass with normal depth testing, drawn after, so visible
-        //      edges in front of geometry pop crisply over the see-through.
-        const ghostLines = new THREE.LineSegments(
-          edges,
-          new THREE.LineBasicMaterial({
-            color,
-            transparent: true,
-            opacity: 0.25,
-            depthTest: false,
-            depthWrite: false,
-          })
-        );
-        ghostLines.renderOrder = 1;
-        group.add(ghostLines);
-
-        const lines = new THREE.LineSegments(
-          edges,
-          new THREE.LineBasicMaterial({
-            color,
-            transparent: true,
-            opacity: 0.95,
-          })
-        );
-        lines.renderOrder = 2;
-        group.add(lines);
-
-        // Build a canvas-based Sprite for the label. Sprites always face the
-        // camera (so labels stay readable from any viewing angle) and they
-        // sidestep the troika-three-text setup-timing issues that left the
-        // previous Text-based labels invisible. Render order is high so the
-        // label always reads on top of the box edges and the world geometry.
-        const labelSprite = makeLabelSprite(label, color);
-        labelSprite.position.set(0, obb.size.y / 2 + 0.06, 0);
-        labelSprite.renderOrder = 3;
-        group.add(labelSprite);
-        group.userData.label = labelSprite;
-        group.userData.labelText = label;
-
-        group.position.copy(obb.center);
-        group.rotation.y = obb.angle;
-        // Fusion bookkeeping so subsequent Detect presses can merge a new
-        // OBB into this one rather than stacking a duplicate.
-        group.userData.center = obb.center.clone();
-        group.userData.size = obb.size.clone();
-        group.userData.angle = obb.angle;
-        group.userData.samples = 1;
-        return group;
-      }
-
-      function setStatus(s) {
-        const el = document.getElementById('status');
-        if (el) el.textContent = s;
-        // The MSDF font uiblocks uses doesn't include the Unicode ellipsis
-        // glyph (U+2026), so swap it for three ASCII dots before handing
-        // the string to UIText, otherwise it renders as '?'.
-        if (xrStatusText) xrStatusText.setText(s.replace(/…/g, '...'));
-      }
-
-      function clearBoxes() {
-        while (boxes.children.length) {
-          const g = boxes.children[0];
-          boxes.remove(g);
-          g.traverse((o) => {
-            if (o.geometry) o.geometry.dispose();
-            if (o.material) {
-              if (Array.isArray(o.material)) {
-                o.material.forEach((m) => m.dispose && m.dispose());
-              } else if (o.material.dispose) {
-                o.material.dispose();
-              }
-            }
-            if (o.dispose && o !== g) o.dispose();
-          });
+      function reloadWith(overrides) {
+        const p = new URLSearchParams(location.search);
+        for (const [k, v] of Object.entries(overrides)) {
+          // Write '0' rather than deleting: some flags default on, so a
+          // missing param is not the same as an unchecked box.
+          if (v === null) p.delete(k);
+          else if (typeof v === 'boolean') p.set(k, v ? '1' : '0');
+          else p.set(k, String(v));
         }
+        location.search = '?' + p.toString();
       }
 
-      // Reentrancy guard. detect() runs for tens of seconds while monkey-
-      // patching xb.core.deviceCamera.getSnapshot; a concurrent press
-      // would capture our wrapper as its "original" and leave it
-      // installed when it restored, plus other SDK consumers calling
-      // getSnapshot during the overlap would receive the wrong cached
-      // frame. We disable the button in the UI but also gate here so
-      // programmatic callers (e.g. tests, playwright) can't trigger it.
-      let _detectInFlight = false;
+      const detector = new Object3DDetector({
+        detectBackend: SETTINGS.detector,
+        maskBackend: SETTINGS.mask === 'mediapipe' ? 'mediapipe' : 'slimsam',
+        showDebugBoxes: true,
+        cameraRotationOffset: {
+          yaw: THREE.MathUtils.degToRad(SETTINGS.yawDeg),
+          pitch: THREE.MathUtils.degToRad(SETTINGS.pitchDeg),
+          roll: THREE.MathUtils.degToRad(SETTINGS.rollDeg),
+            },
+        orientation: {mode: SETTINGS.orient},
+          });
+
+      // -----------------------------------------------------------------
+      // Diagnostics formatting, shared by the DOM readout and the XR panel.
+      // -----------------------------------------------------------------
+      const ms = (v) => (v == null ? '—' : `${v.toFixed(0)} ms`);
+      const DIAG_ROWS = [
+              [
+          'frame latency',
+          (d) =>
+            d.frameLatencyMs == null
+              ? 'no captureTime (may be stale)'
+              : ms(d.frameLatencyMs),
+        ],
+                [
+          'pose match',
+          (d) =>
+            d.poseMatchErrorMs == null ? 'live pose' : ms(d.poseMatchErrorMs),
+                ],
+        ['pose ring', (d) => `${d.poseRingSize} poses`],
+        [
+          'camera model',
+          (d) =>
+            `${d.usedDeviceCameraModel ? 'device' : 'RENDER (fallback)'}` +
+            ` · fov ${d.cameraFovDeg.toFixed(1)}° · aspect ${d.cameraAspect.toFixed(2)}`,
+              ],
+        [
+          'rot offset',
+          (d) =>
+            `yaw ${d.cameraRotationOffsetDeg.yaw.toFixed(1)}° ` +
+            `pitch ${d.cameraRotationOffsetDeg.pitch.toFixed(1)}° ` +
+            `roll ${d.cameraRotationOffsetDeg.roll.toFixed(1)}°`,
+            ],
+        ['snapshot', (d) => `${d.snapshotWidth}×${d.snapshotHeight}`],
+        [
+          'depth remap',
+          (d) =>
+            d.depthRemapIsIdentity == null
+              ? '—'
+              : d.depthRemapIsIdentity
+                ? 'identity'
+                : 'NON-identity',
+        ],
+        [
+          'depth vs eye',
+          (d) =>
+            d.depthVsEyeRotationDeg == null
+              ? '—'
+              : `${d.depthVsEyeRotationDeg.toFixed(1)}°`,
+        ],
+        ['depth verts', (d) => (d.depthMeshVertices ?? '—').toLocaleString()],
+        ['detections', (d) => `${d.detections2d} in 2D → ${d.fitted3d} fitted`],
+        [
+          'rejections',
+          (d) => {
+            const e = Object.entries(d.rejections);
+            return e.length ? e.map(([k, v]) => `${k}:${v}`).join(' ') : 'none';
+          },
+        ],
+        ['orientation', (d) => d.orientationMode],
+        [
+          'room yaw',
+          (d) =>
+            d.roomYawDeg == null
+              ? 'not estimated'
+              : `${d.roomYawDeg.toFixed(1)}° · conf ` +
+                `${(d.roomYawConfidence ?? 0).toFixed(2)} · ` +
+                `${(d.roomFrameSupportM2 ?? 0).toFixed(1)} m²`,
+        ],
+        [
+          'yaws',
+          (d) =>
+            d.yawStats.length === 0
+              ? 'none'
+              : d.yawStats
+                  .slice(0, 4)
+                  .map(
+                    (y) =>
+                      `${y.label}:${y.yawDeg.toFixed(0)}°` +
+                      `(rel ${y.roomRelativeYawDeg.toFixed(0)}°,` +
+                      `${y.confidence.toFixed(2)},${y.method})`
+          )
+                  .join(' '),
+        ],
+        [
+          'timings',
+          (d) =>
+            `wait ${d.timings.freshFrameWait.toFixed(0)} · ` +
+            `snap ${d.timings.snapshot.toFixed(0)} · ` +
+            `mesh ${d.timings.depthMeshSnapshot.toFixed(0)} · ` +
+            `2d ${d.timings.detect2d.toFixed(0)} · ` +
+            `fit ${d.timings.masksAndFit.toFixed(0)} · ` +
+            `total ${d.timings.total.toFixed(0)}`,
+        ],
+        ['error', (d) => d.error ?? 'none'],
+          ];
+
+      const LABEL_WIDTH = Math.max(...DIAG_ROWS.map(([l]) => l.length)) + 2;
+
+      function diagnosticsText() {
+        const d = detector.diagnostics;
+        if (!d) return 'No detection yet.';
+        return DIAG_ROWS.map(
+          ([label, fn]) => label.padEnd(LABEL_WIDTH) + fn(d)
+        ).join('\n');
+      }
+
+      // -----------------------------------------------------------------
+      // Shared actions
+      // -----------------------------------------------------------------
+      const statusEl = document.getElementById('status');
+      const diagnosticsEl = document.getElementById('diagnostics');
+      const detectBtn = document.getElementById('detectBtn');
+      let xrStatusText = null;
+      let inFlight = false;
+
+      function setStatus(text) {
+        statusEl.textContent = text;
+        xrStatusText?.setText(text);
+        console.log('[objects3d-addon]', text);
+      }
+
+      function refreshDiagnostics() {
+        diagnosticsEl.textContent = diagnosticsText();
+      }
 
       async function detect() {
-        if (!xb.core.world?.objects) {
-          setStatus('object detection not available');
-          return;
-        }
-        if (_detectInFlight) {
-          console.info(
-            '[objects_3d] detect already in flight, ignoring re-entry'
-          );
-          return;
-        }
-        _detectInFlight = true;
-        const detectBtn = document.getElementById('detect');
-        if (detectBtn) detectBtn.disabled = true;
+        if (inFlight) return;
+        inFlight = true;
+        detectBtn.disabled = true;
         setStatus('detecting…');
-        // Capture pixels first, then freeze the camera. Two reasons:
-        //   1. getSnapshot reads the current video frame, which itself
-        //      reflects the camera at the most recent render. Freezing
-        //      *after* the snapshot returns minimises drift between the
-        //      pixels and the camera matrices we'll raycast with.
-        //   2. We only call getSnapshot once and derive base64 from the
-        //      same imageData via canvas. The previous code called
-        //      getSnapshot twice (base64 then imageData), each of which
-        //      awaits and may end up reading two *different* video
-        //      frames, so SAM and the detectors would see different
-        //      pixels. One drawImage, one frame, two formats.
-        let snapImageData;
         try {
-          snapImageData = await xb.core.deviceCamera.getSnapshot({
-            outputFormat: 'imageData',
-          });
-        } catch (e) {
-          console.warn('[objects_3d] snapshot capture threw', e);
-          snapImageData = null;
-        }
-        if (!snapImageData) {
-          setStatus('no camera frame');
-          _detectInFlight = false;
-          if (detectBtn) detectBtn.disabled = false;
-          return;
-        }
-        const _b64Canvas = document.createElement('canvas');
-        _b64Canvas.width = snapImageData.width;
-        _b64Canvas.height = snapImageData.height;
-        _b64Canvas.getContext('2d').putImageData(snapImageData, 0, 0);
-        const snapBase64 = _b64Canvas.toDataURL('image/jpeg', 0.9);
-        // Now freeze the camera. State here reflects whatever the live
-        // camera became *after* the snapshot's drawImage finished, which
-        // is at most one render-loop tick later — close enough that the
-        // pixels and the matrix represent the same view.
-        const liveCam = xb.core.camera;
-        const frozenCam = liveCam.clone();
-        frozenCam.matrixAutoUpdate = false;
-        liveCam.updateMatrixWorld();
-        frozenCam.matrix.copy(liveCam.matrix);
-        frozenCam.matrixWorld.copy(liveCam.matrixWorld);
-        frozenCam.matrixWorldInverse.copy(liveCam.matrixWorld).invert();
-        frozenCam.projectionMatrix.copy(liveCam.projectionMatrix);
-        frozenCam.projectionMatrixInverse.copy(liveCam.projectionMatrixInverse);
-        frozenCam.position.copy(liveCam.position);
-        frozenCam.quaternion.copy(liveCam.quaternion);
-        // Diagnostic: if the snapshot aspect doesn't match the camera
-        // aspect, bbox-centre → NDC conversion will systematically miss
-        // along the mismatched axis (uvToNdc corrects for this; the warn
-        // is here so a regression in the correction surfaces quickly).
-        // Fire once per session: the simulator setup is constant, and
-        // logging on every Detect press is just noise after the first.
-        const snapAspect = snapImageData.width / snapImageData.height;
-        if (
-          !window._aspectWarned &&
-          Math.abs(snapAspect - liveCam.aspect) > 0.02
-        ) {
-          window._aspectWarned = true;
-          console.info(
-            '[objects_3d] snapshot vs camera aspect mismatch (corrected by uvToNdc)',
-            'snap',
-            snapImageData.width + 'x' + snapImageData.height,
-            '(' + snapAspect.toFixed(3) + ')',
-            'cam',
-            liveCam.aspect.toFixed(3)
-          );
-        }
-        // Stash the snapshot aspect on the frozen camera so every helper
-        // that has the camera (rayToPlane, fitTinyFlatOBB, etc.) can do
-        // the snapshot-vs-camera NDC correction without explicit threading.
-        frozenCam.userData.snapAspect = snapAspect;
-        // Snapshot the depth mesh in the same tick as the camera freeze
-        // so all three (pixels, camera, depth geometry) are coherent.
-        // Make sure the BVH prototype patch is installed before we build
-        // the per-press bounds tree. Kicked off at init so this is almost
-        // always already resolved; a very early press waits the dynamic
-        // import out here instead of racing it. Resolves false (not throw)
-        // if three-mesh-bvh is unreachable, in which case computeBoundsTree
-        // stays unpatched and the build below is skipped.
-        await bvhReady;
-        const frozenDepthMesh = snapshotDepthMesh();
-        if (!frozenDepthMesh) {
-          setStatus('no depth mesh');
-          _detectInFlight = false;
-          if (detectBtn) detectBtn.disabled = false;
-          return;
-        }
-        const _origGetSnapshot = xb.core.deviceCamera.getSnapshot.bind(
-          xb.core.deviceCamera
-        );
-        xb.core.deviceCamera.getSnapshot = async (opts) => {
-          if (opts?.outputFormat === 'base64') return snapBase64;
-          if (opts?.outputFormat === 'imageData') return snapImageData;
-          return _origGetSnapshot(opts);
-        };
-        // Start SAM init + encode in parallel with detection. Both
-        // network (gemini) and GPU (SAM encoder) work happens concurrently
-        // instead of serially, saving the smaller of the two stages on
-        // the critical path. The encode is a single shot on snapImageData,
-        // which is already pinned and won't change. Attach a no-op catch
-        // immediately so an early-return path doesn't leak the rejection
-        // as an UnhandledRejection warning; the real error surfaces when
-        // we await `samPrep` below (samState branch).
-        let samPrep = null;
-        if (MASK_BACKEND === 'slimsam') {
-          samPrep = (async () => {
-            await getSam();
-            return samEncodeSnapshot(snapImageData);
-          })();
-          samPrep.catch(() => {});
-        }
-        // Everything from here runs inside try/finally so the
-        // getSnapshot monkey-patch, the depth-mesh snapshot, the BVH
-        // bounds tree, the reentrancy flag, and the button-disabled
-        // state always come back even on detection / SAM / fitting
-        // failures. Without this, repeated failed presses leak memory
-        // and the cached-snapshot getter stays installed for other
-        // consumers.
-        try {
-          let detected = [];
-          try {
-            if (DETECT_BACKEND === 'both') {
-              // Run both detectors and union with IoU dedupe. Two
-              // separate runDetection calls because the SDK only exposes
-              // one activeBackend at a time. Run mediapipe first so its
-              // deterministic COCO results anchor the dedupe, then add
-              // gemini's open-vocab finds that don't overlap.
-              const cfg = xb.core.world.objects.options.objects.backendConfig;
-              const prev = cfg.activeBackend;
-              try {
-                cfg.activeBackend = 'mediapipe';
-                const mp = await xb.core.world.objects.runDetection();
-                cfg.activeBackend = 'gemini';
-                const gm = await xb.core.world.objects.runDetection();
-                detected = unionDetections(mp, gm);
-              } finally {
-                cfg.activeBackend = prev;
-              }
-            } else {
-              detected = await xb.core.world.objects.runDetection();
-            }
-          } catch (e) {
-            console.warn('[objects_3d] detection threw', e);
-            setStatus('detection failed (see console)');
-            return;
-          }
-          console.log(
-            '[objects_3d] runDetection returned',
-            detected.length,
-            'objects',
-            detected.map((o) => ({
-              label: o.label,
-              box: o.detection2DBoundingBox && {
-                min: o.detection2DBoundingBox.min.toArray(),
-                max: o.detection2DBoundingBox.max.toArray(),
-              },
-              pos: o.position && o.position.toArray(),
-            }))
-          );
-          if (!detected.length) {
-            setStatus('nothing detected');
-            return;
-          }
-          // Multi-view fusion: keep existing boxes across Detect presses
-          // so pressing from a new camera angle refines them instead of
-          // replacing them. Single-viewpoint OBBs always disagree
-          // slightly because depth raycasts from one POV can't see the
-          // back of an object; averaging centroids and unioning extents
-          // across views converges to the truth. Clear button is the
-          // explicit reset.
-          let samState = null;
-          if (MASK_BACKEND === 'slimsam') {
-            setStatus('encoding snapshot…');
-            try {
-              // Await the SAM prep we started in parallel with detection.
-              // By the time gemini returns, this is usually already done.
-              samState = await samPrep;
-            } catch (e) {
-              console.warn('[objects_3d] sam encoder failed', e);
-              setStatus('sam encoding failed (see console)');
-              return;
-            }
-          }
-          // Reuse the same imageData snapshot captured before
-          // runDetection so SAM masks line up exactly with the bboxes the
-          // detectors returned.
-          const snapshot = snapImageData;
-          // Restore the original snapshot getter; everything downstream
-          // (fitting, raycasting) uses the cached pixel data and the
-          // frozen camera, so there's no need to keep the monkey-patch
-          // active. The outer finally restores it too as a safety net.
-          xb.core.deviceCamera.getSnapshot = _origGetSnapshot;
-          setStatus('fitting boxes…');
-          const floorY = estimateFloorY();
-          // Pipeline the per-object work: mask decode (serial on GPU via
-          // samSerialize) overlaps with depth raycasts + OBB fitting for
-          // the previous object. Without pipelining we wait for mask N+1
-          // to finish decoding before even starting raycast N+1, even
-          // though the raycast is pure CPU and doesn't need the GPU.
-          // Returns null for rejected / surface-skip / failed entries so
-          // the result list stays aligned with `detected` order, which
-          // the final fuse pass walks serially (fuseIntoBoxes mutates
-          // the shared boxes group).
-          async function processOne(obj) {
-            try {
-              if (isSurfaceLabel(obj.label)) {
-                console.log('[objects_3d] skip surface label', obj.label);
-                return null;
-              }
-              const box2d = obj.detection2DBoundingBox;
-              let mask;
-              try {
-                mask =
-                  MASK_BACKEND === 'slimsam'
-                    ? await samMaskFromBbox(samState, box2d)
-                    : await segmenterMaskFromSnapshot(snapshot, box2d);
-              } catch (e) {
-                console.warn(
-                  '[objects_3d]',
-                  MASK_BACKEND,
-                  'mask threw for',
-                  obj.label,
-                  e
-                );
-                return null;
-              }
-              if (!mask) {
-                console.warn('[objects_3d] no mask for', obj.label);
-                return null;
-              }
-              const {points: raw, foregroundPixels} =
-                await sampleDepthInMaskAcrossFrames(
-                  mask,
-                  box2d,
-                  10,
-                  3,
-                  frozenCam,
-                  frozenDepthMesh,
-                  snapAspect
-                );
-              mask.close();
-              // Recompute the anchor ourselves through the frozen camera +
-              // frozen depth mesh so it lines up with the snapshot pixels.
-              // Falls back to the SDK anchor when the bbox-centre ray
-              // misses the mesh (e.g. the centre falls on a thin gap).
-              const anchor =
-                anchorFromBboxCenter(
-                  box2d,
-                  frozenCam,
-                  frozenDepthMesh,
-                  snapAspect
-                ) || obj.position;
-              const cat = categorize(obj.label);
-              // Category-specific outlier rejection. Flats skip upfront
-              // rejection entirely so RANSAC sees the full point set and
-              // finds the dominant plane (mask points off the wall become
-              // outliers there).
-              let points;
-              if (cat === 'flat') {
-                points = raw;
-              } else if (cat === 'small') {
-                const r = radiusFromBbox(box2d, frozenCam, anchor, {
-                  pad: 1.1,
-                  minR: 0.12,
-                  maxR: 0.3,
-                  fallback: 0.25,
-                });
-                points = rejectByAnchor(raw, anchor, r);
-              } else if (cat === 'light') {
-                const r = radiusFromBbox(box2d, frozenCam, anchor, {
-                  pad: 1.2,
-                  minR: 0.2,
-                  maxR: 0.7,
-                  fallback: 0.5,
-                });
-                points = rejectByY(rejectByAnchor(raw, anchor, r), 0.15);
-              } else {
-                const r = radiusFromBbox(box2d, frozenCam, anchor, {
-                  pad: 1.3,
-                  minR: 0.4,
-                  maxR: 2.0,
-                  fallback: 1.0,
-                });
-                const depthFiltered = rejectByAnchorDepth(
-                  raw,
-                  frozenCam,
-                  anchor,
-                  r
-                );
-                points = rejectByAnchor(depthFiltered, anchor, r);
-              }
-              const obb = fitYawOBB(points, {
-                category: cat,
-                camera: frozenCam,
-                anchor: anchor,
-                box2d,
-                tinyFlat: isTinyFlatLabel(obj.label),
-              });
-              if (!obb) {
-                console.info(
-                  '[objects_3d] no obb',
-                  obj.label,
-                  'cat',
-                  cat,
-                  'rawPts',
-                  raw.length,
-                  'keptPts',
-                  points.length
-                );
-                return null;
-              }
-              if (cat === 'furniture' || cat === 'small') {
-                snapBoxToFloor(obb, floorY);
-              }
-              const c = obb.center;
-              const farFromRoom =
-                Math.abs(c.x) > 6 || Math.abs(c.z) > 6 || c.y < -1 || c.y > 5;
-              const minPoints =
-                cat === 'small'
-                  ? 4
-                  : cat === 'light'
-                    ? 8
-                    : cat === 'flat'
-                      ? 8
-                      : 20;
-              const tinyFlat = isTinyFlatLabel(obj.label);
-              const tooFewPoints = !tinyFlat && points.length < minPoints;
-              const oversize =
-                obb.size.x > 4 || obb.size.y > 3 || obb.size.z > 4;
-              const horizMax = Math.max(obb.size.x, obb.size.z);
-              const degenerate =
-                cat !== 'flat' && horizMax > 0.5 && obb.size.y / horizMax < 0.1;
-              if (farFromRoom || tooFewPoints || oversize || degenerate) {
-                console.warn(
-                  '[objects_3d] reject',
-                  obj.label,
-                  'far',
-                  farFromRoom,
-                  'fewPts',
-                  tooFewPoints,
-                  'oversize',
-                  oversize,
-                  'degenerate',
-                  degenerate,
-                  'kept',
-                  points.length,
-                  'center',
-                  c.toArray().map((v) => +v.toFixed(2)),
-                  'size',
-                  obb.size.toArray().map((v) => +v.toFixed(2))
-                );
-                return null;
-              }
-              return {obb, label: obj.label || 'object', cat};
-            } catch (e) {
-              console.warn(
-                '[objects_3d] per-object pipeline threw for',
-                obj.label,
-                e?.message || String(e),
-                e?.stack || ''
-              );
-              return null;
-            }
-          }
-          const results = await Promise.all(detected.map(processOne));
-          // Serial fuse + add pass: fuseIntoBoxes iterates over
-          // boxes.children, and buildBoxGroup mutates it, so this can't
-          // race with itself or with another processOne completing.
-          let kept = 0;
-          for (const r of results) {
-            if (!r) continue;
-            const fused = fuseIntoBoxes(r.obb, r.label, r.cat);
-            if (!fused) {
-              const g = buildBoxGroup(
-                r.obb,
-                r.label,
-                CAT_COLOR[r.cat] || 0x4cd964
-              );
-              g.userData.cat = r.cat;
-              boxes.add(g);
-            }
-            kept++;
-          }
+          const objects = await detector.detect();
+          const d = detector.diagnostics;
           setStatus(
-            `fit ${kept} / ${detected.length} oriented boxes (press again from a new angle to refine)`
+            `${objects.length} objects · ${d ? (d.timings.total / 1000).toFixed(1) : '?'}s`
           );
+          if (d) console.info('[objects3d-addon] diagnostics', d);
+        } catch (e) {
+          console.error(e);
+          setStatus(`failed: ${e?.message ?? e}`);
         } finally {
-          // Centralized cleanup: every exit path from the inner try
-          // (success, "nothing detected", thrown detection, sam encoder
-          // fail) lands here. Restore the snapshot getter even if the
-          // inner happy-path already did it (idempotent), release the
-          // BVH index and geometry, free the material, and clear the
-          // reentrancy gate so the next press can run.
-          xb.core.deviceCamera.getSnapshot = _origGetSnapshot;
-          if (frozenDepthMesh.geometry) {
-            if (frozenDepthMesh.geometry.disposeBoundsTree) {
-              frozenDepthMesh.geometry.disposeBoundsTree();
-            }
-            frozenDepthMesh.geometry.dispose();
-          }
-          if (frozenDepthMesh.material?.dispose) {
-            frozenDepthMesh.material.dispose();
-          }
-          _detectInFlight = false;
-          if (detectBtn) detectBtn.disabled = false;
+          refreshDiagnostics();
+          inFlight = false;
+          detectBtn.disabled = false;
         }
       }
 
-      const options = new xb.Options();
-      options.enableUI();
-      options.enableAI();
-      options.enableCamera();
-      options.enableDepth();
-      options.depth.depthMesh.updateFullResolutionGeometry = true;
-      options.depth.depthTexture.enabled = false;
-      options.depth.matchDepthView = false;
-      options.enableObjectDetection();
-      options.world.objects.backendConfig.activeBackend =
-        DETECT_BACKEND === 'both' ? 'mediapipe' : DETECT_BACKEND;
-      options.world.objects.showDebugVisualizations = false;
-      // Override the SDK default prompt: stock prompt caps at 5 objects and
-      // is heavily worded toward "primary nearby" items, which produces low
-      // recall on a typical living-room scene. Ask for an exhaustive list
-      // including wall-mounted and small things; cap at 20 to give the OBB
-      // fitter headroom without blowing latency.
-      options.world.objects.backendConfig.gemini.systemInstruction =
-        'List every distinct object visible in the image, including small ' +
-        'items (cups, books, remotes), wall-mounted things (pictures, ' +
-        'switches, TVs), and ceiling fixtures (lamps, lights). For each, ' +
-        'return ymin, xmin, ymax, xmax as integers from 0 to 1000 (top-left ' +
-        'origin) and a short lowercase objectName. List up to 20 objects. ' +
-        'Skip walls, floor, ceiling, and any human body parts or UI ' +
-        'elements attached to them.';
-      // Lower MediaPipe's score gate so the demo surfaces borderline COCO
-      // detections (lamps, books, etc. that hover around 0.4). Stock 0.5 is
-      // tuned for production; for a demo we'd rather over-detect.
-      options.world.objects.backendConfig.mediapipe.scoreThreshold = 0.3;
-      // The SDK now exposes options.world.objects.backendConfig.gemini
-      // .generationConfig if you want to pin sampling (e.g. temperature: 0
-      // for deterministic detection). Left at default here so gemini's
-      // open-vocab range stays wide — the union backend benefits more from
-      // peak recall than from per-call repeatability.
-      options.reticles.enabled = true;
-      options.setAppTitle('3D Object Boxes');
-
-      // Used by the spatial cycle buttons + the DOM <select> dropdowns to
-      // re-enter the page with a new backend / mask choice. Reload is the
-      // simplest way to re-initialise options.world.objects.backendConfig
-      // and the mask path, both of which need to be set before xb.init().
-      function cycleQueryParam(name, value) {
-        const p = new URLSearchParams(window.location.search);
-        p.set(name, value);
-        window.location.search = '?' + p.toString();
+      function clearAll() {
+        detector.clearDetections();
+        setStatus('cleared.');
       }
 
-      // Spatial control panel for immersive XR. Built as an xb.Script so
-      // UICore + HeadLeashBehavior get the lifecycle hooks they need. The
-      // panel mirrors the DOM controls (detect / clear + detector / mask
-      // pickers) and shows live status. Uses uiblocks (preferred over the
-      // older xb.SpatialPanel per ruofei's guidance on PR #274).
-      class Objects3dControlPanel extends xb.Script {
+      function copyDiagnostics() {
+        const json = JSON.stringify(detector.diagnostics ?? {}, null, 2);
+        console.info('[objects3d-addon] diagnostics JSON\n' + json);
+        navigator.clipboard
+          ?.writeText(json)
+          .then(() => setStatus('diagnostics copied to clipboard.'))
+          .catch(() => setStatus('diagnostics logged to console.'));
+      }
+
+      // Applies immediately — the detector reads the mode at fit time.
+      const ORIENT_MODES = ['roomFrame', 'free', 'cardinal'];
+      function setOrientation(mode) {
+        SETTINGS.orient = mode;
+        detector.setOrientationMode(mode);
+        document.getElementById('orientSelect').value = mode;
+        xrOrientLabel?.setText(mode);
+        setStatus(`orientation = ${mode} — press detect to apply`);
+      }
+
+      // Applies immediately — the detector reads the offset at capture time.
+      function setRotation(axis, deg) {
+        SETTINGS[axis + 'Deg'] = deg;
+        detector.setCameraRotationOffset({
+          [axis]: THREE.MathUtils.degToRad(deg),
+        });
+        document.getElementById(axis + 'Input').value = String(deg);
+        xrRotationLabels[axis]?.setText(`${deg.toFixed(0)}°`);
+        setStatus(
+          `rotation offset yaw ${SETTINGS.yawDeg}° pitch ${SETTINGS.pitchDeg}° ` +
+            `roll ${SETTINGS.rollDeg}° — press detect to apply`
+        );
+      }
+
+      // -----------------------------------------------------------------
+      // DOM controls
+      // -----------------------------------------------------------------
+      detectBtn.addEventListener('click', detect);
+      document.getElementById('clearBtn').addEventListener('click', clearAll);
+      document
+        .getElementById('copyBtn')
+        .addEventListener('click', copyDiagnostics);
+      for (const axis of ['yaw', 'pitch', 'roll']) {
+        const input = document.getElementById(axis + 'Input');
+        input.value = String(SETTINGS[axis + 'Deg']);
+        input.addEventListener('change', () =>
+          setRotation(axis, parseFloat(input.value) || 0)
+        );
+      }
+      document.getElementById('resetRotBtn').addEventListener('click', () => {
+        for (const axis of ['yaw', 'pitch', 'roll']) setRotation(axis, 0);
+      });
+
+      const matchDepthViewInput = document.getElementById(
+        'matchDepthViewInput'
+      );
+      matchDepthViewInput.checked = SETTINGS.matchDepthView;
+      matchDepthViewInput.addEventListener('change', () =>
+        reloadWith({matchDepthView: matchDepthViewInput.checked})
+      );
+      const fullResDepthInput = document.getElementById('fullResDepthInput');
+      fullResDepthInput.checked = SETTINGS.fullResDepth;
+      fullResDepthInput.addEventListener('change', () =>
+        reloadWith({fullResDepth: fullResDepthInput.checked})
+      );
+      const detectorSelect = document.getElementById('detectorSelect');
+      const maskSelect = document.getElementById('maskSelect');
+      detectorSelect.value = SETTINGS.detector;
+      maskSelect.value = SETTINGS.mask;
+      detectorSelect.addEventListener('change', () =>
+        reloadWith({backend: detectorSelect.value})
+      );
+      maskSelect.addEventListener('change', () =>
+        reloadWith({mask: maskSelect.value})
+      );
+      const orientSelect = document.getElementById('orientSelect');
+      orientSelect.value = SETTINGS.orient;
+      orientSelect.addEventListener('change', () =>
+        setOrientation(orientSelect.value)
+      );
+
+      // -----------------------------------------------------------------
+      // Spatial control + diagnostics panel for immersive XR. Built as an
+      // xb.Script so UICore gets its lifecycle hooks. Mirrors the DOM
+      // controls, which are invisible once the session starts.
+      // -----------------------------------------------------------------
+      const xrRotationLabels = {};
+      let xrDiagnosticsRows = null;
+      let xrOrientLabel = null;
+
+      class DebugPanel extends xb.Script {
         init() {
           this.uiCore = new UICore(this);
           const card = this.uiCore.createCard({
-            name: 'Objects3dControlCard',
-            position: new THREE.Vector3(0, 1.4, -1.0),
-            sizeX: 0.62,
-            sizeY: 0.42,
+            name: 'Objects3dDebugCard',
+            position: new THREE.Vector3(0, 1.35, -0.95),
+            sizeX: 0.95,
+            sizeY: 0.6,
           });
-          const panel = new UIPanel({
+          const root = new UIPanel({
             width: '100%',
             height: '100%',
-            fillColor: 'rgba(15, 18, 25, 0.9)',
+            fillColor: 'rgba(15, 18, 25, 0.92)',
             innerShadowColor: 'rgba(100, 180, 255, 0.12)',
             innerShadowBlur: 60,
             strokeWidth: 3,
@@ -2219,102 +518,284 @@
                 {position: 1, color: '#9b5de5'},
               ],
             },
-            cornerRadius: 22,
-            padding: 18,
+            cornerRadius: 20,
+            padding: 16,
             flexDirection: 'column',
-            gap: 10,
+            gap: 8,
             alignItems: 'stretch',
-            justifyContent: 'flex-start',
           });
-          const titleText = new UIText('3D OBJECT BOXES', {
-            fontSize: 22,
+
+          root.add(
+            new UIText('3D OBJECT BOXES · ADDON', {
+              fontSize: 18,
             fontWeight: 'bold',
             color: '#00f0ff',
             textAlign: 'center',
             width: '100%',
-          });
-          xrStatusText = new UIText('idle', {
-            fontSize: 14,
-            color: '#a0aec0',
+            })
+          );
+          xrStatusText = new UIText(statusEl.textContent, {
+            fontSize: 12,
+            color: '#9ad',
             textAlign: 'center',
             width: '100%',
-            paddingBottom: 4,
           });
-          const separator = new UIPanel({
+          root.add(xrStatusText);
+          root.add(
+            new UIPanel({
             width: '100%',
             height: 2,
             fillColor: 'rgba(255, 255, 255, 0.12)',
-            marginBottom: 4,
-          });
-          const buttonRow = new UIPanel({
-            width: '100%',
-            flexDirection: 'row',
-            gap: 14,
-            justifyContent: 'center',
-            alignItems: 'center',
-          });
-          buttonRow.add(this.makeXrLabeledButton('search', 'detect', detect));
-          buttonRow.add(
-            this.makeXrLabeledButton('delete_sweep', 'clear', () => {
-              clearBoxes();
-              setStatus('cleared');
             })
           );
-          const pickerRow = new UIPanel({
+
+          // Two columns: controls on the left, live diagnostics on the right.
+          const body = new UIPanel({
             width: '100%',
+            flexGrow: 1,
             flexDirection: 'row',
-            gap: 10,
-            justifyContent: 'center',
-            alignItems: 'center',
-            marginTop: 4,
+            gap: 14,
+            alignItems: 'stretch',
           });
-          pickerRow.add(
-            this.makeXrCycleButton(
-              'detector',
-              DETECT_BACKEND,
-              ['gemini', 'mediapipe', 'both'],
-              (next) => cycleQueryParam('backend', next)
-            )
-          );
-          pickerRow.add(
-            this.makeXrCycleButton(
-              'mask',
-              MASK_BACKEND,
-              ['slimsam', 'segmenter'],
-              (next) => cycleQueryParam('mask', next)
-            )
-          );
-          panel.add(titleText);
-          panel.add(xrStatusText);
-          panel.add(separator);
-          panel.add(buttonRow);
-          panel.add(pickerRow);
-          card.add(panel);
+          body.add(this.buildControls());
+          body.add(this.buildDiagnostics());
+          root.add(body);
+
+          card.add(root);
           card.addBehavior(
             new ManipulationBehavior({draggable: true, faceCamera: true})
           );
         }
 
-        // Detect / clear: icon + caption stacked so XR users get the same
-        // affordance as the DOM "Detect 3D objects" / "Clear" buttons.
-        makeXrLabeledButton(iconName, label, onClick) {
+        buildControls() {
+          const col = new UIPanel({
+            width: '42%',
+            flexDirection: 'column',
+            gap: 6,
+            alignItems: 'stretch',
+          });
+
+          const buttons = new UIPanel({
+            width: '100%',
+            flexDirection: 'row',
+            gap: 8,
+            justifyContent: 'center',
+          });
+          buttons.add(this.iconButton('search', 'detect', detect));
+          buttons.add(this.iconButton('delete_sweep', 'clear', clearAll));
+          buttons.add(this.iconButton('content_copy', 'copy', copyDiagnostics));
+          col.add(buttons);
+
+          // Nudge the camera rotation offset live, ±5° per press.
+          for (const axis of ['yaw', 'pitch', 'roll']) {
+            col.add(this.rotationRow(axis));
+          }
+
+          // Everything below needs a reload to take effect.
+          const toggles = new UIPanel({
+            width: '100%',
+            flexDirection: 'row',
+            gap: 6,
+            justifyContent: 'center',
+            flexWrap: 'wrap',
+          });
+          toggles.add(
+            this.toggleButton('matchDepth', SETTINGS.matchDepthView, () =>
+              reloadWith({matchDepthView: !SETTINGS.matchDepthView})
+            )
+          );
+          toggles.add(
+            this.toggleButton('fullResDepth', SETTINGS.fullResDepth, () =>
+              reloadWith({fullResDepth: !SETTINGS.fullResDepth})
+            )
+          );
+          col.add(toggles);
+
+          // Orientation cycles live, so it sits apart from the reload pickers.
+          const orientRow = new UIPanel({
+            width: '100%',
+            flexDirection: 'row',
+            gap: 6,
+            justifyContent: 'center',
+          });
+          orientRow.add(
+            this.cycleButton(
+              'orientation',
+              SETTINGS.orient,
+              ORIENT_MODES,
+              setOrientation,
+              (label) => {
+                xrOrientLabel = label;
+              }
+            )
+          );
+          col.add(orientRow);
+
+          const pickers = new UIPanel({
+            width: '100%',
+            flexDirection: 'row',
+            gap: 6,
+            justifyContent: 'center',
+          });
+          pickers.add(
+            this.cycleButton(
+              'detector',
+              SETTINGS.detector,
+              ['gemini', 'mediapipe', 'both'],
+              (next) => reloadWith({backend: next})
+            )
+          );
+          pickers.add(
+            this.cycleButton(
+              'mask',
+              SETTINGS.mask,
+              ['slimsam', 'mediapipe'],
+              (next) => reloadWith({mask: next})
+            )
+          );
+          col.add(pickers);
+          return col;
+        }
+
+        buildDiagnostics() {
+          const col = new UIPanel({
+            width: '58%',
+            flexDirection: 'column',
+            gap: 1,
+            alignItems: 'stretch',
+            paddingLeft: 10,
+            paddingTop: 4,
+            paddingBottom: 4,
+            cornerRadius: 10,
+            fillColor: 'rgba(0, 0, 0, 0.3)',
+          });
+          xrDiagnosticsRows = DIAG_ROWS.map(([label]) => {
+            const row = new UIPanel({
+              width: '100%',
+              flexDirection: 'row',
+              gap: 6,
+              alignItems: 'center',
+            });
+            row.add(
+              new UIText(label, {
+                width: '38%',
+                fontSize: 9,
+                color: '#7d8794',
+                depthTest: false,
+                renderOrder: 100,
+              })
+            );
+            const value = new UIText('—', {
+              width: '62%',
+              fontSize: 9,
+              color: '#d0d6dd',
+              depthTest: false,
+              renderOrder: 100,
+            });
+            row.add(value);
+            col.add(row);
+            return value;
+          });
+          return col;
+        }
+
+        rotationRow(axis) {
+          const row = new UIPanel({
+            width: '100%',
+            flexDirection: 'row',
+            gap: 5,
+            alignItems: 'center',
+            justifyContent: 'center',
+          });
+          row.add(
+            new UIText(axis, {
+              width: 34,
+              fontSize: 10,
+              color: '#888888',
+              depthTest: false,
+              renderOrder: 100,
+            })
+          );
+          row.add(
+            this.smallButton('−5°', () =>
+              setRotation(axis, SETTINGS[axis + 'Deg'] - 5)
+            )
+          );
+          const label = new UIText(`${SETTINGS[axis + 'Deg'].toFixed(0)}°`, {
+            width: 42,
+            fontSize: 12,
+            fontWeight: 'bold',
+            color: '#ffffff',
+            textAlign: 'center',
+            depthTest: false,
+            renderOrder: 100,
+          });
+          xrRotationLabels[axis] = label;
+          row.add(label);
+          row.add(
+            this.smallButton('+5°', () =>
+              setRotation(axis, SETTINGS[axis + 'Deg'] + 5)
+            )
+          );
+          row.add(this.smallButton('0', () => setRotation(axis, 0)));
+          return row;
+        }
+
+        // A button that shows both its name and its current on/off state.
+        toggleButton(label, on, onClick) {
+          return this.cycleButton(label, on ? 'on' : 'off', [], onClick);
+        }
+
+        smallButton(text, onClick) {
           const idle = '#2a2a2a';
-          const hover = '#3a3a3a';
           const btn = new UIPanel({
-            paddingTop: 8,
-            paddingBottom: 8,
-            paddingLeft: 16,
-            paddingRight: 16,
-            cornerRadius: 12,
+            paddingTop: 3,
+            paddingBottom: 3,
+            paddingLeft: 7,
+            paddingRight: 7,
+            cornerRadius: 7,
+            fillColor: idle,
+            strokeWidth: 1,
+            strokeColor: '#444444',
+            alignItems: 'center',
+            justifyContent: 'center',
+            renderOrder: 10,
+            onHoverEnter: () => btn.setFillColor('#3a3a3a'),
+            onHoverExit: () => btn.setFillColor(idle),
+            onClick: () => {
+              btn.setFillColor('#4796e3');
+              setTimeout(() => btn.setFillColor(idle), 180);
+              onClick();
+            },
+          });
+          btn.add(
+            new UIText(text, {
+              fontSize: 11,
+              color: '#ffffff',
+              depthTest: false,
+              renderOrder: 100,
+            })
+          );
+          return btn;
+        }
+
+        iconButton(iconName, label, onClick) {
+          const idle = '#2a2a2a';
+          const btn = new UIPanel({
+            paddingTop: 6,
+            paddingBottom: 6,
+            paddingLeft: 10,
+            paddingRight: 10,
+            cornerRadius: 10,
             fillColor: idle,
             strokeWidth: 1,
             strokeColor: '#444444',
             flexDirection: 'row',
             alignItems: 'center',
             justifyContent: 'center',
-            gap: 8,
+            gap: 5,
             renderOrder: 10,
-            onHoverEnter: () => btn.setFillColor(hover),
+            onHoverEnter: () => btn.setFillColor('#3a3a3a'),
             onHoverExit: () => btn.setFillColor(idle),
             onClick: () => {
               btn.setFillColor('#4796e3');
@@ -2325,14 +806,14 @@
           btn.add(
             new UIIcon(iconName, {
               color: 'white',
-              width: 22,
-              height: 22,
+              width: 16,
+              height: 16,
               renderOrder: 12,
             })
           );
           btn.add(
             new UIText(label, {
-              fontSize: 14,
+              fontSize: 11,
               color: '#ffffff',
               fontWeight: 'bold',
               depthTest: false,
@@ -2342,111 +823,107 @@
           return btn;
         }
 
-        makeXrIconButton(iconName, onClick) {
+        // Tap to advance to the next value. Most of these reload the page
+        // (their setting must be applied before xb.init), but the ones that
+        // apply live track their own value, so pass onLabelReady to keep the
+        // caption in sync.
+        cycleButton(label, current, values, onChange, onLabelReady) {
           const idle = '#2a2a2a';
-          const hover = '#3a3a3a';
+          let value = current;
           const btn = new UIPanel({
-            width: 56,
-            height: 56,
-            cornerRadius: 12,
-            fillColor: idle,
-            strokeWidth: 1,
-            strokeColor: '#444444',
-            justifyContent: 'center',
-            alignItems: 'center',
-            onHoverEnter: () => btn.setFillColor(hover),
-            onHoverExit: () => btn.setFillColor(idle),
-            onClick: () => {
-              btn.setFillColor('#4796e3');
-              setTimeout(() => btn.setFillColor(idle), 180);
-              onClick();
-            },
-          });
-          btn.add(
-            new UIIcon(iconName, {color: 'white', width: 32, height: 32})
-          );
-          return btn;
-        }
-
-        // Tap-to-cycle picker for XR. Each press advances to the next value
-        // in the list and reloads the page so the backend gets re-initialised
-        // (mirrors the DOM <select> behaviour, which also reloads on change).
-        makeXrCycleButton(label, current, options, onChange) {
-          const idle = '#2a2a2a';
-          const hover = '#3a3a3a';
-          const btn = new UIPanel({
-            paddingTop: 6,
-            paddingBottom: 6,
-            paddingLeft: 12,
-            paddingRight: 12,
-            cornerRadius: 10,
+            paddingTop: 4,
+            paddingBottom: 4,
+            paddingLeft: 8,
+            paddingRight: 8,
+            cornerRadius: 8,
             fillColor: idle,
             strokeWidth: 1,
             strokeColor: '#444444',
             flexDirection: 'column',
             alignItems: 'center',
             justifyContent: 'center',
-            gap: 2,
             renderOrder: 10,
-            onHoverEnter: () => btn.setFillColor(hover),
+            onHoverEnter: () => btn.setFillColor('#3a3a3a'),
             onHoverExit: () => btn.setFillColor(idle),
             onClick: () => {
-              const idx = options.indexOf(current);
-              const next = options[(idx + 1) % options.length];
-              onChange(next);
+              if (values.length === 0) {
+                onChange();
+                return;
+              }
+              value = values[(values.indexOf(value) + 1) % values.length];
+              onChange(value);
             },
           });
           btn.add(
             new UIText(label, {
-              fontSize: 10,
+              fontSize: 8,
               color: '#888888',
               textAlign: 'center',
               depthTest: false,
               renderOrder: 100,
             })
           );
-          btn.add(
-            new UIText(current, {
-              fontSize: 14,
-              color: '#ffffff',
+          const valueText = new UIText(current, {
+            fontSize: 11,
+            color: current === 'off' ? '#888888' : '#ffffff',
               fontWeight: 'bold',
               textAlign: 'center',
               depthTest: false,
               renderOrder: 100,
-            })
-          );
+          });
+          btn.add(valueText);
+          onLabelReady?.(valueText);
           return btn;
+        }
+
+        // Repainting uikit text allocates, so only touch rows whose value
+        // actually changed, and only a few times a second.
+        update() {
+          if (!xrDiagnosticsRows) return;
+          const now = performance.now();
+          if (now - (this._lastRefresh ?? 0) < 250) return;
+          this._lastRefresh = now;
+          const d = detector.diagnostics;
+          this._cache ??= new Array(DIAG_ROWS.length).fill(null);
+          for (let i = 0; i < DIAG_ROWS.length; ++i) {
+            const text = d ? DIAG_ROWS[i][1](d) : '—';
+            if (text !== this._cache[i]) {
+              this._cache[i] = text;
+              xrDiagnosticsRows[i].setText(text);
+            }
+          }
         }
       }
 
-      xb.add(new Objects3dControlPanel());
-      xb.init(options);
-      xb.core.scene.add(boxes);
+      // -----------------------------------------------------------------
+      // Init
+      // -----------------------------------------------------------------
+      const options = new xb.Options();
+      options.enableUI();
+      options.enableAI();
+      options.enableCamera();
+      options.enableDepth();
+      // Off by default: the per-frame full-resolution rebuild unprojects
+      // ~23.7k vertices every depth frame. The detector rebuilds the
+      // full-res mesh on demand inside detect() instead.
+      options.depth.depthMesh.updateFullResolutionGeometry =
+        SETTINGS.fullResDepth;
+      options.depth.depthTexture.enabled = false;
+      options.depth.matchDepthView = SETTINGS.matchDepthView;
+      options.enableObjectDetection();
+      options.world.objects.showDebugVisualizations = false;
+      options.reticles.enabled = true;
+      options.setAppTitle('3D Object Boxes');
+
+      xb.add(detector);
+      xb.add(new DebugPanel());
+      await xb.init(options);
+
+      refreshDiagnostics();
       setStatus(
-        `Press Detect (then move around and press again to refine). backend=${DETECT_BACKEND} mask=${MASK_BACKEND}`
+        `Ready · detector=${SETTINGS.detector} mask=${SETTINGS.mask}` +
+          ` matchDepthView=${SETTINGS.matchDepthView} fullResDepth=${SETTINGS.fullResDepth}`
       );
-
-      document.getElementById('detect').addEventListener('click', detect);
-      document.getElementById('clear').addEventListener('click', () => {
-        clearBoxes();
-        setStatus('cleared');
-      });
-
-      // Backend selector: reflect current selection and reload on change so
-      // the `options.world.objects.backendConfig.activeBackend` + mask path
-      // get re-initialised cleanly (both must be set before xb.init()).
-      const detectorSel = document.getElementById('detectorSelect');
-      const maskSel = document.getElementById('maskSelect');
-      detectorSel.value = DETECT_BACKEND;
-      maskSel.value = MASK_BACKEND;
-      function reloadWithBackends() {
-        const p = new URLSearchParams(window.location.search);
-        p.set('backend', detectorSel.value);
-        p.set('mask', maskSel.value);
-        window.location.search = '?' + p.toString();
-      }
-      detectorSel.addEventListener('change', reloadWithBackends);
-      maskSel.addEventListener('change', reloadWithBackends);
     </script>
   </body>
 </html>

--- a/src/addons/objects3d/Object3DDetector.ts
+++ b/src/addons/objects3d/Object3DDetector.ts
@@ -1,21 +1,34 @@
 /**
  * Reusable 3-D object-detection Script addon.
  *
- * `Object3DDetector` wraps the full pipeline from the `objects_3d` demo into a
- * reusable {@link Script}: snap camera + depth mesh, run 2-D detection, obtain
+ * `Object3DDetector` wraps the full pipeline in a reusable {@link Script}:
+ * snap camera + depth mesh, run 2-D detection, obtain
  * per-object segmentation masks, raycast depth samples into world space, fit an
  * oriented bounding box (OBB), fuse across views, and optionally show debug
  * wireframe boxes.
  */
 
 import * as THREE from 'three';
-import {Script, core, enableAcceleratedRaycast} from 'xrblocks';
+import {
+  Script,
+  core,
+  enableAcceleratedRaycast,
+  getCameraParametersSnapshot,
+  getDeviceCameraWorldFromView,
+} from 'xrblocks';
 
 import {Detected3DObject} from './Detected3DObject';
 import {
   anchorFromBboxCenter,
   sampleDepthInMaskAcrossFrames,
 } from './geometry/DepthSampling';
+import {buildFrozenCamera} from './geometry/FrozenCamera';
+import {PoseRing} from './geometry/PoseRing';
+import {
+  estimateRoomYawFromMesh,
+  RoomFrameAccumulator,
+  yawRelativeToRoom,
+} from './geometry/RoomFrame';
 import {
   fuseIntoBoxes,
   snapBoxToFloor,
@@ -28,6 +41,7 @@ import {
   rejectByAnchorDepth,
   rejectByY,
 } from './geometry/ObbFitting';
+import type {OrientationMode, OrientationOptions} from './geometry/ObbFitting';
 import {categorize, isSurfaceLabel, isTinyFlatLabel} from './labels/Categories';
 import {samEncodeSnapshot, samMaskFromBbox, getSam} from './masks/SamMask';
 import {segmenterMaskFromSnapshot} from './masks/SegmenterMask';
@@ -85,6 +99,120 @@ export interface Object3DDetectorOptions {
    * @defaultValue `false`
    */
   showDebugBoxes?: boolean;
+  /**
+   * Maximum ray-hit distance in metres when sampling the depth mesh.
+   * @defaultValue `12`
+   */
+  maxRayDistance?: number;
+  /**
+   * World-space sanity bounds; fitted boxes whose centre falls outside are
+   * rejected. Tuned for a room-scale scene around the session origin.
+   * @defaultValue `{maxXZ: 6, minY: -1, maxY: 5}`
+   */
+  sceneBounds?: {maxXZ?: number; minY?: number; maxY?: number};
+  /**
+   * Assumed distance in metres from the session origin to the cardinal
+   * walls, used by the tiny-flat fitter (switches, outlets) to snap onto a
+   * wall plane. The default matches the simulator's wood-cabin scene; tune
+   * it (or avoid tiny-flat labels) for real rooms.
+   * @defaultValue `3`
+   */
+  roomHalf?: number;
+  /**
+   * Extra rotation applied to the device-camera pose at capture time, in
+   * radians (YXZ order, i.e. yaw about +Y first). Use this to null out a
+   * constant per-unit calibration error between the SDK's estimated
+   * passthrough-camera extrinsics and the actual hardware: if detections
+   * land rotated clockwise (viewed from above) by θ, pass `{yaw: θ}`.
+   * @defaultValue `{yaw: 0, pitch: 0, roll: 0}`
+   */
+  cameraRotationOffset?: {yaw?: number; pitch?: number; roll?: number};
+  /**
+   * How fitted yaws are reconciled with the room. Defaults to
+   * `{mode: 'roomFrame'}`, which estimates the room's own wall direction from
+   * the depth mesh and falls back to it only when an object's own orientation
+   * is ill-determined. Pass `{mode: 'cardinal'}` for the legacy behaviour of
+   * snapping every box to the session origin's axes.
+   */
+  orientation?: OrientationOptions;
+}
+
+/**
+ * Machine-readable record of what one {@link Object3DDetector.detect} call
+ * observed about its inputs. Chiefly useful for diagnosing on-device
+ * misalignment, where the interesting quantities (how stale the captured
+ * video frame was, whether the depth mesh is rotated relative to the render
+ * view) are invisible from the fitted boxes alone.
+ */
+export interface Object3DDetectorDiagnostics {
+  /** `performance.now()` when the detect call started. */
+  startedAtMs: number;
+  /** Age of the captured video frame at snapshot time, or `null` when the
+   * browser exposes no `captureTime` for the stream. Large values mean the
+   * pixels predate the pose, which rotates every box by the head motion in
+   * between. */
+  frameLatencyMs: number | null;
+  /** Gap between the frame's capture time and the timestamp of the recorded
+   * pose used for it. `null` when no historical pose was applied. */
+  poseMatchErrorMs: number | null;
+  /** Poses currently held in the history ring. */
+  poseRingSize: number;
+  /** Whether the frozen camera came from the SDK's device-camera model
+   * (`true`) or fell back to a clone of the XR render camera (`false`). */
+  usedDeviceCameraModel: boolean;
+  /** Vertical FOV and aspect of the frozen camera actually raycast through. */
+  cameraFovDeg: number;
+  cameraAspect: number;
+  /** Extra rotation applied on top of the SDK extrinsics, in degrees. */
+  cameraRotationOffsetDeg: {yaw: number; pitch: number; roll: number};
+  snapshotWidth: number;
+  snapshotHeight: number;
+  /** Whether the platform's view→depth-buffer UV remap is the identity. */
+  depthRemapIsIdentity: boolean | null;
+  /** Angle between the depth camera's reported orientation and the left eye's,
+   * in degrees. A large value with `matchDepthView: false` means the depth
+   * mesh every ray lands on is itself rotated. */
+  depthVsEyeRotationDeg: number | null;
+  /** Vertices in the frozen depth mesh snapshot. */
+  depthMeshVertices: number | null;
+  /** 2-D detections returned by the detector backend. */
+  detections2d: number;
+  /** Detections that survived fitting and the sanity gates. */
+  fitted3d: number;
+  /** Count of each rejection reason across all detections. */
+  rejections: Record<string, number>;
+  /** Wall-clock milliseconds per stage. */
+  timings: {
+    freshFrameWait: number;
+    snapshot: number;
+    depthMeshSnapshot: number;
+    detect2d: number;
+    masksAndFit: number;
+    total: number;
+  };
+  /** Populated when the call bailed out early. */
+  error: string | null;
+  /** Orientation policy in force for this call. */
+  orientationMode: OrientationMode;
+  /** Estimated room yaw in degrees, or `null` when no frame was available. */
+  roomYawDeg: number | null;
+  /** Confidence of the room frame, in `[0, 1]`. */
+  roomYawConfidence: number | null;
+  /** Vertical surface area that voted for the room frame, in m². */
+  roomFrameSupportM2: number | null;
+  /**
+   * Per-object yaw outcome. `roomRelativeYawDeg` is the useful one on device:
+   * if wall-aligned furniture reads ≈0 here but the boxes still look wrong,
+   * the fault is upstream in the camera model rather than in fitting.
+   */
+  yawStats: Array<{
+    label: string;
+    category: string;
+    yawDeg: number;
+    roomRelativeYawDeg: number;
+    confidence: number;
+    method: string;
+  }>;
 }
 
 // Kick off the three-mesh-bvh dynamic import at module load so it is ready
@@ -94,8 +222,9 @@ const _bvhReady: Promise<boolean> = enableAcceleratedRaycast().catch(
 );
 
 /**
- * Extracts the 3-D object-detection pipeline from the `objects_3d` demo into a
- * reusable {@link Script}. Attach it to the scene before `xb.init()`, then
+ * The 3-D object-detection pipeline as a reusable {@link Script}. See the
+ * `objects_3d` demo for a worked integration. Attach it to the scene before
+ * `xb.init()`, then
  * call `await detector.detect()` to populate `detector.results`.
  *
  * ```ts
@@ -108,9 +237,25 @@ const _bvhReady: Promise<boolean> = enableAcceleratedRaycast().catch(
  * ```
  */
 export class Object3DDetector extends Script {
-  private readonly _opts: Required<Object3DDetectorOptions>;
+  private readonly _opts: Required<
+    Omit<
+      Object3DDetectorOptions,
+      'sceneBounds' | 'cameraRotationOffset' | 'orientation'
+    >
+  > & {
+    sceneBounds: {maxXZ: number; minY: number; maxY: number};
+    cameraRotationOffset: {yaw: number; pitch: number; roll: number};
+    orientation: Required<Omit<OrientationOptions, 'roomYaw'>> & {
+      roomYaw: number | null;
+    };
+  };
   private _results: Detected3DObject[] = [];
   private _detectInFlight = false;
+  // ~1.3 s of pose history at 90 fps, enough to cover passthrough video
+  // pipeline latency when pairing a capture with its capture-time pose.
+  private readonly _poseRing = new PoseRing(120);
+  private readonly _roomFrame = new RoomFrameAccumulator();
+  private _diagnostics: Object3DDetectorDiagnostics | null = null;
 
   /**
    * @param options - Configuration options.
@@ -122,13 +267,119 @@ export class Object3DDetector extends Script {
       maskBackend: options.maskBackend ?? 'slimsam',
       fuseAcrossViews: options.fuseAcrossViews ?? true,
       showDebugBoxes: options.showDebugBoxes ?? false,
+      maxRayDistance: options.maxRayDistance ?? 12,
+      sceneBounds: {
+        maxXZ: options.sceneBounds?.maxXZ ?? MAX_CENTER_HORIZONTAL_DISTANCE_M,
+        minY: options.sceneBounds?.minY ?? MIN_CENTER_HEIGHT_M,
+        maxY: options.sceneBounds?.maxY ?? MAX_CENTER_HEIGHT_M,
+      },
+      roomHalf: options.roomHalf ?? 3,
+      cameraRotationOffset: {
+        yaw: options.cameraRotationOffset?.yaw ?? 0,
+        pitch: options.cameraRotationOffset?.pitch ?? 0,
+        roll: options.cameraRotationOffset?.roll ?? 0,
+      },
+      orientation: {
+        mode: options.orientation?.mode ?? 'roomFrame',
+        roomYaw: options.orientation?.roomYaw ?? null,
+        roomYawConfidence: options.orientation?.roomYawConfidence ?? 0,
+        snapToleranceRad:
+          options.orientation?.snapToleranceRad ?? (12 * Math.PI) / 180,
+        minYawConfidence: options.orientation?.minYawConfidence ?? 0.35,
+      },
     };
+  }
+
+  /**
+   * Record the device-camera pose every frame so {@link detect} can pair a
+   * captured video frame with the pose at the frame's `captureTime` — the
+   * passthrough video lags head tracking, so the pose at snapshot time is
+   * newer than the snapshot's pixels.
+   */
+  override update(): void {
+    const deviceCamera = core.deviceCamera;
+    if (!deviceCamera || deviceCamera.simulatorCamera) return;
+    const xrCameras = core.renderer?.xr?.getCamera?.();
+    if (!xrCameras?.cameras?.length) return;
+    try {
+      this._poseRing.push(
+        performance.now(),
+        getDeviceCameraWorldFromView(
+          core.camera,
+          xrCameras,
+          deviceCamera,
+          this._targetDevice()
+        )
+      );
+    } catch (_e) {
+      // Pose momentarily unavailable; skip this frame.
+    }
   }
 
   /** Currently fitted {@link Detected3DObject} instances from the last
    * (or accumulated) detect run. */
   get results(): Detected3DObject[] {
     return this._results;
+  }
+
+  /**
+   * Diagnostics from the most recent {@link detect} call, or `null` before
+   * the first one. See {@link Object3DDetectorDiagnostics}.
+   */
+  get diagnostics(): Object3DDetectorDiagnostics | null {
+    return this._diagnostics;
+  }
+
+  /** Poses currently held in the capture-time pose history ring. */
+  get poseRingSize(): number {
+    return this._poseRing.size;
+  }
+
+  /** Extra rotation applied to the device-camera pose, in radians. */
+  get cameraRotationOffset(): {yaw: number; pitch: number; roll: number} {
+    return {...this._opts.cameraRotationOffset};
+  }
+
+  /**
+   * Adjust the camera rotation offset between detections, so a calibration
+   * error can be nulled out interactively instead of by reloading. Omitted
+   * components are left unchanged.
+   */
+  setCameraRotationOffset(offset: {
+    yaw?: number;
+    pitch?: number;
+    roll?: number;
+  }): void {
+    const current = this._opts.cameraRotationOffset;
+    current.yaw = offset.yaw ?? current.yaw;
+    current.pitch = offset.pitch ?? current.pitch;
+    current.roll = offset.roll ?? current.roll;
+  }
+
+  /** The orientation policy currently in force. */
+  get orientationMode(): OrientationMode {
+    return this._opts.orientation.mode;
+  }
+
+  /**
+   * Switch orientation policy between detections, so the modes can be
+   * A/B compared on device without reloading.
+   */
+  setOrientationMode(mode: OrientationMode): void {
+    this._opts.orientation.mode = mode;
+  }
+
+  /** The room frame accumulated so far, or `null` before any usable estimate. */
+  get roomFrame(): ReturnType<RoomFrameAccumulator['push']> {
+    return this._roomFrame.current;
+  }
+
+  /**
+   * Discard the accumulated room frame. Call this after the user recenters or
+   * moves to a different space; {@link clearDetections} does it too.
+   */
+  resetRoomFrame(): void {
+    this._roomFrame.reset();
   }
 
   /**
@@ -152,6 +403,7 @@ export class Object3DDetector extends Script {
       this.remove(obj);
     }
     this._results = [];
+    this._roomFrame.reset();
   }
 
   /**
@@ -188,6 +440,77 @@ export class Object3DDetector extends Script {
     }
     this._detectInFlight = true;
 
+    const t0 = performance.now();
+    const diag: Object3DDetectorDiagnostics = {
+      startedAtMs: t0,
+      frameLatencyMs: null,
+      poseMatchErrorMs: null,
+      poseRingSize: this._poseRing.size,
+      usedDeviceCameraModel: false,
+      cameraFovDeg: 0,
+      cameraAspect: 0,
+      cameraRotationOffsetDeg: {
+        yaw: THREE.MathUtils.radToDeg(this._opts.cameraRotationOffset.yaw),
+        pitch: THREE.MathUtils.radToDeg(this._opts.cameraRotationOffset.pitch),
+        roll: THREE.MathUtils.radToDeg(this._opts.cameraRotationOffset.roll),
+      },
+      snapshotWidth: 0,
+      snapshotHeight: 0,
+      depthRemapIsIdentity: null,
+      depthVsEyeRotationDeg: null,
+      depthMeshVertices: null,
+      detections2d: 0,
+      fitted3d: 0,
+      rejections: {},
+      timings: {
+        freshFrameWait: 0,
+        snapshot: 0,
+        depthMeshSnapshot: 0,
+        detect2d: 0,
+        masksAndFit: 0,
+        total: 0,
+      },
+      error: null,
+      orientationMode: this._opts.orientation.mode,
+      roomYawDeg: null,
+      roomYawConfidence: null,
+      roomFrameSupportM2: null,
+      yawStats: [],
+    };
+    const bail = (message: string): Detected3DObject[] => {
+      console.warn(`[Object3DDetector] ${message}`);
+      diag.error = message;
+      diag.timings.total = performance.now() - t0;
+      this._diagnostics = diag;
+      this._detectInFlight = false;
+      return this._results;
+    };
+
+    if (!deviceCamera) {
+      return bail('device camera not available');
+    }
+
+    // Wait for a fresh video frame before snapshotting: inside an immersive
+    // session the hidden <video> element can be throttled, so getSnapshot
+    // would otherwise read a frame captured seconds ago from a different
+    // head pose — every box from that capture then lands rotated by the
+    // intervening head motion. The frame's captureTime also lets us pick the
+    // pose the head actually had when the pixels were captured.
+    let captureTimeMs: number | null = null;
+    try {
+      const meta = await deviceCamera.waitForFreshFrame?.();
+      if (meta) {
+        captureTimeMs = meta.captureTime ?? meta.receiveTime ?? null;
+        if (captureTimeMs !== null) {
+          diag.frameLatencyMs = performance.now() - captureTimeMs;
+        }
+      }
+    } catch (_e) {
+      // Freshness signal is best-effort only.
+    }
+    const tAfterWait = performance.now();
+    diag.timings.freshFrameWait = tAfterWait - t0;
+
     // Wrap the whole body so the in-flight guard is always cleared even if the
     // setup below (canvas / camera clone / bvh / depth snapshot) throws; one
     // failure must not wedge the detector permanently.
@@ -196,18 +519,15 @@ export class Object3DDetector extends Script {
       let snapImageData: ImageData | null = null;
       try {
         snapImageData =
-          deviceCamera?.getSnapshot({outputFormat: 'imageData'}) ?? null;
+          deviceCamera.getSnapshot({outputFormat: 'imageData'}) ?? null;
       } catch (_e) {
         snapImageData = null;
       }
       if (!snapImageData) {
-        console.warn('[Object3DDetector] no camera frame available');
-        return this._results;
+        return bail('no camera frame available');
       }
-      if (!deviceCamera) {
-        console.warn('[Object3DDetector] device camera not available');
-        return this._results;
-      }
+      diag.snapshotWidth = snapImageData.width;
+      diag.snapshotHeight = snapImageData.height;
 
       // Derive base64 from the same ImageData to avoid a second video-frame read.
       const b64Canvas = document.createElement('canvas');
@@ -216,20 +536,25 @@ export class Object3DDetector extends Script {
       b64Canvas.getContext('2d')!.putImageData(snapImageData, 0, 0);
       const snapBase64 = b64Canvas.toDataURL('image/jpeg', 0.9);
 
-      // Freeze the camera matrix so raycasts align with snapshot pixels.
-      const liveCam = core.camera;
-      const frozenCam = liveCam.clone() as THREE.PerspectiveCamera;
-      frozenCam.matrixAutoUpdate = false;
-      liveCam.updateMatrixWorld();
-      frozenCam.matrix.copy(liveCam.matrix);
-      frozenCam.matrixWorld.copy(liveCam.matrixWorld);
-      frozenCam.matrixWorldInverse.copy(liveCam.matrixWorld).invert();
-      frozenCam.projectionMatrix.copy(liveCam.projectionMatrix);
-      frozenCam.projectionMatrixInverse.copy(liveCam.projectionMatrixInverse);
-      frozenCam.position.copy(liveCam.position);
-      frozenCam.quaternion.copy(liveCam.quaternion);
+      // Freeze the camera model at snapshot time so raycasts align with the
+      // snapshot pixels. The RGB frame comes from the physical passthrough
+      // camera, whose intrinsics and pose differ from the XR render camera
+      // (e.g. on Galaxy XR: ~48° vertical FOV near the right eye, versus the
+      // ~90°+ union frustum between the eyes), so build the frozen camera from
+      // the SDK's device-camera model. In the simulator both models coincide.
       const snapAspect = snapImageData.width / snapImageData.height;
-      frozenCam.userData = {...frozenCam.userData, snapAspect};
+      const deviceCam = this._buildDeviceFrozenCamera(
+        snapAspect,
+        captureTimeMs,
+        diag
+      );
+      const frozenCam = deviceCam ?? this._buildRenderFrozenCamera(snapAspect);
+      diag.usedDeviceCameraModel = deviceCam !== null;
+      diag.cameraFovDeg = frozenCam.fov;
+      diag.cameraAspect = frozenCam.aspect;
+      this._collectDepthDiagnostics(diag);
+      const tAfterSnapshot = performance.now();
+      diag.timings.snapshot = tAfterSnapshot - tAfterWait;
 
       // Wait for the BVH patch before building the per-press bounds tree.
       await _bvhReady;
@@ -237,9 +562,38 @@ export class Object3DDetector extends Script {
       // Clone and index the depth mesh.
       const frozenDepthMesh = this._snapshotDepthMesh();
       if (!frozenDepthMesh) {
-        console.warn('[Object3DDetector] no depth mesh available');
-        return this._results;
+        return bail('no depth mesh available');
       }
+      diag.depthMeshVertices =
+        frozenDepthMesh.geometry.attributes['position']?.count ?? null;
+
+      // Estimate the room's dominant wall direction from this capture's depth
+      // mesh, so ill-determined object yaws fall back to the room's axes rather
+      // than to wherever the user happened to be facing at session start.
+      try {
+        this._roomFrame.push(
+          estimateRoomYawFromMesh(frozenDepthMesh, {
+            viewerPosition: frozenCam.position,
+          })
+        );
+      } catch (_e) {
+        // Room estimation is an optimisation; fitting still works without it.
+      }
+      const roomFrame = this._roomFrame.current;
+      if (roomFrame) {
+        diag.roomYawDeg = THREE.MathUtils.radToDeg(roomFrame.yaw);
+        diag.roomYawConfidence = roomFrame.confidence;
+        diag.roomFrameSupportM2 = roomFrame.supportArea;
+      }
+      const orientation: OrientationOptions = {
+        ...this._opts.orientation,
+        roomYaw: roomFrame?.yaw ?? this._opts.orientation.roomYaw,
+        roomYawConfidence:
+          roomFrame?.confidence ?? this._opts.orientation.roomYawConfidence,
+      };
+
+      const tAfterDepthMesh = performance.now();
+      diag.timings.depthMeshSnapshot = tAfterDepthMesh - tAfterSnapshot;
 
       // Monkey-patch getSnapshot so the SDK detector backends read our cached
       // frame instead of the live video (which may have drifted by the time
@@ -297,9 +651,13 @@ export class Object3DDetector extends Script {
           }
         } catch (e) {
           console.warn('[Object3DDetector] runDetection threw', e);
+          diag.error = `runDetection threw: ${(e as Error)?.message ?? e}`;
           return this._results;
+        } finally {
+          diag.timings.detect2d = performance.now() - tAfterDepthMesh;
         }
 
+        diag.detections2d = detected.length;
         if (!detected.length) {
           console.info('[Object3DDetector] nothing detected');
           return this._results;
@@ -313,9 +671,11 @@ export class Object3DDetector extends Script {
             samState = await samPrep;
           } catch (e) {
             console.warn('[Object3DDetector] SAM encoder failed', e);
+            diag.error = `SAM encoder failed: ${(e as Error)?.message ?? e}`;
             return this._results;
           }
         }
+        const tAfterDetect2d = performance.now();
 
         // Restore the snapshot getter; fitting uses the frozen camera / mesh.
         (deviceCamera as unknown as {getSnapshot: SnapFn}).getSnapshot =
@@ -355,7 +715,8 @@ export class Object3DDetector extends Script {
               DEPTH_SAMPLE_FRAME_COUNT,
               frozenCam,
               frozenDepthMesh,
-              snapAspect
+              snapAspect,
+              this._opts.maxRayDistance
             );
             mask.close();
 
@@ -412,6 +773,8 @@ export class Object3DDetector extends Script {
               anchor,
               box2d,
               tinyFlat: isTinyFlatLabel(obj.label),
+              roomHalf: this._opts.roomHalf,
+              orientation,
             });
             if (!obb) return null;
 
@@ -420,11 +783,12 @@ export class Object3DDetector extends Script {
             }
 
             const c = obb.center;
+            const bounds = this._opts.sceneBounds;
             const farFromRoom =
-              Math.abs(c.x) > MAX_CENTER_HORIZONTAL_DISTANCE_M ||
-              Math.abs(c.z) > MAX_CENTER_HORIZONTAL_DISTANCE_M ||
-              c.y < MIN_CENTER_HEIGHT_M ||
-              c.y > MAX_CENTER_HEIGHT_M;
+              Math.abs(c.x) > bounds.maxXZ ||
+              Math.abs(c.z) > bounds.maxXZ ||
+              c.y < bounds.minY ||
+              c.y > bounds.maxY;
             const minPoints = MIN_POINTS_BY_CATEGORY[category];
             const tinyFlat = isTinyFlatLabel(obj.label);
             const tooFewPoints = !tinyFlat && points.length < minPoints;
@@ -446,6 +810,15 @@ export class Object3DDetector extends Script {
                 degenerate,
                 kept: points.length,
               });
+              for (const [reason, hit] of [
+                ['farFromRoom', farFromRoom],
+                ['tooFewPoints', tooFewPoints],
+                ['oversize', oversize],
+                ['degenerate', degenerate],
+              ] as const) {
+                if (hit)
+                  diag.rejections[reason] = (diag.rejections[reason] ?? 0) + 1;
+              }
               return null;
             }
 
@@ -461,6 +834,21 @@ export class Object3DDetector extends Script {
         };
 
         const pipelineResults = await Promise.all(detected.map(processOne));
+        diag.timings.masksAndFit = performance.now() - tAfterDetect2d;
+        diag.fitted3d = pipelineResults.filter((r) => r?.obb).length;
+        for (const r of pipelineResults) {
+          if (!r?.obb) continue;
+          diag.yawStats.push({
+            label: r.label,
+            category: r.category,
+            yawDeg: THREE.MathUtils.radToDeg(r.obb.angle),
+            roomRelativeYawDeg: THREE.MathUtils.radToDeg(
+              yawRelativeToRoom(r.obb.angle, roomFrame)
+            ),
+            confidence: r.obb.yawConfidence ?? 0,
+            method: r.obb.yawMethod ?? 'unknown',
+          });
+        }
 
         // Serial fuse + add pass (fuseIntoBoxes mutates _results).
         for (const r of pipelineResults) {
@@ -516,6 +904,8 @@ export class Object3DDetector extends Script {
           geom.dispose();
         }
         (frozenDepthMesh.material as THREE.Material | undefined)?.dispose?.();
+        diag.timings.total = performance.now() - t0;
+        this._diagnostics = diag;
         this._detectInFlight = false;
       }
     } finally {
@@ -523,10 +913,134 @@ export class Object3DDetector extends Script {
     }
   }
 
+  /**
+   * Build the frozen camera from the SDK's device-camera model (physical
+   * passthrough intrinsics + pose on device; render-camera-derived square
+   * crop in the simulator). Returns `null` when no camera parameters are
+   * available yet (e.g. before init or outside an XR session).
+   */
+  private _buildDeviceFrozenCamera(
+    snapAspect: number,
+    captureTimeMs: number | null = null,
+    diag?: Object3DDetectorDiagnostics
+  ): THREE.PerspectiveCamera | null {
+    const deviceCamera = core.deviceCamera;
+    if (!deviceCamera) return null;
+    try {
+      const params = getCameraParametersSnapshot(
+        core.camera,
+        core.renderer.xr.getCamera(),
+        deviceCamera,
+        this._targetDevice()
+      );
+      if (!params) return null;
+      let worldFromView = params.worldFromView;
+      // Prefer the pose the head had when the video frame was actually
+      // captured over the pose at detect() time — the passthrough video lags
+      // tracking, so during head motion the two differ.
+      if (captureTimeMs !== null && !deviceCamera.simulatorCamera) {
+        const historical = this._poseRing.lookup(captureTimeMs);
+        if (historical) {
+          worldFromView = historical.clone();
+          if (diag) {
+            diag.poseMatchErrorMs = this._poseRing.matchErrorMs(captureTimeMs);
+          }
+        }
+      }
+      const off = this._opts.cameraRotationOffset;
+      if (off.yaw !== 0 || off.pitch !== 0 || off.roll !== 0) {
+        // Post-multiplying applies the correction in the camera's own view
+        // space, on top of the SDK's estimated extrinsics.
+        worldFromView = worldFromView
+          .clone()
+          .multiply(
+            new THREE.Matrix4().makeRotationFromEuler(
+              new THREE.Euler(off.pitch, off.yaw, off.roll, 'YXZ')
+            )
+          );
+      }
+      return buildFrozenCamera({
+        worldFromView,
+        clipFromView: params.clipFromView,
+        viewFromClip: params.viewFromClip,
+        snapAspect,
+      });
+    } catch (_e) {
+      return null;
+    }
+  }
+
+  private _targetDevice(): string {
+    return core.world?.objects?.targetDevice ?? 'galaxyxr';
+  }
+
+  /**
+   * Records how the depth system is configured on this device — whether the
+   * platform reports a depth-camera pose rotated away from the render view,
+   * and whether the view→depth-buffer UV remap is non-trivial. A large
+   * rotation with `matchDepthView: false` means the depth mesh itself — the
+   * surface every detection ray lands on — is the thing to scrutinise when
+   * boxes come back coherently rotated.
+   */
+  private _collectDepthDiagnostics(diag: Object3DDetectorDiagnostics): void {
+    const depth = core.depth;
+    if (!depth || core.deviceCamera?.simulatorCamera) return;
+    try {
+      const norm = depth.normDepthBufferFromNormViewMatrices?.[0];
+      if (norm) {
+        const identity = new THREE.Matrix4();
+        diag.depthRemapIsIdentity = norm.elements.every(
+          (v, i) => Math.abs(v - identity.elements[i]) <= 1e-6
+        );
+      }
+      const eye = core.renderer.xr.getCamera()?.cameras?.[0];
+      const depthRotation = depth.depthCameraRotations?.[0];
+      if (eye && depthRotation) {
+        const eyeRotation = new THREE.Quaternion().setFromRotationMatrix(
+          eye.matrixWorld
+        );
+        diag.depthVsEyeRotationDeg = THREE.MathUtils.radToDeg(
+          eyeRotation.angleTo(depthRotation)
+        );
+      }
+    } catch (_e) {
+      // Diagnostics only.
+    }
+  }
+
+  /**
+   * Legacy fallback: freeze a clone of the render camera. Only correct when
+   * the snapshot was rendered from that camera (simulator / non-XR); kept as
+   * a fallback for callers without device-camera parameters.
+   */
+  private _buildRenderFrozenCamera(
+    snapAspect: number
+  ): THREE.PerspectiveCamera {
+    const liveCam = core.camera;
+    const frozenCam = liveCam.clone() as THREE.PerspectiveCamera;
+    frozenCam.matrixAutoUpdate = false;
+    liveCam.updateMatrixWorld();
+    frozenCam.matrix.copy(liveCam.matrix);
+    frozenCam.matrixWorld.copy(liveCam.matrixWorld);
+    frozenCam.matrixWorldInverse.copy(liveCam.matrixWorld).invert();
+    frozenCam.projectionMatrix.copy(liveCam.projectionMatrix);
+    frozenCam.projectionMatrixInverse.copy(liveCam.projectionMatrixInverse);
+    frozenCam.position.copy(liveCam.position);
+    frozenCam.quaternion.copy(liveCam.quaternion);
+    frozenCam.userData = {...frozenCam.userData, snapAspect};
+    return frozenCam;
+  }
+
   /** Clone the live depth mesh into a static snapshot. */
   private _snapshotDepthMesh(): THREE.Mesh | null {
-    const live = core.depth?.depthMesh;
+    const depth = core.depth;
+    const live = depth?.depthMesh;
     if (!live || !live.geometry) return null;
+    // The full-resolution geometry is only rebuilt per-frame when
+    // options.depth.depthMesh.updateFullResolutionGeometry is set (default
+    // false), so force a rebuild from the cached CPU depth to avoid cloning
+    // a stale mesh.
+    depth.updateFullResolutionDepthMesh();
     const clonedGeom = live.geometry.clone();
     clonedGeom.computeBoundingSphere();
     clonedGeom.computeBoundingBox();

--- a/src/addons/objects3d/geometry/DepthSampling.ts
+++ b/src/addons/objects3d/geometry/DepthSampling.ts
@@ -24,6 +24,10 @@ export interface MaskLike {
 
 // Module-level scratch objects reused across calls to avoid per-call GC.
 const _raycaster = new THREE.Raycaster();
+// three-mesh-bvh honours firstHitOnly and returns the nearest hit without
+// collecting and sorting every intersection along the ray; ignored by the
+// stock three.js raycaster.
+(_raycaster as THREE.Raycaster & {firstHitOnly?: boolean}).firstHitOnly = true;
 const _ndc = new THREE.Vector2();
 
 /**
@@ -170,6 +174,7 @@ export function nextFrame(): Promise<void> {
  * @param cameraOverride - Frozen camera, or `null` for live.
  * @param meshOverride - Frozen depth mesh, or `null` for live.
  * @param snapAspect - Snapshot aspect ratio override.
+ * @param maxDistance - Maximum ray-hit distance in metres.
  * @returns Accumulated world-space hit points and foreground pixel count.
  */
 export async function sampleDepthInMaskAcrossFrames(
@@ -179,14 +184,15 @@ export async function sampleDepthInMaskAcrossFrames(
   frames = 3,
   cameraOverride: THREE.PerspectiveCamera | null = null,
   meshOverride: THREE.Mesh | null = null,
-  snapAspect: number | null = null
+  snapAspect: number | null = null,
+  maxDistance = 12
 ): Promise<{points: THREE.Vector3[]; foregroundPixels: number}> {
   if (cameraOverride || meshOverride) {
     return sampleDepthInMask(
       mask,
       box2d,
       stride,
-      12,
+      maxDistance,
       cameraOverride,
       meshOverride,
       snapAspect

--- a/src/addons/objects3d/geometry/FrozenCamera.test.ts
+++ b/src/addons/objects3d/geometry/FrozenCamera.test.ts
@@ -1,0 +1,131 @@
+import {describe, it, expect} from 'vitest';
+import * as THREE from 'three';
+
+import {buildFrozenCamera} from './FrozenCamera';
+
+/** Build reference matrices from a plain PerspectiveCamera. */
+function referenceCamera(
+  fov: number,
+  aspect: number,
+  position: THREE.Vector3,
+  lookAt: THREE.Vector3
+): THREE.PerspectiveCamera {
+  const cam = new THREE.PerspectiveCamera(fov, aspect, 0.1, 100);
+  cam.position.copy(position);
+  cam.lookAt(lookAt);
+  cam.updateMatrixWorld();
+  cam.updateProjectionMatrix();
+  return cam;
+}
+
+describe('buildFrozenCamera', () => {
+  it('derives fov and aspect from the projection matrix', () => {
+    const ref = referenceCamera(
+      48,
+      16 / 9,
+      new THREE.Vector3(0, 1.6, 0),
+      new THREE.Vector3(0, 1.6, -1)
+    );
+    const frozen = buildFrozenCamera({
+      worldFromView: ref.matrixWorld.clone(),
+      clipFromView: ref.projectionMatrix.clone(),
+    });
+    expect(frozen.fov).toBeCloseTo(48, 5);
+    expect(frozen.aspect).toBeCloseTo(16 / 9, 5);
+  });
+
+  it('defaults snapAspect to the projection aspect (identity uvToNdc)', () => {
+    const ref = referenceCamera(
+      60,
+      1.5,
+      new THREE.Vector3(0, 0, 0),
+      new THREE.Vector3(0, 0, -1)
+    );
+    const frozen = buildFrozenCamera({
+      worldFromView: ref.matrixWorld.clone(),
+      clipFromView: ref.projectionMatrix.clone(),
+    });
+    expect(frozen.userData.snapAspect).toBeCloseTo(1.5, 5);
+  });
+
+  it('keeps an explicit snapAspect override', () => {
+    const ref = referenceCamera(
+      60,
+      1.5,
+      new THREE.Vector3(0, 0, 0),
+      new THREE.Vector3(0, 0, -1)
+    );
+    const frozen = buildFrozenCamera({
+      worldFromView: ref.matrixWorld.clone(),
+      clipFromView: ref.projectionMatrix.clone(),
+      snapAspect: 1.0,
+    });
+    expect(frozen.userData.snapAspect).toBeCloseTo(1.0, 5);
+  });
+
+  it('decomposes the pose from worldFromView', () => {
+    const ref = referenceCamera(
+      70,
+      1,
+      new THREE.Vector3(1, 2, 3),
+      new THREE.Vector3(0, 2, 0)
+    );
+    const frozen = buildFrozenCamera({
+      worldFromView: ref.matrixWorld.clone(),
+      clipFromView: ref.projectionMatrix.clone(),
+    });
+    expect(frozen.position.distanceTo(ref.position)).toBeLessThan(1e-6);
+    expect(Math.abs(frozen.quaternion.dot(ref.quaternion))).toBeCloseTo(1, 6);
+  });
+
+  it('raycasts identically to the reference camera', () => {
+    const ref = referenceCamera(
+      50,
+      1.25,
+      new THREE.Vector3(0.5, 1.2, 2),
+      new THREE.Vector3(0, 1, -2)
+    );
+    const frozen = buildFrozenCamera({
+      worldFromView: ref.matrixWorld.clone(),
+      clipFromView: ref.projectionMatrix.clone(),
+      viewFromClip: ref.projectionMatrixInverse.clone(),
+    });
+    const refRay = new THREE.Raycaster();
+    const frozenRay = new THREE.Raycaster();
+    for (const [x, y] of [
+      [0, 0],
+      [0.7, -0.3],
+      [-1, 1],
+    ]) {
+      refRay.setFromCamera(new THREE.Vector2(x, y), ref);
+      frozenRay.setFromCamera(new THREE.Vector2(x, y), frozen);
+      expect(frozenRay.ray.origin.distanceTo(refRay.ray.origin)).toBeLessThan(
+        1e-6
+      );
+      expect(
+        frozenRay.ray.direction.distanceTo(refRay.ray.direction)
+      ).toBeLessThan(1e-6);
+    }
+  });
+
+  it('a centre ray from an off-axis pose hits the expected world point', () => {
+    // Camera at (0, 1, 5) looking straight down -Z: the NDC-centre ray must
+    // hit a plane at z = 0 exactly at (0, 1, 0).
+    const ref = referenceCamera(
+      45,
+      1.7,
+      new THREE.Vector3(0, 1, 5),
+      new THREE.Vector3(0, 1, 0)
+    );
+    const frozen = buildFrozenCamera({
+      worldFromView: ref.matrixWorld.clone(),
+      clipFromView: ref.projectionMatrix.clone(),
+    });
+    const ray = new THREE.Raycaster();
+    ray.setFromCamera(new THREE.Vector2(0, 0), frozen);
+    const plane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);
+    const hit = new THREE.Vector3();
+    ray.ray.intersectPlane(plane, hit);
+    expect(hit.distanceTo(new THREE.Vector3(0, 1, 0))).toBeLessThan(1e-6);
+  });
+});

--- a/src/addons/objects3d/geometry/FrozenCamera.ts
+++ b/src/addons/objects3d/geometry/FrozenCamera.ts
@@ -1,0 +1,58 @@
+/**
+ * Frozen-camera construction from explicit view / projection matrices.
+ *
+ * Pure (no `xb.core` dependencies) so it can be unit-tested and reused
+ * outside the browser (e.g. by a server that receives serialized matrices).
+ */
+
+import * as THREE from 'three';
+
+/** Matrices describing the camera that captured a snapshot. */
+export interface FrozenCameraMatrices {
+  /** Camera-to-world transform (pose) of the capturing camera. */
+  worldFromView: THREE.Matrix4;
+  /** Projection matrix of the capturing camera. */
+  clipFromView: THREE.Matrix4;
+  /** Inverse projection; computed from `clipFromView` when omitted. */
+  viewFromClip?: THREE.Matrix4;
+  /**
+   * Aspect ratio of the captured snapshot (`width / height`). Defaults to the
+   * aspect implied by `clipFromView`, which makes {@link uvToNdc} an identity
+   * mapping.
+   */
+  snapAspect?: number | null;
+}
+
+/**
+ * Build a static `THREE.PerspectiveCamera` whose matrices are pinned to the
+ * given snapshot-time values. The returned camera works with
+ * `Raycaster.setFromCamera` (which only reads `matrixWorld` and
+ * `projectionMatrixInverse`) and with the fitters' `fov` / `aspect` /
+ * `position` / `quaternion` reads, which are derived from the matrices.
+ *
+ * @param matrices - Snapshot-time camera matrices.
+ * @returns A frozen camera (matrixAutoUpdate disabled).
+ */
+export function buildFrozenCamera(
+  matrices: FrozenCameraMatrices
+): THREE.PerspectiveCamera {
+  const cam = new THREE.PerspectiveCamera();
+  cam.matrixAutoUpdate = false;
+  cam.matrix.copy(matrices.worldFromView);
+  cam.matrixWorld.copy(matrices.worldFromView);
+  cam.matrixWorldInverse.copy(matrices.worldFromView).invert();
+  cam.projectionMatrix.copy(matrices.clipFromView);
+  if (matrices.viewFromClip) {
+    cam.projectionMatrixInverse.copy(matrices.viewFromClip);
+  } else {
+    cam.projectionMatrixInverse.copy(matrices.clipFromView).invert();
+  }
+  matrices.worldFromView.decompose(cam.position, cam.quaternion, cam.scale);
+  // Column-major projection: elements[5] = cot(vFov / 2), elements[0] =
+  // cot(hFov / 2) = elements[5] / aspect.
+  const e = matrices.clipFromView.elements;
+  cam.fov = THREE.MathUtils.radToDeg(2 * Math.atan(1 / e[5]));
+  cam.aspect = e[5] / e[0];
+  cam.userData.snapAspect = matrices.snapAspect ?? cam.aspect;
+  return cam;
+}

--- a/src/addons/objects3d/geometry/ObbFitting.test.ts
+++ b/src/addons/objects3d/geometry/ObbFitting.test.ts
@@ -1,0 +1,319 @@
+import * as THREE from 'three';
+import {describe, expect, it} from 'vitest';
+
+import {
+  buildYawAlignedObb,
+  fitFurnitureOBB,
+  fitYawOBB,
+  ransacPlane,
+} from './ObbFitting';
+import type {InternalObb} from './ObbFitting';
+import {localToWorldXZ, yawDelta90} from './YawEstimation';
+
+const deg = THREE.MathUtils.degToRad;
+
+/** Deterministic PRNG (mulberry32) so RANSAC tests cannot flake. */
+function seededRng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * A filled box of samples of full extent `w` (u) x `h` (y) x `d` (v), centred
+ * at `center` and yawed by `angle` using the renderer's convention.
+ */
+function boxPoints(
+  w: number,
+  h: number,
+  d: number,
+  angle: number,
+  center = new THREE.Vector3(),
+  steps = 6
+): THREE.Vector3[] {
+  const out: THREE.Vector3[] = [];
+  for (let i = 0; i < steps; ++i) {
+    for (let j = 0; j < steps; ++j) {
+      for (let k = 0; k < steps; ++k) {
+        const u = (i / (steps - 1) - 0.5) * w;
+        const y = (j / (steps - 1) - 0.5) * h;
+        const v = (k / (steps - 1) - 0.5) * d;
+        const p = localToWorldXZ(u, v, angle);
+        out.push(
+          new THREE.Vector3(center.x + p.x, center.y + y, center.z + p.z)
+        );
+      }
+    }
+  }
+  return out;
+}
+
+/** Signed distance of `p` from the OBB, in the box's own frame (negative = inside). */
+function obbSignedDistance(obb: InternalObb, p: THREE.Vector3): number {
+  const q = new THREE.Quaternion()
+    .setFromAxisAngle(new THREE.Vector3(0, 1, 0), obb.angle)
+    .invert();
+  const local = p.clone().sub(obb.center).applyQuaternion(q);
+  return Math.max(
+    Math.abs(local.x) - obb.size.x / 2,
+    Math.abs(local.y) - obb.size.y / 2,
+    Math.abs(local.z) - obb.size.z / 2
+  );
+}
+
+describe('fitFurnitureOBB', () => {
+  it('returns null below six points', () => {
+    expect(fitFurnitureOBB(boxPoints(1, 1, 1, 0, undefined, 1))).toBeNull();
+  });
+
+  it('encloses an axis-aligned box', () => {
+    const pts = boxPoints(2, 1, 0.8, 0);
+    const obb = fitFurnitureOBB(pts)!;
+    expect(obb).not.toBeNull();
+    expect(Math.abs(yawDelta90(obb.angle, 0))).toBeLessThan(1e-6);
+    expect(obb.size.x).toBeCloseTo(2, 1);
+    expect(obb.size.z).toBeCloseTo(0.8, 1);
+    for (const p of pts) {
+      expect(obbSignedDistance(obb, p)).toBeLessThan(0.06);
+    }
+  });
+
+  it('contains its points once cardinal snapping has inflated the footprint', () => {
+    // Snapping a rotated cloud to an axis-aligned frame legitimately clips the
+    // extreme corners at the 5/95 percentile, so allow a modest overhang; the
+    // point here is that nothing escapes wildly.
+    for (const d of [15, 30, 40, -25]) {
+      const pts = boxPoints(2.0, 1.0, 0.6, deg(d));
+      const obb = fitFurnitureOBB(pts)!;
+      const worst = Math.max(...pts.map((p) => obbSignedDistance(obb, p)));
+      expect(worst).toBeLessThan(0.2);
+    }
+  });
+
+  it('places the centre at the point cloud centre', () => {
+    const c = new THREE.Vector3(1.5, 0.8, -2.25);
+    const obb = fitFurnitureOBB(boxPoints(1.2, 0.9, 0.7, deg(20), c))!;
+    expect(obb.center.distanceTo(c)).toBeLessThan(0.08);
+  });
+
+  it('snaps yaw to a multiple of 90 degrees in cardinal mode (legacy)', () => {
+    for (const d of [0, 12, 30, 44, 61, 89, 130, -37]) {
+      const obb = fitFurnitureOBB(boxPoints(2, 1, 0.7, deg(d)), {
+        orientation: {mode: 'cardinal'},
+      })!;
+      const quarter = obb.angle / (Math.PI / 2);
+      expect(Math.abs(quarter - Math.round(quarter))).toBeLessThan(1e-6);
+    }
+  });
+});
+
+describe('orientation modes', () => {
+  /** A clearly box-shaped footprint, yawed by `d` degrees. */
+  const rotatedBox = (d: number) =>
+    boxPoints(1.8, 0.9, 0.7, deg(d), new THREE.Vector3(), 8);
+
+  it("keeps a genuinely rotated object's angle in free mode", () => {
+    for (const d of [20, 35, -30]) {
+      const obb = fitFurnitureOBB(rotatedBox(d), {
+        orientation: {mode: 'free'},
+      })!;
+      expect(Math.abs(yawDelta90(obb.angle, deg(d)))).toBeLessThan(deg(4));
+    }
+  });
+
+  it('keeps a confidently off-grid object off the room grid', () => {
+    // Room at 17 degrees, object at 47 degrees: 30 degrees off the grid, well
+    // beyond the snap tolerance, so the measured angle must survive.
+    const obb = fitFurnitureOBB(rotatedBox(47), {
+      orientation: {
+        mode: 'roomFrame',
+        roomYaw: deg(17),
+        roomYawConfidence: 0.9,
+      },
+    })!;
+    expect(Math.abs(yawDelta90(obb.angle, deg(47)))).toBeLessThan(deg(5));
+    expect(Math.abs(yawDelta90(obb.angle, deg(17)))).toBeGreaterThan(deg(15));
+  });
+
+  it('snaps a nearly-aligned object onto the room grid', () => {
+    const obb = fitFurnitureOBB(rotatedBox(20), {
+      orientation: {
+        mode: 'roomFrame',
+        roomYaw: deg(17),
+        roomYawConfidence: 0.9,
+      },
+    })!;
+    expect(Math.abs(yawDelta90(obb.angle, deg(17)))).toBeLessThan(1e-6);
+    expect(obb.yawMethod).toBe('roomFrame-snap');
+  });
+
+  it('falls back to the room frame for an ill-determined footprint', () => {
+    // A round blob has no meaningful orientation.
+    const pts: THREE.Vector3[] = [];
+    for (let i = 0; i < 240; ++i) {
+      const t = (i / 240) * Math.PI * 2;
+      const r = 0.4 * (0.6 + (0.4 * ((i * 7919) % 97)) / 97);
+      pts.push(
+        new THREE.Vector3(Math.cos(t) * r, (i % 5) * 0.05, Math.sin(t) * r)
+      );
+    }
+    const obb = fitFurnitureOBB(pts, {
+      orientation: {
+        mode: 'roomFrame',
+        roomYaw: deg(17),
+        roomYawConfidence: 0.9,
+      },
+    })!;
+    expect(Math.abs(yawDelta90(obb.angle, deg(17)))).toBeLessThan(1e-6);
+    expect(obb.yawMethod).toBe('roomFrame');
+  });
+
+  it('degenerates to the world axes when no room frame is available', () => {
+    const obb = fitFurnitureOBB(rotatedBox(30), {
+      orientation: {mode: 'roomFrame', roomYaw: null},
+    })!;
+    // The measurement is confident, so it survives even without a room frame.
+    expect(Math.abs(yawDelta90(obb.angle, deg(30)))).toBeLessThan(deg(5));
+  });
+
+  it('ignores a low-confidence room frame', () => {
+    const obb = fitFurnitureOBB(rotatedBox(5), {
+      orientation: {
+        mode: 'roomFrame',
+        roomYaw: deg(40),
+        roomYawConfidence: 0.05,
+      },
+    })!;
+    // Room frame is not trusted, so this snaps to the world axes instead of 40.
+    expect(Math.abs(yawDelta90(obb.angle, 0))).toBeLessThan(1e-6);
+  });
+
+  it('is stable across the 45 degree boundary', () => {
+    // 45 degrees is the antipode of the mod-90 domain, where the canonical
+    // representative legitimately flips sign. The drawn box must not.
+    const a = fitFurnitureOBB(rotatedBox(44.5), {orientation: {mode: 'free'}})!;
+    const b = fitFurnitureOBB(rotatedBox(45.5), {orientation: {mode: 'free'}})!;
+    expect(Math.abs(yawDelta90(a.angle, b.angle))).toBeLessThan(deg(4));
+  });
+
+  it('reports confidence and method', () => {
+    const obb = fitFurnitureOBB(rotatedBox(30), {orientation: {mode: 'free'}})!;
+    expect(obb.yawConfidence).toBeGreaterThan(0);
+    expect(obb.yawConfidence).toBeLessThanOrEqual(1);
+    expect(typeof obb.yawMethod).toBe('string');
+  });
+});
+
+/**
+ * The sign-convention guard.
+ *
+ * `fitFurnitureOBB` used to project points onto (cos a, +sin a) while the
+ * renderer draws along (cos a, -sin a), so extents were measured along the
+ * mirror of the axes they are drawn along. Cardinal snapping hid this,
+ * because at multiples of 90 degrees the two axis pairs coincide — which is
+ * exactly why the bug survived. These tests drive the projection at free
+ * angles, where a mirrored axis produces a box rotated by -2*theta relative
+ * to its data.
+ */
+describe('buildYawAlignedObb (render-convention guard)', () => {
+  it('recovers the true extents when told the true yaw', () => {
+    for (const d of [10, 30, 45, 70, -20]) {
+      const a = deg(d);
+      const pts = boxPoints(2.0, 1.0, 0.6, a, new THREE.Vector3(), 8);
+      const obb = buildYawAlignedObb(pts, 0, 0, a);
+      // With the mirrored convention these come out as the extents of the
+      // cloud measured along the wrong axes, i.e. visibly inflated.
+      expect(obb.size.x).toBeCloseTo(2.0, 1);
+      expect(obb.size.z).toBeCloseTo(0.6, 1);
+      expect(obb.angle).toBeCloseTo(a, 12);
+    }
+  });
+
+  it('produces a box that encloses the points it was fitted to', () => {
+    for (const d of [10, 30, 45, 70, -20]) {
+      const a = deg(d);
+      const pts = boxPoints(2.0, 1.0, 0.6, a, new THREE.Vector3(2, 0, -1), 8);
+      const obb = buildYawAlignedObb(pts, 2, -1, a);
+      const worst = Math.max(...pts.map((p) => obbSignedDistance(obb, p)));
+      expect(worst).toBeLessThan(0.02);
+    }
+  });
+
+  it('centres the box on the cloud regardless of the seed centre', () => {
+    const a = deg(35);
+    const c = new THREE.Vector3(1.25, 0.5, -0.75);
+    const pts = boxPoints(1.5, 0.8, 0.5, a, c, 8);
+    // Seed deliberately offset from the true centre.
+    const obb = buildYawAlignedObb(pts, 0, 0, a);
+    expect(obb.center.x).toBeCloseTo(c.x, 1);
+    expect(obb.center.z).toBeCloseTo(c.z, 1);
+  });
+});
+
+describe('fitYawOBB dispatch', () => {
+  it('falls back to the furniture fitter for an unknown category', () => {
+    const pts = boxPoints(2, 1, 0.8, 0);
+    const viaDispatch = fitYawOBB(pts, {category: 'nonsense'});
+    const direct = fitFurnitureOBB(pts)!;
+    expect(viaDispatch).not.toBeNull();
+    expect(viaDispatch!.angle).toBeCloseTo(direct.angle, 12);
+    expect(viaDispatch!.size.x).toBeCloseTo(direct.size.x, 12);
+  });
+
+  it('returns null for too few points', () => {
+    expect(
+      fitYawOBB([new THREE.Vector3()], {category: 'furniture'})
+    ).toBeNull();
+  });
+
+  it('survives an all-identical point cloud', () => {
+    const pts = Array.from({length: 20}, () => new THREE.Vector3(1, 1, 1));
+    const obb = fitYawOBB(pts, {category: 'furniture'});
+    if (obb) {
+      expect(obb.size.x).toBeGreaterThan(0);
+      expect(obb.size.y).toBeGreaterThan(0);
+      expect(obb.size.z).toBeGreaterThan(0);
+      expect(Number.isFinite(obb.angle)).toBe(true);
+    }
+  });
+});
+
+describe('ransacPlane', () => {
+  it('is reproducible with an injected rng', () => {
+    const pts: THREE.Vector3[] = [];
+    for (let i = 0; i < 40; ++i) {
+      pts.push(new THREE.Vector3((i % 8) * 0.1, Math.floor(i / 8) * 0.1, 0));
+    }
+    const a = ransacPlane(pts, 40, 0.01, seededRng(7))!;
+    const b = ransacPlane(pts, 40, 0.01, seededRng(7))!;
+    expect(a).not.toBeNull();
+    expect(a.normal.x).toBeCloseTo(b.normal.x, 12);
+    expect(a.normal.y).toBeCloseTo(b.normal.y, 12);
+    expect(a.normal.z).toBeCloseTo(b.normal.z, 12);
+  });
+
+  it('recovers a known plane normal', () => {
+    const pts: THREE.Vector3[] = [];
+    for (let i = 0; i < 60; ++i) {
+      pts.push(
+        new THREE.Vector3((i % 10) * 0.1, Math.floor(i / 10) * 0.1, 2.0)
+      );
+    }
+    const plane = ransacPlane(pts, 60, 0.01, seededRng(3))!;
+    expect(plane).not.toBeNull();
+    expect(Math.abs(plane.normal.z)).toBeCloseTo(1, 3);
+    expect(plane.point.z).toBeCloseTo(2.0, 3);
+  });
+
+  it('defaults to Math.random when no rng is given', () => {
+    const pts: THREE.Vector3[] = [];
+    for (let i = 0; i < 30; ++i) {
+      pts.push(new THREE.Vector3((i % 6) * 0.1, Math.floor(i / 6) * 0.1, 0));
+    }
+    expect(ransacPlane(pts, 40, 0.01)).not.toBeNull();
+  });
+});

--- a/src/addons/objects3d/geometry/ObbFitting.ts
+++ b/src/addons/objects3d/geometry/ObbFitting.ts
@@ -8,6 +8,20 @@
 import * as THREE from 'three';
 
 import {uvToNdc} from './DepthSampling';
+import {
+  canonicalizeYawObb,
+  combineYawCandidates,
+  localToWorldXZ,
+  minAreaRectXZ,
+  pcaYawConfidence,
+  pcaYawXZ,
+  ransacVerticalPlane,
+  worldToLocalXZ,
+  wrapPi,
+  wrapQuarterPi,
+  yawDelta90,
+} from './YawEstimation';
+import type {YawCandidate, YawEstimate} from './YawEstimation';
 
 /**
  * Internal OBB representation used by fitters and fusion.
@@ -21,6 +35,47 @@ export interface InternalObb {
   size: THREE.Vector3;
   /** Yaw angle around world Y, in radians. */
   angle: number;
+  /**
+   * How well determined {@link angle} was, in `[0, 1]`. Populated by the
+   * fitters; consumed by diagnostics and (in future) by cross-view fusion to
+   * weight one observation's yaw against another's.
+   */
+  yawConfidence?: number;
+  /** Name of the estimator that produced {@link angle}. Diagnostics only. */
+  yawMethod?: string;
+}
+
+/**
+ * How a fitted yaw should be reconciled with the surrounding room.
+ *
+ * - `'cardinal'` — legacy: snap unconditionally to the nearest multiple of 90°
+ *   about the **session origin**. Kept as an escape hatch and A/B baseline.
+ * - `'roomFrame'` — snap to the estimated room axes, but only when the object's
+ *   own yaw is poorly determined or already close to them.
+ * - `'free'` — always use the measured yaw.
+ */
+export type OrientationMode = 'cardinal' | 'roomFrame' | 'free';
+
+/** Orientation policy plus the room frame to resolve against. */
+export interface OrientationOptions {
+  /** @defaultValue `'roomFrame'` */
+  mode?: OrientationMode;
+  /** Estimated room yaw in radians, or `null` when unknown. */
+  roomYaw?: number | null;
+  /** Confidence of {@link roomYaw}, in `[0, 1]`. */
+  roomYawConfidence?: number;
+  /**
+   * Objects within this angle of the room frame are snapped to it, which
+   * removes jitter on genuinely wall-aligned furniture.
+   * @defaultValue 12°
+   */
+  snapToleranceRad?: number;
+  /**
+   * Below this yaw confidence the object's own estimate is discarded in favour
+   * of the room frame.
+   * @defaultValue 0.35
+   */
+  minYawConfidence?: number;
 }
 
 /** Options forwarded from the detector to the per-category fitters. */
@@ -35,6 +90,152 @@ export interface ObbFitOptions {
   box2d?: THREE.Box2 | null;
   /** Whether the label is a tiny flat item (switch, outlet, etc.). */
   tinyFlat?: boolean;
+  /**
+   * Assumed distance in metres from the session origin to the cardinal walls
+   * (`x = ±roomHalf`, `z = ±roomHalf`), used by {@link fitTinyFlatOBB}.
+   * Defaults to 3, matching the simulator's wood-cabin scene.
+   */
+  roomHalf?: number;
+  /** Orientation policy and room frame. */
+  orientation?: OrientationOptions;
+}
+
+/** Minimum room-frame confidence before it is allowed to influence a fit. */
+const MIN_ROOM_YAW_CONFIDENCE = 0.3;
+const DEFAULT_SNAP_TOLERANCE_RAD = (12 * Math.PI) / 180;
+const DEFAULT_MIN_YAW_CONFIDENCE = 0.35;
+
+/**
+ * Reconcile a measured yaw with the orientation policy and the room frame.
+ * This is the single decision point for every fitter, so the modes behave
+ * consistently across categories.
+ *
+ * @param est - Measured yaw, or `null` when estimation failed outright.
+ * @param opts - Orientation policy and room frame.
+ * @returns The yaw to use, its confidence, and which path produced it.
+ */
+export function resolveYaw(
+  est: YawEstimate | null,
+  opts: OrientationOptions = {}
+): {angle: number; confidence: number; method: string} {
+  const mode = opts.mode ?? 'roomFrame';
+  if (mode === 'cardinal') {
+    return {
+      angle: snapYawToCardinal(est?.angle ?? 0),
+      confidence: est?.confidence ?? 0,
+      method: 'cardinal',
+    };
+  }
+  if (!est) {
+    // Nothing measurable; fall back to the room frame (or the world axes).
+    const roomYaw =
+      opts.roomYaw != null &&
+      (opts.roomYawConfidence ?? 0) >= MIN_ROOM_YAW_CONFIDENCE
+        ? opts.roomYaw
+        : 0;
+    return {angle: roomYaw, confidence: 0, method: 'roomFrame'};
+  }
+  if (mode === 'free') {
+    return {angle: est.angle, confidence: est.confidence, method: est.method};
+  }
+  // 'roomFrame'. With no usable room estimate this degenerates to the world
+  // axes, i.e. to the legacy grid, which is the safe direction to fail in.
+  const hasRoom =
+    opts.roomYaw != null &&
+    (opts.roomYawConfidence ?? 0) >= MIN_ROOM_YAW_CONFIDENCE;
+  const roomYaw = hasRoom ? opts.roomYaw! : 0;
+  const minConfidence = opts.minYawConfidence ?? DEFAULT_MIN_YAW_CONFIDENCE;
+  if (est.confidence < minConfidence) {
+    // This is the case that used to produce a snap of up to 45°.
+    return {angle: roomYaw, confidence: est.confidence, method: 'roomFrame'};
+  }
+  const tolerance = opts.snapToleranceRad ?? DEFAULT_SNAP_TOLERANCE_RAD;
+  if (Math.abs(yawDelta90(est.angle, roomYaw)) < tolerance) {
+    return {
+      angle: roomYaw,
+      confidence: est.confidence,
+      method: 'roomFrame-snap',
+    };
+  }
+  // Confidently off the room grid: keep the measured angle.
+  return {angle: est.angle, confidence: est.confidence, method: est.method};
+}
+
+/**
+ * Estimate an object's yaw from its footprint by combining a minimum-area
+ * rectangle fit, a vertical-plane fit, and PCA.
+ *
+ * @param points - World-space samples.
+ * @param cx - Centre X used for the PCA scatter.
+ * @param cz - Centre Z used for the PCA scatter.
+ * @param rng - Random source for the RANSAC vote.
+ */
+export function estimateObjectYaw(
+  points: THREE.Vector3[],
+  cx: number,
+  cz: number,
+  rng: () => number = Math.random
+): YawEstimate | null {
+  const candidates: YawCandidate[] = [];
+
+  const scatter = pcaYawXZ(points, cx, cz);
+  // Trim before hulling: the hull is built from extreme points, so a few stray
+  // mask pixels would otherwise steer the rectangle fit.
+  const trimmed = scatter
+    ? trimToPercentile(points, cx, cz, scatter.angle)
+    : points;
+  const rect = minAreaRectXZ(trimmed);
+  if (rect) {
+    candidates.push({
+      angle: rect.angle,
+      weight: rect.supportRatio,
+      method: 'minAreaRect',
+    });
+  }
+  const plane = ransacVerticalPlane(trimmed, {rng});
+  if (plane) {
+    candidates.push({
+      angle: Math.atan2(plane.normal.x, plane.normal.z),
+      weight: 0.7 * plane.inlierRatio,
+      method: 'verticalPlane',
+    });
+  }
+  if (scatter) {
+    candidates.push({
+      angle: scatter.angle,
+      weight: 0.5 * pcaYawConfidence(scatter),
+      method: 'pca',
+    });
+  }
+  return combineYawCandidates(candidates);
+}
+
+/**
+ * Drop samples outside the 2nd/98th percentile along the box's own axes, so a
+ * handful of outliers cannot drag the convex hull.
+ */
+function trimToPercentile(
+  points: THREE.Vector3[],
+  cx: number,
+  cz: number,
+  angle: number
+): THREE.Vector3[] {
+  if (points.length < 12) return points;
+  const us: number[] = [];
+  const vs: number[] = [];
+  for (const p of points) {
+    const {u, v} = worldToLocalXZ(p.x - cx, p.z - cz, angle);
+    us.push(u);
+    vs.push(v);
+  }
+  const uLo = pctile(us, 0.02),
+    uHi = pctile(us, 0.98);
+  const vLo = pctile(vs, 0.02),
+    vHi = pctile(vs, 0.98);
+  const kept = points.filter((_, i) => {
+    return us[i] >= uLo && us[i] <= uHi && vs[i] >= vLo && vs[i] <= vHi;
+  });
+  return kept.length >= 6 ? kept : points;
 }
 
 // Module-level scratch objects reused across calls to reduce GC pressure.
@@ -204,13 +405,16 @@ export function rejectByY(
  * @param points - Input point cloud (needs at least 3).
  * @param iters - Number of RANSAC iterations.
  * @param eps - Inlier distance threshold in metres.
+ * @param rng - Random source; inject a seeded generator to make the result
+ *   reproducible (tests would otherwise be flaky).
  * @returns Best plane `{ normal, point, inliers }`, or `null` if fewer than
  *   six inliers were found.
  */
 export function ransacPlane(
   points: THREE.Vector3[],
   iters = 80,
-  eps = 0.02
+  eps = 0.02,
+  rng: () => number = Math.random
 ): {
   normal: THREE.Vector3;
   point: THREE.Vector3;
@@ -227,9 +431,9 @@ export function ransacPlane(
     point: null,
   };
   for (let it = 0; it < iters; it++) {
-    const ia = (Math.random() * points.length) | 0;
-    const ib = (Math.random() * points.length) | 0;
-    const ic = (Math.random() * points.length) | 0;
+    const ia = (rng() * points.length) | 0;
+    const ib = (rng() * points.length) | 0;
+    const ic = (rng() * points.length) | 0;
     if (ia === ib || ib === ic || ia === ic) continue;
     const a = points[ia],
       b = points[ib],
@@ -357,6 +561,8 @@ export function fitYawOBB(
 ): InternalObb | null {
   const cat = opts.category ?? 'furniture';
   if (cat === 'flat') {
+    // A flat fitter's angle encodes a surface normal, not a box orientation,
+    // so it keeps its full ±180° range and is not canonicalized.
     if (opts.tinyFlat) {
       const r = fitTinyFlatOBB(opts);
       if (r) return r;
@@ -366,13 +572,14 @@ export function fitYawOBB(
   }
   if (cat === 'small') {
     const r = fitSmallOBB(points, opts);
-    if (r) return r;
+    if (r) return canonicalizeYawObb(r);
   }
   if (cat === 'light') {
     const r = fitLightOBB(points, opts);
-    if (r) return r;
+    if (r) return canonicalizeYawObb(r);
   }
-  return fitFurnitureOBB(points);
+  const r = fitFurnitureOBB(points, opts);
+  return r ? canonicalizeYawObb(r) : null;
 }
 
 /**
@@ -395,14 +602,19 @@ export function fitTinyFlatOBB(opts: ObbFitOptions): InternalObb | null {
   _tfRay.setFromCamera(_tfNdc, cam);
   const o = _tfRay.ray.origin,
     d = _tfRay.ray.direction;
+  const roomHalf = opts.roomHalf ?? 3.0;
   let anchorOk = false;
   if (opts.anchor) {
     const a = opts.anchor;
-    if (Math.abs(a.x) <= 4 && Math.abs(a.z) <= 4 && a.y >= -0.5 && a.y <= 4) {
+    if (
+      Math.abs(a.x) <= roomHalf + 1 &&
+      Math.abs(a.z) <= roomHalf + 1 &&
+      a.y >= -0.5 &&
+      a.y <= 4
+    ) {
       anchorOk = true;
     }
   }
-  const roomHalf = 3.0;
   const candidates = [
     {n: new THREE.Vector3(1, 0, 0), d: -roomHalf},
     {n: new THREE.Vector3(-1, 0, 0), d: -roomHalf},
@@ -500,11 +712,41 @@ export function fitFlatOBB(
   if (!plane) return null;
   const n = new THREE.Vector3(plane.normal.x, 0, plane.normal.z);
   if (n.lengthSq() < 1e-6) return null;
+  const verticality = n.length();
   n.normalize();
-  if (Math.abs(n.x) > Math.abs(n.z)) {
-    n.set(Math.sign(n.x), 0, 0);
-  } else {
-    n.set(0, 0, Math.sign(n.z));
+  // Reconcile the measured wall normal with the room frame rather than
+  // snapping it to the session origin's axes. The confidence blends how many
+  // points supported the plane with how vertical the surface actually is.
+  const inlierRatio = plane.inliers.length / Math.max(1, workingPoints.length);
+  const measured = Math.atan2(n.x, n.z);
+  const resolved = resolveYaw(
+    {
+      angle: wrapQuarterPi(measured),
+      confidence: Math.min(1, inlierRatio * verticality),
+      method: 'wallPlane',
+      agreementR: 1,
+    },
+    opts.orientation
+  );
+  // resolveYaw works modulo 90°, so rebuild the normal from the resolved yaw
+  // by picking the representative closest to the measured direction, then
+  // restore the camera-facing sign the caller depends on.
+  n.set(Math.sin(resolved.angle), 0, Math.cos(resolved.angle));
+  let bestDot = -Infinity;
+  const measuredDir = new THREE.Vector3(
+    Math.sin(measured),
+    0,
+    Math.cos(measured)
+  );
+  const candidate = new THREE.Vector3();
+  for (let k = 0; k < 4; ++k) {
+    const a = resolved.angle + (k * Math.PI) / 2;
+    candidate.set(Math.sin(a), 0, Math.cos(a));
+    const d = candidate.dot(measuredDir);
+    if (d > bestDot) {
+      bestDot = d;
+      n.copy(candidate);
+    }
   }
   if (opts.camera) {
     _diff.subVectors(opts.camera.position, plane.point);
@@ -536,7 +778,13 @@ export function fitFlatOBB(
     (ymin + ymax) / 2,
     planePoint.z - uc * sn
   );
-  return {center, size: new THREE.Vector3(sizeU, sizeY, 0.05), angle};
+  return {
+    center,
+    size: new THREE.Vector3(sizeU, sizeY, 0.05),
+    angle,
+    yawConfidence: resolved.confidence,
+    yawMethod: resolved.method,
+  };
 }
 
 /**
@@ -620,7 +868,7 @@ export function fitLightOBB(
 ): InternalObb | null {
   if (points.length < 6) return null;
   const tight = rejectByDepth(points, opts.camera ?? null, 0.1);
-  return fitFurnitureOBB(tight);
+  return fitFurnitureOBB(tight, opts);
 }
 
 /**
@@ -631,47 +879,73 @@ export function fitLightOBB(
  * @param points - World-space depth samples (at least 6 required).
  * @returns Fitted {@link InternalObb}, or `null` when fewer than 6 points.
  */
-export function fitFurnitureOBB(points: THREE.Vector3[]): InternalObb | null {
+export function fitFurnitureOBB(
+  points: THREE.Vector3[],
+  opts: ObbFitOptions = {}
+): InternalObb | null {
   if (points.length < 6) return null;
   const xs = points.map((p) => p.x).sort((a, b) => a - b);
-  const ys = points.map((p) => p.y).sort((a, b) => a - b);
   const zs = points.map((p) => p.z).sort((a, b) => a - b);
   const med = (arr: number[]) => arr[Math.floor(arr.length / 2)];
   const cx = med(xs),
-    _cy = med(ys),
     cz = med(zs);
-  let Sxx = 0,
-    Sxz = 0,
-    Szz = 0;
-  for (const p of points) {
-    const dx = p.x - cx,
-      dz = p.z - cz;
-    Sxx += dx * dx;
-    Sxz += dx * dz;
-    Szz += dz * dz;
-  }
-  let angle = 0.5 * Math.atan2(2 * Sxz, Sxx - Szz);
-  const snapCandidates = [0, Math.PI / 2, -Math.PI / 2, Math.PI, -Math.PI];
-  let bestSnap = angle,
-    bestErr = Infinity;
-  for (const c of snapCandidates) {
-    const err = Math.abs(((angle - c + Math.PI) % (2 * Math.PI)) - Math.PI);
+  const est = estimateObjectYaw(points, cx, cz);
+  const resolved = resolveYaw(est, opts.orientation);
+  const obb = buildYawAlignedObb(points, cx, cz, resolved.angle);
+  obb.yawConfidence = resolved.confidence;
+  obb.yawMethod = resolved.method;
+  return obb;
+}
+
+/**
+ * Snap a yaw to the nearest of 0 / ±90 / 180°.
+ *
+ * Retained for the legacy `'cardinal'` orientation mode. Note this is an
+ * unconditional snap with no confidence gate, so its worst-case error is 45°,
+ * and it snaps to the *session origin's* axes rather than the room's.
+ */
+function snapYawToCardinal(angle: number): number {
+  const candidates = [0, Math.PI / 2, -Math.PI / 2, Math.PI, -Math.PI];
+  let best = angle;
+  let bestErr = Infinity;
+  for (const c of candidates) {
+    const err = Math.abs(wrapPi(angle - c));
     if (err < bestErr) {
       bestErr = err;
-      bestSnap = c;
+      best = c;
     }
   }
-  angle = bestSnap;
-  const cs = Math.cos(angle),
-    sn = Math.sin(angle);
+  return best;
+}
+
+/**
+ * Build a yaw-aligned box around `(cx, cz)` at a fixed `angle`, with
+ * percentile-clipped extents so stray mask pixels do not inflate it.
+ *
+ * Projection goes through {@link worldToLocalXZ} / {@link localToWorldXZ} so
+ * the extents are measured along exactly the axes the renderer will draw
+ * along. Measuring along one axis pair and drawing along its mirror is a bug
+ * that stays invisible while yaws are snapped to multiples of 90° and appears
+ * the moment they are not.
+ *
+ * @param points - World-space samples.
+ * @param cx - Seed centre X (median).
+ * @param cz - Seed centre Z (median).
+ * @param angle - Box yaw in radians.
+ */
+export function buildYawAlignedObb(
+  points: THREE.Vector3[],
+  cx: number,
+  cz: number,
+  angle: number
+): InternalObb {
   const us: number[] = [],
     vs: number[] = [],
     ysProj: number[] = [];
   for (const p of points) {
-    const dx = p.x - cx,
-      dz = p.z - cz;
-    us.push(dx * cs + dz * sn);
-    vs.push(-dx * sn + dz * cs);
+    const {u, v} = worldToLocalXZ(p.x - cx, p.z - cz, angle);
+    us.push(u);
+    vs.push(v);
     ysProj.push(p.y);
   }
   const umin = pctile(us, 0.05),
@@ -680,12 +954,9 @@ export function fitFurnitureOBB(points: THREE.Vector3[]): InternalObb | null {
     vmax = pctile(vs, 0.95);
   const ymin = pctile(ysProj, 0.02),
     ymax = pctile(ysProj, 0.98);
-  const uc = (umin + umax) / 2,
-    vc = (vmin + vmax) / 2;
-  const offX = uc * cs - vc * sn;
-  const offZ = uc * sn + vc * cs;
+  const off = localToWorldXZ((umin + umax) / 2, (vmin + vmax) / 2, angle);
   return {
-    center: new THREE.Vector3(cx + offX, (ymin + ymax) / 2, cz + offZ),
+    center: new THREE.Vector3(cx + off.x, (ymin + ymax) / 2, cz + off.z),
     size: new THREE.Vector3(
       Math.max(0.02, umax - umin),
       Math.max(0.02, ymax - ymin),

--- a/src/addons/objects3d/geometry/PoseRing.test.ts
+++ b/src/addons/objects3d/geometry/PoseRing.test.ts
@@ -1,0 +1,60 @@
+import * as THREE from 'three';
+import {describe, expect, it} from 'vitest';
+
+import {PoseRing} from './PoseRing';
+
+function translation(x: number): THREE.Matrix4 {
+  return new THREE.Matrix4().makeTranslation(x, 0, 0);
+}
+
+describe('PoseRing', () => {
+  it('returns null when empty', () => {
+    const ring = new PoseRing(4);
+    expect(ring.lookup(100)).toBeNull();
+  });
+
+  it('returns the nearest pose by timestamp', () => {
+    const ring = new PoseRing(4);
+    ring.push(100, translation(1));
+    ring.push(200, translation(2));
+    ring.push(300, translation(3));
+    const m = ring.lookup(190);
+    expect(m).not.toBeNull();
+    expect(new THREE.Vector3().setFromMatrixPosition(m!).x).toBe(2);
+  });
+
+  it('rejects samples older than maxAgeMs', () => {
+    const ring = new PoseRing(4);
+    ring.push(100, translation(1));
+    expect(ring.lookup(700, 500)).toBeNull();
+    expect(ring.lookup(600, 500)).not.toBeNull();
+  });
+
+  it('overwrites oldest entries once capacity is exceeded', () => {
+    const ring = new PoseRing(2);
+    ring.push(100, translation(1));
+    ring.push(200, translation(2));
+    ring.push(300, translation(3));
+    expect(ring.size).toBe(2);
+    // t=100 was evicted; nearest to 100 within 150ms is t=200.
+    const m = ring.lookup(100, 150);
+    expect(new THREE.Vector3().setFromMatrixPosition(m!).x).toBe(2);
+  });
+
+  it('copies the pushed matrix rather than retaining the reference', () => {
+    const ring = new PoseRing(2);
+    const m = translation(5);
+    ring.push(100, m);
+    m.makeTranslation(9, 0, 0);
+    const stored = ring.lookup(100)!;
+    expect(new THREE.Vector3().setFromMatrixPosition(stored).x).toBe(5);
+  });
+
+  it('clear() empties the ring', () => {
+    const ring = new PoseRing(4);
+    ring.push(100, translation(1));
+    ring.clear();
+    expect(ring.size).toBe(0);
+    expect(ring.lookup(100)).toBeNull();
+  });
+});

--- a/src/addons/objects3d/geometry/PoseRing.ts
+++ b/src/addons/objects3d/geometry/PoseRing.ts
@@ -1,0 +1,83 @@
+import * as THREE from 'three';
+
+/**
+ * Fixed-capacity ring buffer of timestamped camera poses.
+ *
+ * The passthrough video pipeline delivers RGB pixels with some latency, so
+ * the camera pose at snapshot time is slightly *newer* than the pixels being
+ * snapshotted. Recording the device-camera pose every frame lets a capture be
+ * paired with the pose closest to the frame's `captureTime`, instead of the
+ * pose at the moment `detect()` happened to run.
+ *
+ * Entries are preallocated once; {@link push} copies into the next slot, so
+ * steady-state recording does not allocate.
+ */
+export class PoseRing {
+  private readonly entries: {t: number; worldFromView: THREE.Matrix4}[];
+  private next = 0;
+  private count = 0;
+
+  constructor(capacity = 120) {
+    this.entries = Array.from({length: Math.max(1, capacity)}, () => ({
+      t: 0,
+      worldFromView: new THREE.Matrix4(),
+    }));
+  }
+
+  /** Number of poses currently stored. */
+  get size(): number {
+    return this.count;
+  }
+
+  /** Record a pose. `t` is a `performance.now()`-timebase timestamp. */
+  push(t: number, worldFromView: THREE.Matrix4): void {
+    const entry = this.entries[this.next];
+    entry.t = t;
+    entry.worldFromView.copy(worldFromView);
+    this.next = (this.next + 1) % this.entries.length;
+    this.count = Math.min(this.count + 1, this.entries.length);
+  }
+
+  /** Remove all stored poses. */
+  clear(): void {
+    this.next = 0;
+    this.count = 0;
+  }
+
+  /**
+   * The stored pose whose timestamp is nearest to `t`, or `null` when the
+   * ring is empty or the nearest sample is further than `maxAgeMs` away.
+   * Returns a reference to ring-internal storage — copy before holding on to
+   * it across further {@link push} calls.
+   */
+  lookup(t: number, maxAgeMs = 500): THREE.Matrix4 | null {
+    const best = this.nearest(t);
+    return best && best.delta <= maxAgeMs ? best.entry.worldFromView : null;
+  }
+
+  /**
+   * How far the nearest stored pose is from `t`, in milliseconds, or `null`
+   * when the ring is empty. Small values mean the capture was paired with a
+   * pose recorded at essentially the right instant.
+   */
+  matchErrorMs(t: number): number | null {
+    return this.nearest(t)?.delta ?? null;
+  }
+
+  private nearest(t: number): {
+    entry: {t: number; worldFromView: THREE.Matrix4};
+    delta: number;
+  } | null {
+    let best: {t: number; worldFromView: THREE.Matrix4} | null = null;
+    let bestDelta = Infinity;
+    for (let i = 0; i < this.count; ++i) {
+      const entry = this.entries[i];
+      const delta = Math.abs(entry.t - t);
+      if (delta < bestDelta) {
+        bestDelta = delta;
+        best = entry;
+      }
+    }
+    return best ? {entry: best, delta: bestDelta} : null;
+  }
+}

--- a/src/addons/objects3d/geometry/RoomFrame.test.ts
+++ b/src/addons/objects3d/geometry/RoomFrame.test.ts
@@ -1,0 +1,288 @@
+import * as THREE from 'three';
+import {describe, expect, it} from 'vitest';
+
+import {
+  estimateRoomYawFromMesh,
+  RoomFrameAccumulator,
+  yawRelativeToRoom,
+} from './RoomFrame';
+import {yawDelta90} from './YawEstimation';
+
+const deg = THREE.MathUtils.degToRad;
+
+/**
+ * A mesh of four walls enclosing a room of half-extent `half`, rotated by
+ * `yawDeg` about the origin. Triangles are kept small so they survive the
+ * `maxEdge` skirt filter.
+ */
+function roomMesh(yawDeg: number, half = 2, cell = 0.1): THREE.Mesh {
+  const positions: number[] = [];
+  const q = new THREE.Quaternion().setFromAxisAngle(
+    new THREE.Vector3(0, 1, 0),
+    deg(yawDeg)
+  );
+  const push = (x: number, y: number, z: number) => {
+    const v = new THREE.Vector3(x, y, z).applyQuaternion(q);
+    positions.push(v.x, v.y, v.z);
+  };
+  // Each wall is a grid of quads in a plane of constant x or z.
+  const steps = Math.max(2, Math.round((2 * half) / cell));
+  const hSteps = Math.max(2, Math.round(2 / cell));
+  for (const [axis, sign] of [
+    ['x', 1],
+    ['x', -1],
+    ['z', 1],
+    ['z', -1],
+  ] as const) {
+    for (let i = 0; i < steps; ++i) {
+      for (let j = 0; j < hSteps; ++j) {
+        const t0 = -half + (i / steps) * 2 * half;
+        const t1 = -half + ((i + 1) / steps) * 2 * half;
+        const y0 = (j / hSteps) * 2;
+        const y1 = ((j + 1) / hSteps) * 2;
+        const fixed = sign * half;
+        const corner = (t: number, y: number) =>
+          axis === 'x' ? push(fixed, y, t) : push(t, y, fixed);
+        corner(t0, y0);
+        corner(t1, y0);
+        corner(t1, y1);
+        corner(t0, y0);
+        corner(t1, y1);
+        corner(t0, y1);
+      }
+    }
+  }
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute(
+    'position',
+    new THREE.Float32BufferAttribute(positions, 3)
+  );
+  const mesh = new THREE.Mesh(geometry);
+  mesh.updateMatrixWorld();
+  return mesh;
+}
+
+/** A mesh of only horizontal (floor) triangles. */
+function floorMesh(): THREE.Mesh {
+  const positions: number[] = [];
+  for (let i = 0; i < 20; ++i) {
+    for (let j = 0; j < 20; ++j) {
+      const x0 = i * 0.1,
+        x1 = x0 + 0.1;
+      const z0 = j * 0.1,
+        z1 = z0 + 0.1;
+      positions.push(x0, 0, z0, x1, 0, z0, x1, 0, z1);
+      positions.push(x0, 0, z0, x1, 0, z1, x0, 0, z1);
+    }
+  }
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute(
+    'position',
+    new THREE.Float32BufferAttribute(positions, 3)
+  );
+  return new THREE.Mesh(geometry);
+}
+
+describe('estimateRoomYawFromMesh', () => {
+  it('recovers an axis-aligned room', () => {
+    const frame = estimateRoomYawFromMesh(roomMesh(0))!;
+    expect(frame).not.toBeNull();
+    expect(Math.abs(yawDelta90(frame.yaw, 0))).toBeLessThan(deg(1.5));
+    expect(frame.confidence).toBeGreaterThan(0.9);
+    expect(frame.supportArea).toBeGreaterThan(1);
+  });
+
+  it('recovers a rotated room', () => {
+    for (const d of [17, 30, 41]) {
+      const frame = estimateRoomYawFromMesh(roomMesh(d))!;
+      expect(Math.abs(yawDelta90(frame.yaw, deg(d)))).toBeLessThan(deg(1.5));
+      expect(frame.confidence).toBeGreaterThan(0.9);
+    }
+  });
+
+  it('handles the wrap at 89 degrees', () => {
+    const frame = estimateRoomYawFromMesh(roomMesh(89))!;
+    expect(Math.abs(yawDelta90(frame.yaw, deg(89)))).toBeLessThan(deg(1.5));
+    expect(frame.yaw).toBeGreaterThanOrEqual(0);
+    expect(frame.yaw).toBeLessThan(Math.PI / 2);
+  });
+
+  it('returns null for a floor-only mesh', () => {
+    expect(estimateRoomYawFromMesh(floorMesh())).toBeNull();
+  });
+
+  it('reports low confidence for a cylindrical room', () => {
+    const positions: number[] = [];
+    const N = 240;
+    for (let i = 0; i < N; ++i) {
+      const t0 = (i / N) * Math.PI * 2;
+      const t1 = ((i + 1) / N) * Math.PI * 2;
+      const r = 2;
+      const x0 = Math.cos(t0) * r,
+        z0 = Math.sin(t0) * r;
+      const x1 = Math.cos(t1) * r,
+        z1 = Math.sin(t1) * r;
+      for (let j = 0; j < 12; ++j) {
+        const y0 = j * 0.15,
+          y1 = y0 + 0.15;
+        positions.push(x0, y0, z0, x1, y0, z1, x1, y1, z1);
+        positions.push(x0, y0, z0, x1, y1, z1, x0, y1, z0);
+      }
+    }
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute(
+      'position',
+      new THREE.Float32BufferAttribute(positions, 3)
+    );
+    const frame = estimateRoomYawFromMesh(new THREE.Mesh(geometry))!;
+    expect(frame).not.toBeNull();
+    expect(frame.confidence).toBeLessThan(0.25);
+  });
+
+  /**
+   * Pins the skirt filter. Depth meshes bridge discontinuities with long
+   * triangles whose normals are silhouette artefacts; without `maxEdge` they
+   * outvote the real walls because their area is large.
+   */
+  it('rejects stretched skirt triangles', () => {
+    const mesh = roomMesh(20);
+    const positions = Array.from(
+      (mesh.geometry.attributes['position'] as THREE.BufferAttribute)
+        .array as Float32Array
+    );
+    // Huge triangles bridging opposite walls. They are *vertical*, so the
+    // verticality filter admits them and only maxEdge can reject them, and
+    // their normals point ~30 degrees off the room grid.
+    for (let i = 0; i < 12; ++i) {
+      const y = i * 0.15;
+      // Long horizontal edge plus a purely vertical edge => horizontal normal.
+      positions.push(-2, y, -2, 2, y, 1.4, -2, y + 1.5, -2);
+    }
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute(
+      'position',
+      new THREE.Float32BufferAttribute(positions, 3)
+    );
+    const dirty = new THREE.Mesh(geometry);
+
+    const filtered = estimateRoomYawFromMesh(dirty)!;
+    expect(Math.abs(yawDelta90(filtered.yaw, deg(20)))).toBeLessThan(deg(2));
+
+    // With the filter effectively disabled the skirts are admitted and drag
+    // the support area up with off-grid normals.
+    const unfiltered = estimateRoomYawFromMesh(dirty, {maxEdge: 100})!;
+    expect(unfiltered.supportArea).toBeGreaterThan(filtered.supportArea);
+    expect(unfiltered.confidence).toBeLessThan(filtered.confidence);
+  });
+
+  it('honours the range cap', () => {
+    const near = estimateRoomYawFromMesh(roomMesh(0), {
+      viewerPosition: new THREE.Vector3(0, 1, 0),
+      maxRange: 10,
+    })!;
+    const clipped = estimateRoomYawFromMesh(roomMesh(0), {
+      viewerPosition: new THREE.Vector3(0, 1, 0),
+      maxRange: 2.05,
+    });
+    expect(near).not.toBeNull();
+    // A 2 m half-extent room is mostly beyond a 2.05 m radius at the corners.
+    if (clipped) {
+      expect(clipped.supportArea).toBeLessThan(near.supportArea);
+    }
+  });
+
+  it('returns null for an empty geometry', () => {
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.Float32BufferAttribute([], 3));
+    expect(estimateRoomYawFromMesh(new THREE.Mesh(geometry))).toBeNull();
+  });
+
+  it('applies the mesh world matrix', () => {
+    const mesh = roomMesh(0);
+    mesh.rotation.y = deg(25);
+    mesh.updateMatrixWorld();
+    const frame = estimateRoomYawFromMesh(mesh)!;
+    expect(Math.abs(yawDelta90(frame.yaw, deg(25)))).toBeLessThan(deg(2));
+  });
+});
+
+describe('RoomFrameAccumulator', () => {
+  const frame = (yawDeg: number, confidence = 0.95, supportArea = 10) => ({
+    yaw: deg(yawDeg),
+    confidence,
+    supportArea,
+    triangles: 500,
+  });
+
+  it('starts empty', () => {
+    expect(new RoomFrameAccumulator().current).toBeNull();
+  });
+
+  it('ignores null estimates', () => {
+    const acc = new RoomFrameAccumulator();
+    expect(acc.push(null)).toBeNull();
+  });
+
+  it('averages consistent estimates', () => {
+    const acc = new RoomFrameAccumulator();
+    acc.push(frame(17));
+    const result = acc.push(frame(18))!;
+    expect(Math.abs(yawDelta90(result.yaw, deg(17.5)))).toBeLessThan(deg(0.5));
+  });
+
+  it('holds its ground on a single outlier', () => {
+    const acc = new RoomFrameAccumulator();
+    acc.push(frame(17));
+    const afterOutlier = acc.push(frame(60))!;
+    expect(Math.abs(yawDelta90(afterOutlier.yaw, deg(17)))).toBeLessThan(
+      deg(1)
+    );
+  });
+
+  it('re-seeds after sustained drift', () => {
+    const acc = new RoomFrameAccumulator();
+    acc.push(frame(17));
+    acc.push(frame(60));
+    const result = acc.push(frame(60))!;
+    expect(Math.abs(yawDelta90(result.yaw, deg(60)))).toBeLessThan(deg(1));
+  });
+
+  it('clears on reset', () => {
+    const acc = new RoomFrameAccumulator();
+    acc.push(frame(17));
+    acc.reset();
+    expect(acc.current).toBeNull();
+  });
+});
+
+describe('yawRelativeToRoom', () => {
+  it('is zero for an aligned object', () => {
+    expect(
+      Math.abs(
+        yawRelativeToRoom(deg(17), {
+          yaw: deg(17),
+          confidence: 1,
+          supportArea: 5,
+          triangles: 1,
+        })
+      )
+    ).toBeLessThan(1e-9);
+  });
+
+  it('treats a 90 degree offset as aligned', () => {
+    expect(
+      Math.abs(
+        yawRelativeToRoom(deg(107), {
+          yaw: deg(17),
+          confidence: 1,
+          supportArea: 5,
+          triangles: 1,
+        })
+      )
+    ).toBeLessThan(1e-9);
+  });
+
+  it('measures against the world axes without a frame', () => {
+    expect(yawRelativeToRoom(deg(10), null)).toBeCloseTo(deg(10), 9);
+  });
+});

--- a/src/addons/objects3d/geometry/RoomFrame.ts
+++ b/src/addons/objects3d/geometry/RoomFrame.ts
@@ -1,0 +1,287 @@
+/**
+ * Estimation of a room's dominant horizontal axis ("Manhattan frame") from a
+ * depth mesh.
+ *
+ * Snapping object yaws to the *session origin's* X/Z axes assumes the user
+ * happened to be facing a wall when the session started, which on a headset is
+ * essentially never true. Estimating the room's own axes from the geometry the
+ * device already reconstructs removes that assumption: a box whose orientation
+ * is ill-determined can then fall back to something physically meaningful
+ * instead of an arbitrary grid.
+ *
+ * All functions are pure (no `xb.core` dependencies): they take a
+ * `THREE.Mesh` and are safe to unit-test, or to run server-side in Node.
+ */
+
+import * as THREE from 'three';
+
+import {wrapQuarterPi, yawDelta90} from './YawEstimation';
+
+const HALF_PI = Math.PI / 2;
+
+/** Estimated room orientation. */
+export interface RoomFrame {
+  /** Dominant horizontal axis of the room, wrapped into `[0, π/2)`. */
+  yaw: number;
+  /**
+   * Mean resultant length of the vote in the 4θ domain, in `[0, 1]`. High for
+   * a rectangular room, low for a curved or cluttered one.
+   */
+  confidence: number;
+  /** Total area of vertical surface that voted, in m². */
+  supportArea: number;
+  /** Number of triangles that passed all filters. */
+  triangles: number;
+}
+
+/** Tuning for {@link estimateRoomYawFromMesh}. */
+export interface RoomFrameOptions {
+  /** Cap on triangles visited; the mesh is strided down to this. */
+  maxTriangles?: number;
+  /**
+   * Reject triangles with any edge longer than this, in metres. Essential:
+   * the depth mesh is a camera-grid mesh, so triangles spanning a depth
+   * discontinuity become long "skirts" whose normals are silhouette
+   * artefacts rather than real surfaces.
+   */
+  maxEdge?: number;
+  /** Keep only surfaces whose normal is within this of horizontal. */
+  maxAbsNy?: number;
+  /** Minimum total voting area before a result is trusted at all. */
+  minSupportArea?: number;
+  /** Viewer position; triangles beyond `maxRange` of it are ignored. */
+  viewerPosition?: THREE.Vector3;
+  /** Range cap in metres — depth noise grows with distance. */
+  maxRange?: number;
+}
+
+const DEFAULTS = {
+  maxTriangles: 20000,
+  maxEdge: 0.2,
+  maxAbsNy: 0.25,
+  minSupportArea: 1.0,
+  maxRange: 6,
+};
+
+const _a = new THREE.Vector3();
+const _b = new THREE.Vector3();
+const _c = new THREE.Vector3();
+const _ab = new THREE.Vector3();
+const _ac = new THREE.Vector3();
+const _n = new THREE.Vector3();
+const _centroid = new THREE.Vector3();
+
+/**
+ * Estimate the room's dominant horizontal axis from a depth mesh.
+ *
+ * Every near-vertical triangle votes for its normal's yaw, weighted by area,
+ * in the `4θ` domain so that the four walls of a rectangular room reinforce
+ * each other rather than cancelling. The vote is then refined around the
+ * histogram peak so one large wall cannot drag the answer.
+ *
+ * @param mesh - Depth mesh; `matrixWorld` is applied to its vertices.
+ * @param options - See {@link RoomFrameOptions}.
+ * @returns The estimated frame, or `null` when too little vertical surface was
+ *   visible to say anything honest.
+ */
+export function estimateRoomYawFromMesh(
+  mesh: THREE.Mesh,
+  options: RoomFrameOptions = {}
+): RoomFrame | null {
+  const opts = {...DEFAULTS, ...options};
+  const geometry = mesh.geometry;
+  const position = geometry?.attributes?.['position'] as
+    | THREE.BufferAttribute
+    | undefined;
+  if (!position || position.count < 3) return null;
+
+  const index = geometry.getIndex();
+  const triangleCount = index ? index.count / 3 : position.count / 3;
+  if (triangleCount < 1) return null;
+  const stride = Math.max(1, Math.ceil(triangleCount / opts.maxTriangles));
+
+  mesh.updateMatrixWorld();
+  const matrixWorld = mesh.matrixWorld;
+  const maxEdgeSq = opts.maxEdge * opts.maxEdge;
+  const maxRangeSq = opts.maxRange * opts.maxRange;
+
+  // Weighted circular sums in the 4-theta domain, plus a 1-degree histogram
+  // over [0, 90) used to locate the dominant peak.
+  let sumCos = 0;
+  let sumSin = 0;
+  let sumWeight = 0;
+  let kept = 0;
+  const BINS = 90;
+  const histogram = new Float64Array(BINS);
+  const binAngles = new Float64Array(BINS);
+
+  for (let t = 0; t < triangleCount; t += stride) {
+    const base = t * 3;
+    const i0 = index ? index.getX(base) : base;
+    const i1 = index ? index.getX(base + 1) : base + 1;
+    const i2 = index ? index.getX(base + 2) : base + 2;
+
+    _a.fromBufferAttribute(position, i0).applyMatrix4(matrixWorld);
+    _b.fromBufferAttribute(position, i1).applyMatrix4(matrixWorld);
+    _c.fromBufferAttribute(position, i2).applyMatrix4(matrixWorld);
+
+    _ab.subVectors(_b, _a);
+    _ac.subVectors(_c, _a);
+    if (
+      _ab.lengthSq() > maxEdgeSq ||
+      _ac.lengthSq() > maxEdgeSq ||
+      _b.distanceToSquared(_c) > maxEdgeSq
+    ) {
+      continue;
+    }
+
+    _n.crossVectors(_ab, _ac);
+    const doubleArea = _n.length();
+    if (doubleArea < 1e-8) continue;
+    _n.multiplyScalar(1 / doubleArea);
+    if (Math.abs(_n.y) > opts.maxAbsNy) continue;
+
+    if (opts.viewerPosition) {
+      _centroid
+        .copy(_a)
+        .add(_b)
+        .add(_c)
+        .multiplyScalar(1 / 3);
+      if (_centroid.distanceToSquared(opts.viewerPosition) > maxRangeSq) {
+        continue;
+      }
+    }
+
+    const area = doubleArea / 2;
+    const theta = Math.atan2(_n.x, _n.z);
+    sumCos += area * Math.cos(4 * theta);
+    sumSin += area * Math.sin(4 * theta);
+    sumWeight += area;
+    kept++;
+
+    const wrapped = ((theta % HALF_PI) + HALF_PI) % HALF_PI;
+    const bin = Math.min(BINS - 1, Math.floor((wrapped / HALF_PI) * BINS));
+    histogram[bin] += area;
+    binAngles[bin] += area * wrapped;
+  }
+
+  if (sumWeight < opts.minSupportArea || kept === 0) return null;
+
+  const confidence = Math.min(1, Math.hypot(sumCos, sumSin) / sumWeight);
+
+  // Refine around the histogram peak: a weighted mean over the peak bin and
+  // its two neighbours on each side, which is robust to one dominant wall
+  // skewing the global circular mean.
+  let peak = 0;
+  for (let i = 1; i < BINS; ++i) {
+    if (histogram[i] > histogram[peak]) peak = i;
+  }
+  let refinedWeight = 0;
+  let refinedSum = 0;
+  const peakCentre = ((peak + 0.5) / BINS) * HALF_PI;
+  for (let d = -2; d <= 2; ++d) {
+    const i = (peak + d + BINS) % BINS;
+    const w = histogram[i];
+    if (w <= 0) continue;
+    const mean = binAngles[i] / w;
+    // Unwrap relative to the peak so bins either side of the 0/90 seam blend.
+    refinedSum += w * (peakCentre + yawDelta90(mean, peakCentre));
+    refinedWeight += w;
+  }
+  const yaw =
+    refinedWeight > 0
+      ? (((refinedSum / refinedWeight) % HALF_PI) + HALF_PI) % HALF_PI
+      : (((0.25 * Math.atan2(sumSin, sumCos)) % HALF_PI) + HALF_PI) % HALF_PI;
+
+  return {yaw, confidence, supportArea: sumWeight, triangles: kept};
+}
+
+/** Drift beyond which the accumulated frame is assumed stale. */
+const DRIFT_TOLERANCE_RAD = (20 * Math.PI) / 180;
+
+/**
+ * Running estimate of the room frame across multiple captures.
+ *
+ * Each `detect()` sees a different slice of the room, so accumulating genuinely
+ * improves the estimate. There is no reference-space reset event to hook, so
+ * staleness is detected by drift instead: two consecutive estimates that both
+ * disagree with the accumulated value clear it and re-seed.
+ */
+export class RoomFrameAccumulator {
+  private sumCos = 0;
+  private sumSin = 0;
+  private sumWeight = 0;
+  private consecutiveOutliers = 0;
+  private latest: RoomFrame | null = null;
+
+  /** The accumulated frame, or `null` before any usable estimate. */
+  get current(): RoomFrame | null {
+    return this.latest;
+  }
+
+  /**
+   * Fold one per-capture estimate into the running frame.
+   *
+   * @param frame - Estimate from {@link estimateRoomYawFromMesh}, or `null`.
+   * @returns The updated accumulated frame.
+   */
+  push(frame: RoomFrame | null): RoomFrame | null {
+    if (!frame) return this.latest;
+
+    if (this.latest) {
+      const drift = Math.abs(yawDelta90(frame.yaw, this.latest.yaw));
+      if (drift > DRIFT_TOLERANCE_RAD) {
+        this.consecutiveOutliers++;
+        if (this.consecutiveOutliers >= 2) {
+          // The room frame really has moved (or the reference space reset).
+          this.reset();
+        } else {
+          // One disagreement could be a bad capture; keep the current frame.
+          return this.latest;
+        }
+      } else {
+        this.consecutiveOutliers = 0;
+      }
+    }
+
+    const w = frame.supportArea * frame.confidence;
+    this.sumCos += w * Math.cos(4 * frame.yaw);
+    this.sumSin += w * Math.sin(4 * frame.yaw);
+    this.sumWeight += w;
+    if (this.sumWeight <= 0) return this.latest;
+
+    const yaw =
+      (((0.25 * Math.atan2(this.sumSin, this.sumCos)) % HALF_PI) + HALF_PI) %
+      HALF_PI;
+    this.latest = {
+      yaw,
+      confidence: Math.min(
+        1,
+        Math.hypot(this.sumCos, this.sumSin) / this.sumWeight
+      ),
+      supportArea: frame.supportArea,
+      triangles: frame.triangles,
+    };
+    return this.latest;
+  }
+
+  /** Discard all accumulated evidence. */
+  reset(): void {
+    this.sumCos = 0;
+    this.sumSin = 0;
+    this.sumWeight = 0;
+    this.consecutiveOutliers = 0;
+    this.latest = null;
+  }
+}
+
+/**
+ * Signed angle from the room frame to `yaw`, in `[-π/4, π/4)`. Near zero means
+ * the object is aligned with the room's walls.
+ */
+export function yawRelativeToRoom(
+  yaw: number,
+  frame: RoomFrame | null
+): number {
+  return wrapQuarterPi(yaw - (frame?.yaw ?? 0));
+}

--- a/src/addons/objects3d/geometry/YawEstimation.test.ts
+++ b/src/addons/objects3d/geometry/YawEstimation.test.ts
@@ -1,0 +1,406 @@
+import * as THREE from 'three';
+import {describe, expect, it} from 'vitest';
+
+import {
+  canonicalizeYawObb,
+  combineYawCandidates,
+  convexHullXZ,
+  localToWorldXZ,
+  minAreaRectXZ,
+  pcaYawConfidence,
+  pcaYawXZ,
+  ransacVerticalPlane,
+  worldToLocalXZ,
+  wrapPi,
+  wrapQuarterPi,
+  yawDelta90,
+} from './YawEstimation';
+
+/** Deterministic PRNG (mulberry32) so RANSAC tests cannot flake. */
+function seededRng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Rotate a local (u, v) footprint point into world XZ at yaw `a`. */
+function at(u: number, v: number, a: number) {
+  return localToWorldXZ(u, v, a);
+}
+
+const deg = THREE.MathUtils.degToRad;
+
+/**
+ * The eight corners of an OBB, computed the way the renderer draws it:
+ * `BoxGeometry(size)` rotated by `rotation.y = angle` about `center`.
+ * Tests assert on corner sets rather than angles wherever an angle has more
+ * than one valid representation.
+ */
+function renderCorners(obb: {
+  center: THREE.Vector3;
+  size: THREE.Vector3;
+  angle: number;
+}): THREE.Vector3[] {
+  const q = new THREE.Quaternion().setFromAxisAngle(
+    new THREE.Vector3(0, 1, 0),
+    obb.angle
+  );
+  const out: THREE.Vector3[] = [];
+  for (const sx of [-0.5, 0.5]) {
+    for (const sy of [-0.5, 0.5]) {
+      for (const sz of [-0.5, 0.5]) {
+        out.push(
+          new THREE.Vector3(sx * obb.size.x, sy * obb.size.y, sz * obb.size.z)
+            .applyQuaternion(q)
+            .add(obb.center)
+        );
+      }
+    }
+  }
+  return out;
+}
+
+/** Smallest distance from `p` to any point in `set`. */
+function nearestDistance(p: THREE.Vector3, set: THREE.Vector3[]): number {
+  return Math.min(...set.map((q) => q.distanceTo(p)));
+}
+
+describe('wrapPi', () => {
+  it('wraps into (-pi, pi]', () => {
+    expect(wrapPi(0)).toBeCloseTo(0, 10);
+    expect(wrapPi(deg(190))).toBeCloseTo(deg(-170), 10);
+    expect(wrapPi(deg(-190))).toBeCloseTo(deg(170), 10);
+    expect(wrapPi(deg(720))).toBeCloseTo(0, 10);
+  });
+});
+
+describe('wrapQuarterPi', () => {
+  it('wraps into [-45deg, 45deg)', () => {
+    expect(wrapQuarterPi(deg(0))).toBeCloseTo(0, 10);
+    expect(wrapQuarterPi(deg(30))).toBeCloseTo(deg(30), 10);
+    expect(wrapQuarterPi(deg(90))).toBeCloseTo(0, 10);
+    expect(wrapQuarterPi(deg(100))).toBeCloseTo(deg(10), 10);
+    expect(wrapQuarterPi(deg(-100))).toBeCloseTo(deg(-10), 10);
+  });
+
+  it('always lands inside the half-open interval', () => {
+    for (let d = -360; d <= 360; d += 3) {
+      const w = wrapQuarterPi(deg(d));
+      expect(w).toBeGreaterThanOrEqual(-Math.PI / 4 - 1e-12);
+      expect(w).toBeLessThan(Math.PI / 4 + 1e-12);
+    }
+  });
+});
+
+describe('yawDelta90', () => {
+  it('treats yaws 90 degrees apart as identical', () => {
+    // Same box: rotate 90 degrees and swap width/depth.
+    expect(Math.abs(yawDelta90(deg(0), deg(90)))).toBeLessThan(1e-9);
+    expect(Math.abs(yawDelta90(deg(30), deg(120)))).toBeLessThan(1e-9);
+  });
+
+  it('measures small differences with sign', () => {
+    expect(yawDelta90(deg(44), deg(46))).toBeCloseTo(deg(-2), 9);
+    expect(yawDelta90(deg(89), deg(1))).toBeCloseTo(deg(-2), 9);
+    expect(yawDelta90(deg(1), deg(89))).toBeCloseTo(deg(2), 9);
+  });
+
+  it('reports maximal disagreement at 45 degrees', () => {
+    expect(Math.abs(yawDelta90(deg(0), deg(45)))).toBeCloseTo(Math.PI / 4, 9);
+  });
+});
+
+describe('worldToLocalXZ / localToWorldXZ', () => {
+  it('matches the renderer convention (rotation.y = angle)', () => {
+    // three.js Ry(a) maps local +X to world (cos a, 0, -sin a). A point one
+    // unit along the box's u axis must therefore land there.
+    const a = deg(30);
+    const w = localToWorldXZ(1, 0, a);
+    expect(w.x).toBeCloseTo(Math.cos(a), 12);
+    expect(w.z).toBeCloseTo(-Math.sin(a), 12);
+
+    // Cross-check against three.js itself rather than trusting the algebra.
+    const v = new THREE.Vector3(1, 0, 0).applyQuaternion(
+      new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), a)
+    );
+    expect(w.x).toBeCloseTo(v.x, 12);
+    expect(w.z).toBeCloseTo(v.z, 12);
+  });
+
+  it('round-trips for arbitrary angles and offsets', () => {
+    for (const d of [0, 17, 45, 90, -33, 200]) {
+      const a = deg(d);
+      const {u, v} = worldToLocalXZ(0.7, -1.3, a);
+      const back = localToWorldXZ(u, v, a);
+      expect(back.x).toBeCloseTo(0.7, 12);
+      expect(back.z).toBeCloseTo(-1.3, 12);
+    }
+  });
+});
+
+describe('canonicalizeYawObb', () => {
+  const base = {
+    center: new THREE.Vector3(1, 2, 3),
+    size: new THREE.Vector3(2, 1, 0.5),
+  };
+
+  it('leaves an already-canonical yaw untouched', () => {
+    const obb = {...base, angle: deg(20)};
+    const c = canonicalizeYawObb(obb);
+    expect(c.angle).toBeCloseTo(deg(20), 12);
+    expect(c.size.x).toBe(2);
+    expect(c.size.z).toBe(0.5);
+  });
+
+  it('swaps extents when it rotates by an odd quarter turn', () => {
+    const c = canonicalizeYawObb({...base, angle: deg(100)});
+    expect(c.angle).toBeCloseTo(deg(10), 9);
+    expect(c.size.x).toBeCloseTo(0.5, 12);
+    expect(c.size.z).toBeCloseTo(2, 12);
+  });
+
+  it('preserves the rendered volume for angles across the circle', () => {
+    for (let d = -180; d <= 180; d += 7) {
+      const obb = {...base, size: base.size.clone(), angle: deg(d)};
+      const c = canonicalizeYawObb(obb);
+      const before = renderCorners(obb);
+      const after = renderCorners(c);
+      // Same eight corners, possibly in a different order.
+      for (const p of before) {
+        expect(nearestDistance(p, after)).toBeLessThan(1e-9);
+      }
+      expect(c.size.y).toBeCloseTo(obb.size.y, 12);
+    }
+  });
+
+  it('does not mutate its input', () => {
+    const obb = {...base, size: base.size.clone(), angle: deg(100)};
+    canonicalizeYawObb(obb);
+    expect(obb.angle).toBeCloseTo(deg(100), 12);
+    expect(obb.size.x).toBe(2);
+  });
+});
+
+describe('convexHullXZ', () => {
+  it('drops interior points', () => {
+    const hull = convexHullXZ([
+      {x: 0, z: 0},
+      {x: 2, z: 0},
+      {x: 2, z: 2},
+      {x: 0, z: 2},
+      {x: 1, z: 1},
+      {x: 0.5, z: 1.2},
+    ]);
+    expect(hull).toHaveLength(4);
+  });
+
+  it('excludes collinear points on an edge', () => {
+    const hull = convexHullXZ([
+      {x: 0, z: 0},
+      {x: 1, z: 0},
+      {x: 2, z: 0},
+      {x: 2, z: 2},
+      {x: 0, z: 2},
+    ]);
+    expect(hull).toHaveLength(4);
+  });
+
+  it('returns short inputs unchanged', () => {
+    expect(
+      convexHullXZ([
+        {x: 0, z: 0},
+        {x: 1, z: 1},
+      ])
+    ).toHaveLength(2);
+  });
+});
+
+describe('minAreaRectXZ', () => {
+  /** A filled rectangle footprint of extent w x d, yawed by `a`. */
+  const rect = (w: number, d: number, a: number, steps = 12) => {
+    const pts = [];
+    for (let i = 0; i < steps; ++i) {
+      for (let j = 0; j < steps; ++j) {
+        pts.push(
+          at((i / (steps - 1) - 0.5) * w, (j / (steps - 1) - 0.5) * d, a)
+        );
+      }
+    }
+    return pts;
+  };
+
+  it('recovers an axis-aligned rectangle', () => {
+    const r = minAreaRectXZ(rect(2, 1, 0))!;
+    expect(r).not.toBeNull();
+    expect(Math.abs(yawDelta90(r.angle, 0))).toBeLessThan(deg(1));
+    expect(Math.max(r.width, r.depth)).toBeCloseTo(2, 1);
+    expect(Math.min(r.width, r.depth)).toBeCloseTo(1, 1);
+  });
+
+  it('recovers a rotated rectangle', () => {
+    for (const d of [15, 30, 60, -25]) {
+      const r = minAreaRectXZ(rect(2, 1, deg(d)))!;
+      expect(Math.abs(yawDelta90(r.angle, deg(d)))).toBeLessThan(deg(2));
+    }
+  });
+
+  it('recovers the face direction of a single-face slab', () => {
+    // One visible face of a large object: a thin, long slab.
+    const pts = [];
+    for (let i = 0; i < 80; ++i) {
+      pts.push(at((i / 79 - 0.5) * 1.5, ((i % 3) - 1) * 0.01, deg(30)));
+    }
+    const r = minAreaRectXZ(pts)!;
+    expect(Math.abs(yawDelta90(r.angle, deg(30)))).toBeLessThan(deg(2));
+    expect(r.supportRatio).toBeGreaterThan(0.8);
+  });
+
+  /**
+   * The case that justifies preferring the rectangle fit over PCA. Two visible
+   * faces of a piece of furniture form an L; PCA's principal axis bisects the
+   * two legs and lands ~45 degrees off, while the minimising rectangle locks
+   * onto the faces.
+   */
+  it('beats PCA on an L-shaped two-face scan', () => {
+    const a = deg(30);
+    const pts = [];
+    for (let i = 0; i < 60; ++i) {
+      pts.push(at((i / 59) * 1.2, 0, a)); // along u
+      pts.push(at(0, (i / 59) * 1.2, a)); // along v
+    }
+    const rectFit = minAreaRectXZ(pts)!;
+    expect(Math.abs(yawDelta90(rectFit.angle, a))).toBeLessThan(deg(3));
+
+    let cx = 0,
+      cz = 0;
+    for (const p of pts) {
+      cx += p.x;
+      cz += p.z;
+    }
+    const pca = pcaYawXZ(pts, cx / pts.length, cz / pts.length)!;
+    // PCA lands near the bisector, i.e. ~45 degrees off in the mod-90 domain.
+    expect(Math.abs(yawDelta90(pca.angle, a))).toBeGreaterThan(deg(30));
+  });
+
+  it('resists a few far outliers thanks to trimming upstream', () => {
+    // Untrimmed, the hull is dragged by extremes; documents why ObbFitting
+    // trims to the 2/98 percentile before calling this.
+    const pts = rect(2, 1, deg(30));
+    const clean = minAreaRectXZ(pts)!;
+    pts.push({x: 8, z: -6}, {x: -7, z: 9});
+    const dirty = minAreaRectXZ(pts)!;
+    expect(Math.abs(yawDelta90(clean.angle, deg(30)))).toBeLessThan(deg(2));
+    expect(dirty.area).toBeGreaterThan(clean.area * 5);
+  });
+
+  it('returns null for a degenerate footprint', () => {
+    expect(minAreaRectXZ([{x: 0, z: 0}])).toBeNull();
+  });
+});
+
+describe('pcaYawXZ / pcaYawConfidence', () => {
+  it('is confident about a thin slab', () => {
+    const pts = [];
+    for (let i = 0; i < 200; ++i) {
+      pts.push(at((i / 199 - 0.5) * 1.5, ((i % 3) - 1) * 0.005, deg(20)));
+    }
+    const s = pcaYawXZ(pts, 0, 0)!;
+    expect(Math.abs(yawDelta90(s.angle, deg(20)))).toBeLessThan(deg(2));
+    expect(s.anisotropy).toBeGreaterThan(0.9);
+    expect(pcaYawConfidence(s)).toBeGreaterThan(0.35);
+  });
+
+  it('is not confident about a round blob', () => {
+    const pts = [];
+    for (let i = 0; i < 300; ++i) {
+      const t = (i / 300) * Math.PI * 2;
+      pts.push({x: Math.cos(t) * 0.5, z: Math.sin(t) * 0.5});
+    }
+    const s = pcaYawXZ(pts, 0, 0)!;
+    expect(s.anisotropy).toBeLessThan(0.1);
+    expect(pcaYawConfidence(s)).toBeLessThan(0.35);
+  });
+
+  it('rejects small samples outright', () => {
+    const pts = [];
+    for (let i = 0; i < 10; ++i) pts.push(at(i * 0.1, 0, 0));
+    const s = pcaYawXZ(pts, 0.45, 0)!;
+    expect(pcaYawConfidence(s)).toBe(0);
+  });
+});
+
+describe('ransacVerticalPlane', () => {
+  it('finds a vertical wall among floor clutter', () => {
+    const pts: THREE.Vector3[] = [];
+    // A vertical plane at 25 degrees.
+    for (let i = 0; i < 60; ++i) {
+      const p = at((i / 59 - 0.5) * 2, 0, deg(25));
+      pts.push(new THREE.Vector3(p.x, (i % 6) * 0.2, p.z));
+    }
+    // Plus horizontal floor points, which a general plane fit might prefer.
+    for (let i = 0; i < 40; ++i) {
+      pts.push(new THREE.Vector3((i % 8) * 0.2, 0, Math.floor(i / 8) * 0.2));
+    }
+    const fit = ransacVerticalPlane(pts, {rng: seededRng(11)})!;
+    expect(fit).not.toBeNull();
+    expect(Math.abs(fit.normal.y)).toBeLessThan(1e-9);
+    // The wall runs along 25 degrees, so its normal is 90 degrees off — the
+    // same class in the mod-90 domain.
+    const normalYaw = Math.atan2(fit.normal.x, fit.normal.z);
+    expect(Math.abs(yawDelta90(normalYaw, deg(25)))).toBeLessThan(deg(4));
+  });
+
+  it('is reproducible with a seeded rng', () => {
+    const pts: THREE.Vector3[] = [];
+    for (let i = 0; i < 50; ++i) {
+      pts.push(new THREE.Vector3((i % 10) * 0.1, Math.floor(i / 10) * 0.3, 1));
+    }
+    const a = ransacVerticalPlane(pts, {rng: seededRng(5)})!;
+    const b = ransacVerticalPlane(pts, {rng: seededRng(5)})!;
+    expect(a.normal.x).toBeCloseTo(b.normal.x, 12);
+    expect(a.inlierCount).toBe(b.inlierCount);
+  });
+
+  it('returns null without enough points', () => {
+    expect(ransacVerticalPlane([new THREE.Vector3()])).toBeNull();
+  });
+});
+
+describe('combineYawCandidates', () => {
+  it('treats candidates 90 degrees apart as agreeing', () => {
+    const r = combineYawCandidates([
+      {angle: deg(0), weight: 1, method: 'a'},
+      {angle: deg(90), weight: 1, method: 'b'},
+    ])!;
+    expect(r.agreementR).toBeCloseTo(1, 6);
+    expect(Math.abs(yawDelta90(r.angle, 0))).toBeLessThan(1e-6);
+  });
+
+  it('cancels for candidates 45 degrees apart', () => {
+    const r = combineYawCandidates([
+      {angle: deg(0), weight: 1, method: 'a'},
+      {angle: deg(45), weight: 1, method: 'b'},
+    ])!;
+    expect(r.agreementR).toBeLessThan(0.05);
+  });
+
+  it('ignores zero-weight candidates and reports the top method', () => {
+    const r = combineYawCandidates([
+      {angle: deg(80), weight: 0, method: 'ignored'},
+      {angle: deg(10), weight: 0.9, method: 'winner'},
+      {angle: deg(12), weight: 0.2, method: 'other'},
+    ])!;
+    expect(r.method).toBe('winner');
+    expect(Math.abs(yawDelta90(r.angle, deg(10)))).toBeLessThan(deg(2));
+  });
+
+  it('returns null when nothing carries weight', () => {
+    expect(
+      combineYawCandidates([{angle: 0, weight: 0, method: 'a'}])
+    ).toBeNull();
+  });
+});

--- a/src/addons/objects3d/geometry/YawEstimation.ts
+++ b/src/addons/objects3d/geometry/YawEstimation.ts
@@ -1,0 +1,505 @@
+/**
+ * Yaw-angle utilities for oriented bounding boxes.
+ *
+ * All functions are pure (no `xb.core` dependencies) and are safe to
+ * unit-test without a running XR session.
+ *
+ * ## Conventions
+ *
+ * An {@link InternalObb}'s `angle` is a yaw about world +Y, and the renderer
+ * applies it as `group.rotation.y = angle` (see `visuals/BoxGroup.ts`'s
+ * `buildBoxGroup`). A three.js Y-rotation by `a` maps local
+ * +X to world `(cos a, 0, -sin a)`, so the box's local u-axis is
+ * `(cos a, -sin a)` and its v-axis is `(sin a, cos a)` in the world XZ plane.
+ * {@link worldToLocalXZ} and {@link localToWorldXZ} are the single definition
+ * of that convention; every fitter should go through them rather than inlining
+ * the trigonometry, which is how the two halves of the codebase drifted apart
+ * in the first place.
+ *
+ * ## The mod-90° quotient
+ *
+ * A box's yaw is only defined modulo 90°: rotating by 90° and swapping
+ * `size.x` with `size.z` describes an identical box. Comparisons, averaging and
+ * snapping therefore operate on `4θ` mapped onto the unit circle, where two
+ * angles 90° apart coincide (they are the same box) and two 45° apart are
+ * antipodal (maximally disagreeing). {@link yawDelta90} and
+ * {@link canonicalizeYawObb} implement that quotient.
+ */
+
+import * as THREE from 'three';
+
+import type {InternalObb} from './ObbFitting';
+
+const TWO_PI = Math.PI * 2;
+const HALF_PI = Math.PI / 2;
+const QUARTER_PI = Math.PI / 4;
+
+/** Wrap an angle into `(-π, π]`. */
+export function wrapPi(a: number): number {
+  const m = (((a + Math.PI) % TWO_PI) + TWO_PI) % TWO_PI;
+  return m - Math.PI;
+}
+
+/**
+ * Wrap an angle into `[-π/4, π/4)` — the canonical representative of its
+ * mod-90° equivalence class.
+ */
+export function wrapQuarterPi(a: number): number {
+  const m = (((a + QUARTER_PI) % HALF_PI) + HALF_PI) % HALF_PI;
+  return m - QUARTER_PI;
+}
+
+/**
+ * Signed difference between two yaws in the mod-90° quotient, in
+ * `[-π/4, π/4)`. Yaws 90° apart return ~0 because they describe the same box.
+ */
+export function yawDelta90(a: number, b: number): number {
+  return wrapQuarterPi(a - b);
+}
+
+/**
+ * Project a world-space XZ offset into a box's local (u, v) frame.
+ * The inverse of {@link localToWorldXZ}.
+ *
+ * @param dx - World X offset from the box centre.
+ * @param dz - World Z offset from the box centre.
+ * @param a - Box yaw in radians.
+ */
+export function worldToLocalXZ(
+  dx: number,
+  dz: number,
+  a: number
+): {u: number; v: number} {
+  const cs = Math.cos(a);
+  const sn = Math.sin(a);
+  return {u: dx * cs - dz * sn, v: dx * sn + dz * cs};
+}
+
+/**
+ * Map a box-local (u, v) offset back into world XZ.
+ * The inverse of {@link worldToLocalXZ}.
+ *
+ * @param u - Offset along the box's local u (width) axis.
+ * @param v - Offset along the box's local v (depth) axis.
+ * @param a - Box yaw in radians.
+ */
+export function localToWorldXZ(
+  u: number,
+  v: number,
+  a: number
+): {x: number; z: number} {
+  const cs = Math.cos(a);
+  const sn = Math.sin(a);
+  return {x: u * cs + v * sn, z: -u * sn + v * cs};
+}
+
+/**
+ * Rewrite an OBB so its yaw is the canonical representative of its mod-90°
+ * class, in `[-π/4, π/4)`. When the rewrite rotates by ±90° the u and v
+ * extents are swapped, so the box describes exactly the same volume.
+ *
+ * Do not apply this to boxes whose `angle` encodes a surface *normal*
+ * direction rather than a box orientation (the `flat` category), because those
+ * need their full ±180° range to stay facing the camera.
+ *
+ * @param obb - Box to canonicalize. Not mutated.
+ * @returns An equivalent box with a canonical yaw.
+ */
+export function canonicalizeYawObb(obb: InternalObb): InternalObb {
+  const angle = wrapQuarterPi(obb.angle);
+  // A rotation by an odd multiple of 90° exchanges the u and v axes.
+  const quarterTurns = Math.round((obb.angle - angle) / HALF_PI);
+  const swapped = Math.abs(quarterTurns % 2) === 1;
+  if (!swapped && angle === obb.angle) return obb;
+  return {
+    ...obb,
+    angle,
+    size: swapped
+      ? new THREE.Vector3(obb.size.z, obb.size.y, obb.size.x)
+      : obb.size.clone(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Convex hull + minimum-area rectangle
+// ---------------------------------------------------------------------------
+
+/** A 2-D point in the world XZ plane. */
+export interface PointXZ {
+  x: number;
+  z: number;
+}
+
+/**
+ * Convex hull of a set of XZ points, via Andrew's monotone chain.
+ * Returns the hull in counter-clockwise order without repeating the first
+ * point. Inputs of fewer than three points are returned as-is.
+ */
+export function convexHullXZ(points: readonly PointXZ[]): PointXZ[] {
+  if (points.length < 3) return points.map((p) => ({x: p.x, z: p.z}));
+  const sorted = points
+    .map((p) => ({x: p.x, z: p.z}))
+    .sort((a, b) => (a.x === b.x ? a.z - b.z : a.x - b.x));
+  // Cross product of OA x OB; >0 means a counter-clockwise turn.
+  const cross = (o: PointXZ, a: PointXZ, b: PointXZ) =>
+    (a.x - o.x) * (b.z - o.z) - (a.z - o.z) * (b.x - o.x);
+
+  const build = (src: PointXZ[]): PointXZ[] => {
+    const out: PointXZ[] = [];
+    for (const p of src) {
+      while (
+        out.length >= 2 &&
+        cross(out[out.length - 2], out[out.length - 1], p) <= 0
+      ) {
+        out.pop();
+      }
+      out.push(p);
+    }
+    out.pop();
+    return out;
+  };
+
+  const lower = build(sorted);
+  const upper = build(sorted.slice().reverse());
+  const hull = lower.concat(upper);
+  return hull.length >= 3 ? hull : sorted;
+}
+
+/** Result of {@link minAreaRectXZ}. */
+export interface MinAreaRect {
+  /** Canonical yaw in `[-π/4, π/4)`, in the render convention. */
+  angle: number;
+  /** Extent along the box's local u axis. */
+  width: number;
+  /** Extent along the box's local v axis. */
+  depth: number;
+  /** Area of the minimising rectangle, in m². */
+  area: number;
+  /** Number of hull vertices the fit was computed from. */
+  hullCount: number;
+  /**
+   * How strongly the hull actually supports these axes: the fraction of hull
+   * perimeter lying within 10° (mod 90°) of a rectangle edge. Near 1 for a
+   * genuinely box-like footprint, low for a rounded or blobby one.
+   */
+  supportRatio: number;
+}
+
+/**
+ * Minimum-area enclosing rectangle of the XZ footprint, by rotating calipers
+ * over the convex hull edges.
+ *
+ * Preferred over PCA for yaw because of the common partial-scan geometry: when
+ * two faces of a piece of furniture are visible the samples form an L, and
+ * PCA's principal axis bisects the two legs — up to 45° wrong — whereas the
+ * minimising rectangle locks onto the faces. For a single visible face the
+ * samples form a slab and the rectangle hugs it, recovering the face
+ * direction.
+ *
+ * Use the returned `angle` only; `width`/`depth` are driven by extreme points
+ * and are less robust than percentile-clipped extents.
+ *
+ * @param points - World-space samples (at least three distinct XZ positions).
+ * @returns The minimising rectangle, or `null` when the footprint is
+ *   degenerate (collinear or a single point).
+ */
+export function minAreaRectXZ(points: readonly PointXZ[]): MinAreaRect | null {
+  const hull = convexHullXZ(points);
+  if (hull.length < 3) return null;
+
+  let best: MinAreaRect | null = null;
+  for (let i = 0; i < hull.length; ++i) {
+    const a = hull[i];
+    const b = hull[(i + 1) % hull.length];
+    const ex = b.x - a.x;
+    const ez = b.z - a.z;
+    const len = Math.hypot(ex, ez);
+    if (len < 1e-9) continue;
+    // Yaw whose local u axis (cos, -sin) lies along this hull edge.
+    const angle = Math.atan2(-ez / len, ex / len);
+    let uMin = Infinity,
+      uMax = -Infinity,
+      vMin = Infinity,
+      vMax = -Infinity;
+    for (const p of hull) {
+      const {u, v} = worldToLocalXZ(p.x, p.z, angle);
+      if (u < uMin) uMin = u;
+      if (u > uMax) uMax = u;
+      if (v < vMin) vMin = v;
+      if (v > vMax) vMax = v;
+    }
+    const width = uMax - uMin;
+    const depth = vMax - vMin;
+    const area = width * depth;
+    if (!best || area < best.area) {
+      best = {
+        angle,
+        width,
+        depth,
+        area,
+        hullCount: hull.length,
+        supportRatio: 0,
+      };
+    }
+  }
+  if (!best) return null;
+
+  // How much of the hull perimeter runs parallel to the chosen axes.
+  let aligned = 0;
+  let perimeter = 0;
+  for (let i = 0; i < hull.length; ++i) {
+    const a = hull[i];
+    const b = hull[(i + 1) % hull.length];
+    const len = Math.hypot(b.x - a.x, b.z - a.z);
+    if (len < 1e-9) continue;
+    perimeter += len;
+    const edgeAngle = Math.atan2(-(b.z - a.z) / len, (b.x - a.x) / len);
+    if (Math.abs(yawDelta90(edgeAngle, best.angle)) < (10 * Math.PI) / 180) {
+      aligned += len;
+    }
+  }
+  const supportRatio = perimeter > 0 ? aligned / perimeter : 0;
+
+  const canonical = wrapQuarterPi(best.angle);
+  const swapped =
+    Math.abs(Math.round((best.angle - canonical) / HALF_PI) % 2) === 1;
+  return {
+    ...best,
+    angle: canonical,
+    width: swapped ? best.depth : best.width,
+    depth: swapped ? best.width : best.depth,
+    supportRatio,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PCA + confidence
+// ---------------------------------------------------------------------------
+
+/** Second-moment summary of an XZ point set. */
+export interface ScatterXZ {
+  /** Yaw of the major axis, in the render convention. */
+  angle: number;
+  /** Larger eigenvalue of the normalised scatter matrix. */
+  lambda1: number;
+  /** Smaller eigenvalue. */
+  lambda2: number;
+  /** `(λ1 − λ2) / (λ1 + λ2)`, in `[0, 1]`. Zero for an isotropic blob. */
+  anisotropy: number;
+  /** Asymptotic standard error of {@link angle}, in radians. */
+  sigmaThetaRad: number;
+  /** Number of points. */
+  count: number;
+}
+
+/**
+ * Principal-axis yaw of an XZ point set, with an uncertainty estimate.
+ *
+ * The reported `sigmaThetaRad` is the asymptotic standard error of the
+ * principal-axis angle, `sqrt(λ1·λ2 / (N·(λ1−λ2)²))`. This is the right
+ * quantity to gate on because it correctly reports high confidence for a thin
+ * slab (λ2 → 0) and low confidence for a round blob (λ1 ≈ λ2), matching the
+ * physical intuition about which footprints determine an orientation.
+ *
+ * @param points - World-space samples.
+ * @param cx - Centre X to measure offsets from.
+ * @param cz - Centre Z to measure offsets from.
+ * @returns Scatter summary, or `null` for fewer than three points.
+ */
+export function pcaYawXZ(
+  points: readonly PointXZ[],
+  cx: number,
+  cz: number
+): ScatterXZ | null {
+  const n = points.length;
+  if (n < 3) return null;
+  let Sxx = 0,
+    Sxz = 0,
+    Szz = 0;
+  for (const p of points) {
+    const dx = p.x - cx;
+    const dz = p.z - cz;
+    Sxx += dx * dx;
+    Sxz += dx * dz;
+    Szz += dz * dz;
+  }
+  Sxx /= n;
+  Sxz /= n;
+  Szz /= n;
+  const mean = (Sxx + Szz) / 2;
+  const disc = Math.hypot((Sxx - Szz) / 2, Sxz);
+  const lambda1 = mean + disc;
+  const lambda2 = Math.max(0, mean - disc);
+  if (lambda1 <= 1e-12) return null;
+  // PCA gives the major axis as (cos φ, sin φ); a box's u axis is
+  // (cos a, -sin a), so a = -φ.
+  const angle = wrapQuarterPi(-0.5 * Math.atan2(2 * Sxz, Sxx - Szz));
+  const gap = lambda1 - lambda2;
+  const sigmaThetaRad =
+    gap > 1e-12 ? Math.sqrt((lambda1 * lambda2) / (n * gap * gap)) : Infinity;
+  return {
+    angle,
+    lambda1,
+    lambda2,
+    anisotropy: gap / (lambda1 + lambda2),
+    sigmaThetaRad,
+    count: n,
+  };
+}
+
+/** Reference angular error at which PCA confidence falls to 1/e. */
+const SIGMA_REF_RAD = (6 * Math.PI) / 180;
+
+/**
+ * Map a {@link ScatterXZ} to a 0..1 confidence. Returns 0 when the point count
+ * or anisotropy is too low for the angle to mean anything at all.
+ */
+export function pcaYawConfidence(s: ScatterXZ): number {
+  if (s.count < 20 || s.anisotropy < 0.15) return 0;
+  if (!Number.isFinite(s.sigmaThetaRad)) return 0;
+  return Math.exp(-s.sigmaThetaRad / SIGMA_REF_RAD);
+}
+
+// ---------------------------------------------------------------------------
+// Vertical-plane RANSAC
+// ---------------------------------------------------------------------------
+
+/** Result of {@link ransacVerticalPlane}. */
+export interface VerticalPlaneFit {
+  /** Horizontal unit normal of the fitted plane. */
+  normal: THREE.Vector3;
+  /** A point on the plane (centroid of the inliers). */
+  point: THREE.Vector3;
+  /** Fraction of input points within `eps` of the plane. */
+  inlierRatio: number;
+  /** Number of inliers. */
+  inlierCount: number;
+}
+
+/**
+ * RANSAC fit of a *vertical* plane, sampling two points and taking
+ * `normalize(cross(p2 − p1, +Y))` as the normal.
+ *
+ * Constructing the normal this way guarantees verticality, needs far fewer
+ * iterations than filtering general 3-point planes, and has no collinearity
+ * degeneracy. Filtering the output of a general plane fit would be much worse
+ * here: on a sofa the largest plane is often the horizontal seat, so most
+ * iterations would be discarded.
+ *
+ * @param points - World-space samples.
+ * @param options - Iteration count, inlier threshold, and random source.
+ * @returns The best vertical plane, or `null` if none had enough support.
+ */
+export function ransacVerticalPlane(
+  points: readonly THREE.Vector3[],
+  {
+    iters = 60,
+    eps = 0.02,
+    rng = Math.random,
+  }: {iters?: number; eps?: number; rng?: () => number} = {}
+): VerticalPlaneFit | null {
+  if (points.length < 6) return null;
+  let bestNormal: THREE.Vector3 | null = null;
+  let bestCount = 0;
+  let bestOffset = 0;
+  for (let it = 0; it < iters; ++it) {
+    const a = points[(rng() * points.length) | 0];
+    const b = points[(rng() * points.length) | 0];
+    const dx = b.x - a.x;
+    const dz = b.z - a.z;
+    const len = Math.hypot(dx, dz);
+    if (len < 1e-4) continue;
+    // cross(edge, +Y) for a horizontal edge, normalised.
+    const nx = -dz / len;
+    const nz = dx / len;
+    const offset = nx * a.x + nz * a.z;
+    let count = 0;
+    for (const p of points) {
+      if (Math.abs(nx * p.x + nz * p.z - offset) < eps) count++;
+    }
+    if (count > bestCount) {
+      bestCount = count;
+      bestNormal = new THREE.Vector3(nx, 0, nz);
+      bestOffset = offset;
+    }
+  }
+  if (!bestNormal || bestCount < 6) return null;
+  const centroid = new THREE.Vector3();
+  let n = 0;
+  for (const p of points) {
+    if (Math.abs(bestNormal.x * p.x + bestNormal.z * p.z - bestOffset) < eps) {
+      centroid.add(p);
+      n++;
+    }
+  }
+  if (n > 0) centroid.multiplyScalar(1 / n);
+  return {
+    normal: bestNormal,
+    point: centroid,
+    inlierRatio: bestCount / points.length,
+    inlierCount: bestCount,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Candidate combination
+// ---------------------------------------------------------------------------
+
+/** One estimator's opinion about an object's yaw. */
+export interface YawCandidate {
+  angle: number;
+  /** Relative trust in this candidate; candidates with weight ≤ 0 are ignored. */
+  weight: number;
+  method: string;
+}
+
+/** Combined yaw estimate produced by {@link combineYawCandidates}. */
+export interface YawEstimate {
+  /** Canonical yaw in `[-π/4, π/4)`. */
+  angle: number;
+  /** 0..1 overall confidence, folding in how well the candidates agreed. */
+  confidence: number;
+  /** Method name of the highest-weighted contributing candidate. */
+  method: string;
+  /** Mean resultant length of the candidates in the 4θ domain, 0..1. */
+  agreementR: number;
+}
+
+/**
+ * Combine yaw candidates by averaging them in the `4θ` domain, so that
+ * candidates 90° apart reinforce (they describe the same box) while candidates
+ * 45° apart cancel to `agreementR ≈ 0` — the correct signal that the estimators
+ * fundamentally disagree.
+ *
+ * @param candidates - Per-estimator opinions.
+ * @returns Combined estimate, or `null` when no candidate carried any weight.
+ */
+export function combineYawCandidates(
+  candidates: readonly YawCandidate[]
+): YawEstimate | null {
+  let C = 0,
+    S = 0,
+    W = 0;
+  let topWeight = -Infinity;
+  let topMethod = 'none';
+  for (const c of candidates) {
+    if (!(c.weight > 0) || !Number.isFinite(c.angle)) continue;
+    C += c.weight * Math.cos(4 * c.angle);
+    S += c.weight * Math.sin(4 * c.angle);
+    W += c.weight;
+    if (c.weight > topWeight) {
+      topWeight = c.weight;
+      topMethod = c.method;
+    }
+  }
+  if (W <= 0) return null;
+  const agreementR = Math.min(1, Math.hypot(C, S) / W);
+  return {
+    angle: wrapQuarterPi(0.25 * Math.atan2(S, C)),
+    // W is a sum of weight x per-estimator confidence, so W / count is the
+    // weighted mean confidence; scaling by agreement penalises disagreement.
+    confidence: agreementR * Math.min(1, W / Math.max(1, candidates.length)),
+    method: topMethod,
+    agreementR,
+  };
+}

--- a/src/addons/objects3d/index.ts
+++ b/src/addons/objects3d/index.ts
@@ -7,10 +7,53 @@
 
 export {Detected3DObject} from './Detected3DObject';
 export {Object3DDetector} from './Object3DDetector';
-export type {Object3DDetectorOptions} from './Object3DDetector';
+export type {
+  Object3DDetectorOptions,
+  Object3DDetectorDiagnostics,
+} from './Object3DDetector';
 
 // Pure helpers worth reusing from application code.
-export {uvToNdc} from './geometry/DepthSampling';
+export {uvToNdc, sampleDepthInMask} from './geometry/DepthSampling';
+export {buildFrozenCamera} from './geometry/FrozenCamera';
+export type {FrozenCameraMatrices} from './geometry/FrozenCamera';
+export {PoseRing} from './geometry/PoseRing';
+
+// Yaw estimation and the room ("Manhattan") frame.
+export {
+  canonicalizeYawObb,
+  combineYawCandidates,
+  convexHullXZ,
+  localToWorldXZ,
+  minAreaRectXZ,
+  pcaYawConfidence,
+  pcaYawXZ,
+  ransacVerticalPlane,
+  worldToLocalXZ,
+  wrapPi,
+  wrapQuarterPi,
+  yawDelta90,
+} from './geometry/YawEstimation';
+export type {
+  MinAreaRect,
+  PointXZ,
+  ScatterXZ,
+  VerticalPlaneFit,
+  YawCandidate,
+  YawEstimate,
+} from './geometry/YawEstimation';
+export {
+  estimateRoomYawFromMesh,
+  RoomFrameAccumulator,
+  yawRelativeToRoom,
+} from './geometry/RoomFrame';
+export type {RoomFrame, RoomFrameOptions} from './geometry/RoomFrame';
+export {
+  buildYawAlignedObb,
+  estimateObjectYaw,
+  resolveYaw,
+} from './geometry/ObbFitting';
+export type {OrientationMode, OrientationOptions} from './geometry/ObbFitting';
+export {fitYawOBB} from './geometry/ObbFitting';
 export {box2dIoU, snapBoxToFloor, unionDetections} from './geometry/Fusion';
 export type {FusionRecord} from './geometry/Fusion';
 export type {InternalObb, ObbFitOptions} from './geometry/ObbFitting';

--- a/src/video/VideoStream.ts
+++ b/src/video/VideoStream.ts
@@ -64,6 +64,27 @@ export type VideoStreamOptions = {
   willCaptureFrequently?: boolean;
 };
 
+/**
+ * Subset of the WICG `VideoFrameCallbackMetadata` fields we rely on. For
+ * camera-backed streams Chrome reports `captureTime` (when the frame left the
+ * camera pipeline) in the `performance.now()` timebase.
+ */
+export type VideoFrameMetadata = {
+  presentationTime: number;
+  expectedDisplayTime: number;
+  mediaTime: number;
+  presentedFrames: number;
+  captureTime?: number;
+  receiveTime?: number;
+};
+
+type VideoElementWithFrameCallback = HTMLVideoElement & {
+  requestVideoFrameCallback?: (
+    callback: (now: number, metadata: VideoFrameMetadata) => void
+  ) => number;
+  cancelVideoFrameCallback?: (handle: number) => void;
+};
+
 function blobToBase64(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -177,6 +198,41 @@ export class VideoStream<
         reject(error);
       }
     }
+  }
+
+  /**
+   * Waits for the next new video frame before returning, so a subsequent
+   * {@link getSnapshot} reads fresh pixels instead of whatever (possibly
+   * stale) frame the `<video>` element currently holds. Hidden or
+   * non-composited video elements — the normal situation inside an immersive
+   * XR session — can be throttled by the browser, in which case the held
+   * frame may be arbitrarily old.
+   *
+   * Resolves with the frame's metadata (whose `captureTime`, when present,
+   * dates the pixels in the `performance.now()` timebase), or `null` when the
+   * signal is unavailable (`requestVideoFrameCallback` unsupported, no active
+   * media stream) or no frame arrived within `timeoutMs`.
+   */
+  waitForFreshFrame(timeoutMs = 400): Promise<VideoFrameMetadata | null> {
+    const video = this.video_ as VideoElementWithFrameCallback;
+    if (!this.loaded || !video.requestVideoFrameCallback || !video.srcObject) {
+      return Promise.resolve(null);
+    }
+    return new Promise((resolve) => {
+      let done = false;
+      const handle = video.requestVideoFrameCallback!((_now, metadata) => {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        resolve(metadata);
+      });
+      const timer = setTimeout(() => {
+        if (done) return;
+        done = true;
+        video.cancelVideoFrameCallback?.(handle);
+        resolve(null);
+      }, timeoutMs);
+    });
   }
 
   /**


### PR DESCRIPTION
# Object3d device fixes (on top of PR 417)

## Description

Continues #417, which extracted the objects_3d pipeline into the objects3d addon. The extraction was right, but the pipeline didn't work on a headset: boxes were the wrong size, in the wrong place, all facing the same direction.

Root cause — the wrong camera. Rays were cast through a clone of the XR render camera (the ~90° union frustum between the eyes) while the pixels came from the physical passthrough camera (~48° FOV, near the right eye). Different intrinsics, different pose, so every ray left at the wrong angle.

- Build the frozen camera from the SDK's device-camera model, falling back to the old clone only when unavailable — simulator behaviour is unchanged.
- Wait for a fresh video frame and pair it with the pose at its captureTime; captures were pairing seconds-old pixels with the current head pose.
- Enable matchDepthView (the demo overrode the SDK default off), so the depth mesh every ray lands on is no longer rotated relative to the view.
- Drop the unconditional 90° yaw snap — no confidence gate, up to 45° error.
- Snap instead to the room's wall direction, estimated from depth-mesh vertical normals. The old grid was the session origin, i.e. wherever the user happened to face at startup.
- Estimate yaw from a minimum-area rectangle over the convex hull, gated on scatter confidence; PCA alone lands 45° off when two faces are visible.
- Fix a sign bug the snapping hid: extents measured along (cos a, +sin a), drawn along (cos a, −sin a).
- Replace the 2,452-line inline demo copy with the addon page (929 lines);

Orientation is selectable via {mode: 'roomFrame' | 'free' | 'cardinal'}, defaulting to roomFrame, which degrades to today's output if estimation fails.

## Type of Change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Checklist

- [x] **Tested in simulator & device**: Verified functionality in desktop simulator and/or physical hardware (where applicable).
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.

## Disclaimer:

Real-world performers suffers from small objects, sensor accuracy, and object cluttering, so it is not as perfect as in the simulator.

