### PR TITLE
fix(virtualkeyboard): honour the keyboard transform

### DIFF
--- a/demos/math3d/Math3D.js
+++ b/demos/math3d/Math3D.js
@@ -96,7 +96,7 @@ export class Math3D extends xb.Script {
 
     this.keyboard = new Keyboard();
     this.add(this.keyboard);
-    this.keyboard.position.set(0, -0.3, 0);
+    this.keyboard.position.set(0, 0.9, -1);
 
     const startFn = this.mathObjects[0].functionText;
 

--- a/src/addons/netblocks/samples/integration/main.ts
+++ b/src/addons/netblocks/samples/integration/main.ts
@@ -554,18 +554,10 @@ class IntegrationSample extends NetSample {
   }
 
   private _buildKeyboard(session: NonNullable<this['net']['session']>) {
-    // Subclass to override init() (which would otherwise reset the
-    // keyboard's transform to its default position above the user).
-    class PositionedKeyboard extends Keyboard {
-      override init(): void {
-        super.init();
-        const sub = (this as unknown as {subspace: xb.SpatialPanel}).subspace;
-        sub.position.set(-0.7, 0.7, -0.7);
-        sub.scale.setScalar(0.6);
-        sub.rotation.set(-Math.PI / 6, 0, 0);
-      }
-    }
-    const keyboard = new PositionedKeyboard();
+    const keyboard = new Keyboard();
+    keyboard.position.set(-0.7, 0.7, -0.7);
+    keyboard.scale.setScalar(0.6);
+    keyboard.rotation.set(-Math.PI / 6, 0, 0);
     this._keyboard = keyboard;
     xb.add(keyboard);
     keyboard.onTextChanged = (text: string) => {

--- a/src/addons/virtualkeyboard/Keyboard.ts
+++ b/src/addons/virtualkeyboard/Keyboard.ts
@@ -26,6 +26,9 @@ const KEY_WIDTH = 0.07;
 const KEY_HEIGHT = 0.08;
 const FONT_SIZE = 0.45;
 
+/** Where the keyboard sits when an app does not place it itself. */
+const DEFAULT_KEYBOARD_POSITION = {x: 0, y: 1.2, z: -1};
+
 const KEYBOARD_COLOR = '#1a1a1b';
 const DEFAULT_KEY_COLOR = '#333334';
 const SPECIAL_KEY_COLOR = '#3e4a59';
@@ -127,6 +130,10 @@ export class Keyboard extends xb.Script {
       backgroundColor: KEYBOARD_COLOR,
       width: TOTAL_KEYBOARD_WIDTH,
       height: TOTAL_KEYBOARD_HEIGHT,
+      // Sits at the keyboard's own origin, so the keys land wherever the
+      // keyboard is put. Left on, the panel would place itself in front of the
+      // user and ignore that entirely.
+      useDefaultPosition: false,
     });
     this.subspace.isRoot = true;
     this.add(this.subspace);
@@ -136,10 +143,17 @@ export class Keyboard extends xb.Script {
 
     this.createKeyboard();
     this.subspace.updateLayouts();
-  }
 
-  override init(): void {
-    this.subspace.position.set(0, 1.2, -1);
+    // Default placement, in front of the user and a little above waist height.
+    // Set on the keyboard itself rather than on the panel inside it, so an app
+    // that assigns a position simply replaces this instead of being offset by
+    // it. Previously this was applied in init(), which runs after the app has
+    // positioned the keyboard and so silently moved it somewhere else.
+    this.position.set(
+      DEFAULT_KEYBOARD_POSITION.x,
+      DEFAULT_KEYBOARD_POSITION.y,
+      DEFAULT_KEYBOARD_POSITION.z
+    );
   }
 
   private createKeyboard(): void {


### PR DESCRIPTION
## Description

setting `position` on a `Keyboard` doesn't put it there. `init()` runs after your app has positioned it and moves the panel inside to a fixed spot, and that panel carries its own default placement underneath, so there are two things fighting whatever you set.

i ran into this building the netblocks integration sample and worked around it there by subclassing `Keyboard`, overriding `init()` and casting through to the panel it keeps private. that workaround is the clearest sign the api is wrong, so it goes away in this. `demos/math3d` has its own version of the same thing, a negative y picked to cancel out the offset that gets added afterwards.

moves the default onto the keyboard itself, set in the constructor, so assigning a position replaces it instead of being added to it, and pins the panel to the keyboard's origin.

a keyboard nobody places still appears exactly where it always did, `(0, 1.2, -1)` before and after. math3d lands in the same physical spot too, just written as where it goes rather than as an offset to cancel.

came up again while placing a keyboard in the spatial anchors demos on #494, where it landed a metre further away and high enough to sit through the panel above it. that demo compensates from the outside for now, and once this lands the compensation there is two constants to delete.

## Type of Change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

- **Simulator Recording**: <!-- TODO -->
- **Device Recording**: <!-- TODO -->

## Checklist

- [x] **Tested in simulator & device**: verified in the desktop simulator. measured the keyboard's world position in math3d before and after, it lands in the same place, and a keyboard with no position set still defaults to `(0, 1.2, -1)` exactly as before.
- [x] **Large Assets ($\ge$ 1MB)**: none added.
- [x] **SDK Dynamic Dependencies**: no new dependencies.
- [x] **Security**: no keys or secrets.
