### PR TITLE
Disable matchDepthView by default and update occlusion

### DIFF
--- a/src/depth/Depth.ts
+++ b/src/depth/Depth.ts
@@ -437,17 +437,9 @@ export class Depth {
         this.rawValueToMeters,
         0,
         (this.gpuDepthData[0] as unknown as {depthNear: number} | undefined)
-          ?.depthNear
-      );
-    }
-    const rightDepthTexture = this.getTexture(1);
-    if (rightDepthTexture) {
-      this.occlusionPass!.setDepthTexture(
-        rightDepthTexture,
-        this.rawValueToMeters,
-        1,
-        (this.gpuDepthData[1] as unknown as {depthNear: number} | undefined)
-          ?.depthNear
+          ?.depthNear,
+        this.depthViewMatrices[0],
+        this.depthProjectionMatrices[0]
       );
     }
     const xrIsPresenting = this.renderer.xr.isPresenting;

--- a/src/depth/DepthOptions.ts
+++ b/src/depth/DepthOptions.ts
@@ -39,7 +39,7 @@ export class DepthOptions {
   usagePreference: XRDepthUsage[] = [];
   dataFormatPreference: XRDepthDataFormat[] = ['float32', 'luminance-alpha'];
   depthTypeRequest: XRDepthType[] = ['raw'];
-  matchDepthView = true;
+  matchDepthView = false;
 
   constructor(options?: DeepReadonly<DeepPartial<DepthOptions>>) {
     deepMerge(this, options);

--- a/src/depth/occlusion/OcclusionMapMeshMaterial.ts
+++ b/src/depth/occlusion/OcclusionMapMeshMaterial.ts
@@ -14,6 +14,8 @@ export class OcclusionMapMeshMaterial extends THREE.MeshBasicMaterial {
       cameraFar: {value: camera.far},
       cameraNear: {value: camera.near},
       uFloatDepth: {value: useFloatDepth},
+      uDepthViewMatrix: {value: camera.matrixWorldInverse.clone()},
+      uDepthProjectionMatrix: {value: camera.projectionMatrix.clone()},
       // Used for interpreting Quest 3 depth.
       uDepthNear: {value: 0},
     };
@@ -24,6 +26,8 @@ export class OcclusionMapMeshMaterial extends THREE.MeshBasicMaterial {
         .replace(
           '#include <common>',
           [
+            'uniform mat4 uDepthProjectionMatrix;',
+            'uniform mat4 uDepthViewMatrix;',
             'varying vec2 vTexCoord;',
             'varying float vVirtualDepth;',
             '#include <common>',
@@ -33,10 +37,12 @@ export class OcclusionMapMeshMaterial extends THREE.MeshBasicMaterial {
           '#include <fog_vertex>',
           [
             '#include <fog_vertex>',
-            'vec4 view_position = modelViewMatrix * vec4( position, 1.0 );',
-            'vVirtualDepth = -view_position.z;',
-            'gl_Position = gl_Position / gl_Position.w;',
-            'vTexCoord = 0.5 + 0.5 * gl_Position.xy;',
+            'vec4 world_position = modelMatrix * vec4( position, 1.0 );',
+            'vec4 depth_view_position = uDepthViewMatrix * world_position;',
+            'vVirtualDepth = -depth_view_position.z;',
+            'vec4 depth_clip_position = uDepthProjectionMatrix * depth_view_position;',
+            'vec2 depth_ndc = depth_clip_position.xy / max(0.00001, depth_clip_position.w);',
+            'vTexCoord = 0.5 + 0.5 * depth_ndc;',
           ].join('\n')
         );
       shader.fragmentShader = shader.fragmentShader
@@ -86,7 +92,9 @@ export class OcclusionMapMeshMaterial extends THREE.MeshBasicMaterial {
             'vec4 texCoord = vec4(vTexCoord, 0, 1);',
             'vec2 uv = vec2(texCoord.x, uIsTextureArray?texCoord.y:(1.0 - texCoord.y));',
             'highp float real_depth = uIsTextureArray ? DepthArrayGetMeters(uDepthTextureArray, uv) : DepthGetMeters(uDepthTexture, uv);',
-            'gl_FragColor = vec4(step(vVirtualDepth, real_depth), 1.0, 0.0, 1.0);',
+            'bool outOfBounds = uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0 || vVirtualDepth <= 0.0;',
+            'float isNotOccluded = outOfBounds ? 1.0 : step(vVirtualDepth, real_depth);',
+            'gl_FragColor = vec4(isNotOccluded, 1.0, 0.0, 1.0);',
           ].join('\n')
         );
     };

--- a/src/depth/occlusion/OcclusionPass.test.ts
+++ b/src/depth/occlusion/OcclusionPass.test.ts
@@ -1,0 +1,157 @@
+import {describe, it, expect} from 'vitest';
+import * as THREE from 'three';
+
+import {OcclusionMapMeshMaterial} from './OcclusionMapMeshMaterial';
+import {OcclusionPass} from './OcclusionPass';
+
+describe('OcclusionMapMeshMaterial', () => {
+  it('declares uDepthViewMatrix and uDepthProjectionMatrix in uniforms and initializes with camera matrices', () => {
+    const camera = new THREE.PerspectiveCamera();
+    camera.position.set(1, 2, 3);
+    camera.updateMatrixWorld(true);
+
+    const material = new OcclusionMapMeshMaterial(camera, true);
+    expect(material.uniforms.uDepthViewMatrix).toBeDefined();
+    expect(material.uniforms.uDepthProjectionMatrix).toBeDefined();
+    expect(
+      material.uniforms.uDepthViewMatrix.value.equals(camera.matrixWorldInverse)
+    ).toBe(true);
+    expect(
+      material.uniforms.uDepthProjectionMatrix.value.equals(
+        camera.projectionMatrix
+      )
+    ).toBe(true);
+  });
+
+  it('transforms vertex position and computes vTexCoord using depth camera matrices in vertexShader onBeforeCompile', () => {
+    const camera = new THREE.PerspectiveCamera();
+    const material = new OcclusionMapMeshMaterial(camera, true);
+
+    const fakeShader = {
+      uniforms: {} as {[uniform: string]: THREE.IUniform},
+      vertexShader: '#include <common>\n#include <fog_vertex>',
+      fragmentShader: 'uniform vec3 diffuse;',
+    };
+
+    material.onBeforeCompile(fakeShader as unknown as THREE.ShaderMaterial);
+    expect(fakeShader.uniforms.uDepthViewMatrix).toBeDefined();
+    expect(fakeShader.uniforms.uDepthProjectionMatrix).toBeDefined();
+    expect(fakeShader.vertexShader).toContain('uniform mat4 uDepthViewMatrix;');
+    expect(fakeShader.vertexShader).toContain(
+      'uniform mat4 uDepthProjectionMatrix;'
+    );
+    expect(fakeShader.vertexShader).toContain(
+      'vec4 world_position = modelMatrix * vec4( position, 1.0 );'
+    );
+    expect(fakeShader.vertexShader).toContain(
+      'vec4 depth_view_position = uDepthViewMatrix * world_position;'
+    );
+    expect(fakeShader.vertexShader).toContain(
+      'vVirtualDepth = -depth_view_position.z;'
+    );
+    expect(fakeShader.vertexShader).toContain(
+      'vec4 depth_clip_position = uDepthProjectionMatrix * depth_view_position;'
+    );
+    expect(fakeShader.vertexShader).toContain(
+      'vec2 depth_ndc = depth_clip_position.xy / max(0.00001, depth_clip_position.w);'
+    );
+    expect(fakeShader.vertexShader).toContain(
+      'vTexCoord = 0.5 + 0.5 * depth_ndc;'
+    );
+  });
+});
+
+describe('OcclusionPass', () => {
+  it('stores depthViewMatrix and depthProjectionMatrix when provided to setDepthTexture', () => {
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera();
+    const occlusionPass = new OcclusionPass(scene, camera);
+
+    const texture = new THREE.Texture();
+    const depthViewMatrix = new THREE.Matrix4().makeTranslation(10, 20, 30);
+    const depthProjectionMatrix = new THREE.Matrix4().makeScale(2, 2, 2);
+
+    occlusionPass.setDepthTexture(
+      /*depthTexture=*/ texture,
+      /*rawValueToMeters=*/ 0.01,
+      /*viewId=*/ 0,
+      /*depthNear=*/ undefined,
+      /*depthViewMatrix=*/ depthViewMatrix,
+      /*depthProjectionMatrix=*/ depthProjectionMatrix
+    );
+
+    // Render a scene to trigger uniform assignment from stored matrices.
+    const fakeRenderer = {
+      getRenderTarget: () => null,
+      setRenderTarget: () => {},
+      getDrawingBufferSize: (vec: THREE.Vector2) => vec.set(100, 100),
+      render: () => {},
+      xr: {
+        getCamera: () => ({cameras: []}),
+      },
+    } as unknown as THREE.WebGLRenderer;
+
+    const dimensions = new THREE.Vector2(100, 100);
+    occlusionPass.renderOcclusionMapFromScene(fakeRenderer, dimensions, 0);
+
+    // Verify that the overrideMaterial has both uniforms set to the provided matrices.
+    const overrideMat = occlusionPass['occlusionMeshMaterial'];
+    expect(
+      overrideMat.uniforms.uDepthViewMatrix.value.equals(depthViewMatrix)
+    ).toBe(true);
+    expect(
+      overrideMat.uniforms.uDepthProjectionMatrix.value.equals(
+        depthProjectionMatrix
+      )
+    ).toBe(true);
+
+    occlusionPass.dispose();
+  });
+
+  it('falls back to camera matrices when no depthViewMatrix or depthProjectionMatrix is provided', () => {
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera();
+    const occlusionPass = new OcclusionPass(scene, camera);
+
+    const texture = new THREE.Texture();
+    occlusionPass.setDepthTexture(
+      /*depthTexture=*/ texture,
+      /*rawValueToMeters=*/ 0.01,
+      /*viewId=*/ 0,
+      /*depthNear=*/ undefined,
+      /*depthViewMatrix=*/ undefined,
+      /*depthProjectionMatrix=*/ undefined
+    );
+
+    const fakeCamera = new THREE.PerspectiveCamera();
+    fakeCamera.matrixWorldInverse.makeTranslation(5, 5, 5);
+    fakeCamera.projectionMatrix.makeScale(3, 3, 3);
+
+    const fakeRenderer = {
+      getRenderTarget: () => null,
+      setRenderTarget: () => {},
+      getDrawingBufferSize: (vec: THREE.Vector2) => vec.set(100, 100),
+      render: () => {},
+      xr: {
+        getCamera: () => ({cameras: [fakeCamera]}),
+      },
+    } as unknown as THREE.WebGLRenderer;
+
+    const dimensions = new THREE.Vector2(100, 100);
+    occlusionPass.renderOcclusionMapFromScene(fakeRenderer, dimensions, 0);
+
+    const overrideMat = occlusionPass['occlusionMeshMaterial'];
+    expect(
+      overrideMat.uniforms.uDepthViewMatrix.value.equals(
+        fakeCamera.matrixWorldInverse
+      )
+    ).toBe(true);
+    expect(
+      overrideMat.uniforms.uDepthProjectionMatrix.value.equals(
+        fakeCamera.projectionMatrix
+      )
+    ).toBe(true);
+
+    occlusionPass.dispose();
+  });
+});

--- a/src/depth/occlusion/OcclusionPass.ts
+++ b/src/depth/occlusion/OcclusionPass.ts
@@ -37,6 +37,8 @@ export class OcclusionPass extends Pass {
   private occlusionUniforms: ShaderUniforms;
   private occlusionQuad: FullScreenQuad;
   private depthNear: (number | undefined)[] = [];
+  private depthViewMatrices: THREE.Matrix4[] = [];
+  private depthProjectionMatrices: THREE.Matrix4[] = [];
   // Cached dimensions of the render targets so we only call setSize()
   // when they actually changed. setSize() forces a GPU texture
   // reallocation even when called with the same dimensions, which
@@ -151,13 +153,21 @@ export class OcclusionPass extends Pass {
     depthTexture: THREE.Texture,
     rawValueToMeters: number,
     viewId: number,
-    depthNear?: number
+    depthNear?: number,
+    depthViewMatrix?: THREE.Matrix4,
+    depthProjectionMatrix?: THREE.Matrix4
   ) {
     this.depthTextures[viewId] = depthTexture;
     this.occlusionMapUniforms.uRawValueToMeters.value = rawValueToMeters;
     this.occlusionMeshMaterial.uniforms.uRawValueToMeters.value =
       rawValueToMeters;
     this.depthNear[viewId] = depthNear;
+    if (depthViewMatrix) {
+      this.depthViewMatrices[viewId] = depthViewMatrix;
+    }
+    if (depthProjectionMatrix) {
+      this.depthProjectionMatrices[viewId] = depthProjectionMatrix;
+    }
     depthTexture.needsUpdate = true;
   }
 
@@ -214,12 +224,16 @@ export class OcclusionPass extends Pass {
     } else {
       this.occlusionMeshMaterial.uniforms.uDepthTexture.value = texture;
     }
+    const camera = renderer.xr.getCamera().cameras[viewId] || this.camera;
+    this.occlusionMeshMaterial.uniforms.uDepthViewMatrix.value =
+      this.depthViewMatrices[viewId] || camera.matrixWorldInverse;
+    this.occlusionMeshMaterial.uniforms.uDepthProjectionMatrix.value =
+      this.depthProjectionMatrices[viewId] || camera.projectionMatrix;
     this.scene.overrideMaterial = this.occlusionMeshMaterial;
     renderer.getDrawingBufferSize(dimensions);
     this.resizeOcclusionMap(dimensions);
     const renderTarget = this.occlusionMapTexture;
     renderer.setRenderTarget(renderTarget);
-    const camera = renderer.xr.getCamera().cameras[viewId] || this.camera;
     const originalCameraLayers = Array.from(Array(32).keys()).filter(
       (element) => camera.layers.isEnabled(element)
     );


### PR DESCRIPTION
## Description

This CL updates occlusion to support matchDepthView=false and sets it to false by default now that occlusion and depth mesh no longer require matchDepthView.

When matchDepthView is false, the WebXR depth sensor may have a different pose (view matrix) and projection matrix than the rendering camera.

This change updates the occlusion pipeline to support matchDepthView=false:
1. Both Z-depth (vVirtualDepth) and texture UV coordinates (vTexCoord) are computed in the depth camera's clip and projection space (uDepthViewMatrix and uDepthProjectionMatrix).
2. Out-of-bounds fragments (outside [0, 1] UV or behind the depth camera) are safely treated as unoccluded (1.0), preventing edge clamping artifacts for objects outside the depth sensor's FOV.
3. Unused rightDepthTexture setDepthTexture call is removed from Depth.renderOcclusionPass() since occlusion currently renders a single mono occlusion map.

## Type of Change
- [x] New feature / enhancement


## Checklist

- [x] **Tested in simulator & device**: Ran occlusion scene on galaxy XR. Verified occlusion lines up with VST.
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.
