### PR TITLE
Direct Touch to Work Like Select

### DIFF
--- a/src/core/Script.ts
+++ b/src/core/Script.ts
@@ -221,18 +221,24 @@ export function ScriptMixin<TBase extends Constructor<THREE.Object3D>>(
     onHovering(_event: HoverEvent): boolean | void {}
     /**
      * Called when a hand's index finger starts touching this object.
+     * Direct touch starts the object's selection lifecycle by default. Call
+     * `event.preventDefault()` to handle contact without selecting.
      */
     onObjectTouchStart(_event: ObjectTouchStartEvent): boolean | void {}
     /**
      * Called every frame that a hand's index finger is touching this object.
+     * The object remains selected during these frames unless touch selection
+     * was prevented when contact started.
      */
     onObjectTouching(_event: ObjectTouchEvent): boolean | void {}
     /**
      * Called when a hand's index finger stops touching this object.
+     * This ends the default selection lifecycle after the touch callback.
      */
     onObjectTouchEnd(_event: ObjectTouchEvent): boolean | void {}
     /**
      * Called when a hand starts grabbing this object (touching + pinching).
+     * A grab starts built-in direct-touch manipulation when enabled.
      */
     onObjectGrabStart(_event: ObjectGrabEvent) {}
     /**
@@ -241,6 +247,7 @@ export function ScriptMixin<TBase extends Constructor<THREE.Object3D>>(
     onObjectGrabbing(_event: ObjectGrabEvent) {}
     /**
      * Called when a hand stops grabbing this object.
+     * This ends built-in direct-touch manipulation without ending contact.
      */
     onObjectGrabEnd(_event: ObjectGrabEvent) {}
 

--- a/src/interaction/Interaction.test.ts
+++ b/src/interaction/Interaction.test.ts
@@ -25,6 +25,7 @@ async function activateScripts(
 
 class RecordingButton extends UIButton {
   starts: SelectEvent[] = [];
+  selecting: SelectEvent[] = [];
   ends: SelectEndEvent[] = [];
   longSelects: LongSelectEvent[] = [];
   touchStarts: ObjectTouchStartEvent[] = [];
@@ -37,6 +38,10 @@ class RecordingButton extends UIButton {
   override onObjectSelectEnd(event: SelectEndEvent): true {
     this.ends.push(event);
     return true;
+  }
+
+  override onSelecting(event: SelectEvent): void {
+    this.selecting.push(event);
   }
 
   override onObjectLongSelect(event: LongSelectEvent): true {
@@ -150,7 +155,7 @@ describe('Interaction public behavior', () => {
     expect(interaction.getResolvedRay(source)?.surface).toBe(logical);
   });
 
-  it('dispatches touch first, honors prevention, suspends the ray, and activates once on contact', async () => {
+  it('keeps selection active for the full direct-touch contact', async () => {
     const clicked = vi.fn();
     const button = new RecordingButton({label: 'Touch', onClick: clicked});
     button.onObjectTouchStart = (event) => {
@@ -201,17 +206,32 @@ describe('Interaction public behavior', () => {
       raySources: [ray(hand, false)],
       directTouches: [touch],
     });
-    expect(acceptedClick).toHaveBeenCalledOnce();
-    expect(accepted.ends.at(-1)).toMatchObject({
-      completed: true,
-      reason: 'released',
+    expect(accepted.touchStarts).toHaveLength(1);
+    expect(accepted.starts).toHaveLength(1);
+    expect(accepted.ends).toHaveLength(0);
+    expect(acceptedClick).not.toHaveBeenCalled();
+    expect(interaction.isSelectingAt(accepted)).toBe(true);
+    expect(accepted.selecting).toHaveLength(1);
+    expect(accepted.selecting[0].source.type).toBe('direct-touch');
+
+    interaction.update({
+      raySources: [ray(hand, false)],
+      directTouches: [touch],
     });
+    expect(accepted.selecting).toHaveLength(2);
+    expect(accepted.ends).toHaveLength(0);
+
     interaction.update({
       raySources: [ray(hand, false)],
       directTouches: [{...touch, point: new THREE.Vector3(2, 0, 0)}],
     });
     expect(acceptedClick).toHaveBeenCalledOnce();
-    expect(accepted.ends.at(-1)?.source.type).toBe('direct-touch');
+    expect(accepted.ends.at(-1)).toMatchObject({
+      completed: true,
+      reason: 'released',
+      source: {type: 'direct-touch'},
+    });
+    expect(interaction.isSelectingAt(accepted)).toBe(false);
   });
 
   it('jumps and streams a slider, commits once, and restores on cancellation', async () => {

--- a/src/interaction/Interaction.ts
+++ b/src/interaction/Interaction.ts
@@ -549,7 +549,7 @@ export class Interaction {
       ) {
         action = 'none';
       }
-    } else if (wantsManipulation) {
+    } else if (wantsManipulation && !touch) {
       action = 'manipulate';
     }
     if (gaze && semantic?.kind !== 'button') action = 'none';
@@ -739,7 +739,7 @@ export class Interaction {
             true
           );
         }
-        this.updateGrab(touchState, contact);
+        this.updateGrab(touchState, contact, snapshot);
       } catch (error) {
         this.touches.delete(contact.controller);
         this.cancelFailedCapture(contact.controller, error);
@@ -753,7 +753,7 @@ export class Interaction {
     if (contact.phase === 'move') {
       try {
         this.dispatchTouch(touch, 'onObjectTouching');
-        this.updateGrab(touch, contact);
+        this.updateGrab(touch, contact, snapshot);
       } catch (error) {
         this.touches.delete(contact.controller);
         this.cancelFailedCapture(contact.controller, error);
@@ -764,7 +764,7 @@ export class Interaction {
     this.touches.delete(contact.controller);
     this.suppressedUntilRelease.add(contact.controller);
     try {
-      this.finishGrab(touch);
+      this.finishGrab(touch, snapshot);
       this.dispatchTouch(touch, 'onObjectTouchEnd');
     } finally {
       if (!touch.prevented) {
@@ -797,7 +797,7 @@ export class Interaction {
     const touch = this.touches.get(controller);
     if (!touch) return;
     this.touches.delete(controller);
-    this.finishGrab(touch);
+    this.finishGrab(touch, this.sourceStates.get(controller));
     this.dispatchTouch(touch, 'onObjectTouchEnd');
   }
 
@@ -847,9 +847,13 @@ export class Interaction {
     };
   }
 
-  private updateGrab(touch: TouchState, contact: DirectTouchContact): void {
+  private updateGrab(
+    touch: TouchState,
+    contact: DirectTouchContact,
+    snapshot: InteractionSourceState
+  ): void {
     if (!contact.selected || !touch.hand) {
-      this.finishGrab(touch);
+      this.finishGrab(touch, snapshot);
       return;
     }
     const event = this.createGrabEvent(touch);
@@ -861,6 +865,7 @@ export class Interaction {
         'onObjectGrabStart',
         event
       );
+      this.startGrabManipulation(touch, snapshot);
     } else {
       dispatchInteractionPath(
         this.callbacks,
@@ -871,8 +876,41 @@ export class Interaction {
     }
   }
 
-  private finishGrab(touch: TouchState): void {
+  private startGrabManipulation(
+    touch: TouchState,
+    snapshot: InteractionSourceState
+  ): void {
+    const capture = this.captures.get(touch.selection.source);
+    if (
+      capture?.kind !== 'target' ||
+      !capture.touch ||
+      capture.action !== 'select' ||
+      !capture.selection.manipulation
+    ) {
+      return;
+    }
+    capture.action = 'manipulate';
+    if (!this.manipulation.tryStart(capture.selection, snapshot)) {
+      capture.action = 'select';
+    }
+  }
+
+  private finishGrab(
+    touch: TouchState,
+    snapshot?: InteractionSourceState
+  ): void {
     if (!touch.grabbing || !touch.hand) return;
+    const capture = this.captures.get(touch.selection.source);
+    if (
+      capture?.kind === 'target' &&
+      capture.touch &&
+      capture.action === 'manipulate'
+    ) {
+      this.runManipulationTransition(() =>
+        this.manipulation.end(touch.selection.source, snapshot)
+      );
+      capture.action = 'select';
+    }
     touch.grabbing = false;
     dispatchInteractionPath(
       this.callbacks,

--- a/src/interaction/Interaction.ts
+++ b/src/interaction/Interaction.ts
@@ -732,24 +732,12 @@ export class Interaction {
         const prevented = this.dispatchTouchStart(touchState);
         touchState.prevented = prevented;
         if (!prevented) {
-          const capture = this.startTargetCapture(
+          this.startTargetCapture(
             contact.controller,
             snapshot,
             contact.resolved,
             true
           );
-          if (
-            capture.action === 'select' ||
-            (capture.action === 'semantic' &&
-              capture.semantic?.kind === 'button')
-          ) {
-            this.endSelection(
-              contact.controller,
-              'released',
-              capture.selection.target,
-              snapshot
-            );
-          }
         }
         this.updateGrab(touchState, contact);
       } catch (error) {


### PR DESCRIPTION
# Updated Direct Touch

## Description

- Changed direct touch to go from clicking on touch start (selectOn -> selectOff) to follow raycast select, selecting, off. 
- updated manipulation so direct touch doesnt drag the object by default, only grab
- 

## Type of Change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

- **Simulator Recording**: <!-- Attach video/GIF running in desktop simulator -->
- **Device Recording**: <!-- Attach video/GIF running on physical hardware -->

## Checklist

- [x] **Tested in simulator & device**: Verified functionality in desktop simulator and/or physical hardware (where applicable).
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.
