### PR TITLE
Cleaning Tests

### DIFF
--- a/src/StylizedFace.test.ts
+++ b/src/StylizedFace.test.ts
@@ -1,40 +1,30 @@
-import {describe, it, expect} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {StylizedFace} from './StylizedFace';
 import {ZERO_VISEME} from './VisemeWeights';
 
 describe('StylizedFace', () => {
-  it('extends Script (an Object3D) so it can be added under a head pivot', () => {
-    const m = new StylizedFace();
-    expect(m.isObject3D).toBe(true);
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      beginPath: vi.fn(),
+      clearRect: vi.fn(),
+      ellipse: vi.fn(),
+      fill: vi.fn(),
+    } as unknown as CanvasRenderingContext2D);
   });
 
-  it('rest pose: openHeight is ~0 and width is ~1', () => {
-    const m = new StylizedFace();
-    m.setVisemes(ZERO_VISEME);
-    expect(m.metrics.openHeight).toBeLessThan(0.02);
-    expect(m.metrics.width).toBeGreaterThan(0.95);
-    expect(m.metrics.width).toBeLessThan(1.05);
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it('jawOpen drives openHeight upward', () => {
+  it('maps open and vowel visemes to the mouth shape', () => {
     const m = new StylizedFace();
     m.setVisemes({...ZERO_VISEME, jawOpen: 1});
     expect(m.metrics.openHeight).toBeGreaterThan(0.6);
-  });
-
-  it('oo narrows width', () => {
-    const m = new StylizedFace();
     m.setVisemes(ZERO_VISEME);
     const restW = m.metrics.width;
     m.setVisemes({...ZERO_VISEME, oo: 1});
     expect(m.metrics.width).toBeLessThan(restW);
-  });
-
-  it('ee widens horizontal mouth', () => {
-    const m = new StylizedFace();
-    m.setVisemes(ZERO_VISEME);
-    const restW = m.metrics.width;
     m.setVisemes({...ZERO_VISEME, ee: 1});
     expect(m.metrics.width).toBeGreaterThan(restW);
   });
@@ -67,117 +57,7 @@ describe('StylizedFace', () => {
     expect(m.texture.version).toBeGreaterThan(versionAfterFirst);
   });
 
-  it('eyes default on: ellipse() called 3 times per redraw (mouth + 2 eyes)', () => {
-    const ellipseCalls: number[][] = [];
-    const fakeCtx = new Proxy(
-      {},
-      {
-        get(_t, prop) {
-          if (prop === 'ellipse') {
-            return (...args: number[]) => ellipseCalls.push(args);
-          }
-          return () => {};
-        },
-        set() {
-          return true;
-        },
-      }
-    );
-    const origGetContext = HTMLCanvasElement.prototype.getContext;
-    (
-      HTMLCanvasElement.prototype as unknown as {
-        getContext: (t: string) => unknown;
-      }
-    ).getContext = (t: string) => (t === '2d' ? fakeCtx : null);
-    try {
-      ellipseCalls.length = 0;
-      const m = new StylizedFace();
-      void m;
-      // Constructor calls drawIfDirty() once. With eyes on we
-      // expect: 1 mouth ellipse + 2 eye ellipses (both inside one path).
-      expect(ellipseCalls.length).toBe(3);
-      ellipseCalls.length = 0;
-      m.setVisemes({...ZERO_VISEME, jawOpen: 0.5});
-      expect(ellipseCalls.length).toBe(3);
-    } finally {
-      HTMLCanvasElement.prototype.getContext = origGetContext;
-    }
-  });
-
-  it('showEyes false: ellipse() only called for the mouth', () => {
-    const ellipseCalls: number[][] = [];
-    const fakeCtx = new Proxy(
-      {},
-      {
-        get(_t, prop) {
-          if (prop === 'ellipse') {
-            return (...args: number[]) => ellipseCalls.push(args);
-          }
-          return () => {};
-        },
-        set() {
-          return true;
-        },
-      }
-    );
-    const origGetContext = HTMLCanvasElement.prototype.getContext;
-    (
-      HTMLCanvasElement.prototype as unknown as {
-        getContext: (t: string) => unknown;
-      }
-    ).getContext = (t: string) => (t === '2d' ? fakeCtx : null);
-    try {
-      ellipseCalls.length = 0;
-      const m = new StylizedFace({showEyes: false});
-      void m;
-      expect(ellipseCalls.length).toBe(1);
-    } finally {
-      HTMLCanvasElement.prototype.getContext = origGetContext;
-    }
-  });
-
-  it('eyes blink: scale returns to 1 between blinks, dips during a blink', () => {
-    const m = new StylizedFace();
-    type Internal = {
-      currentBlinkScale: (now: number) => number;
-      nextBlinkAt: number;
-      blinkStartAt: number;
-    };
-    const inner = m as unknown as Internal;
-    inner.nextBlinkAt = 1000;
-    inner.blinkStartAt = -Infinity;
-
-    expect(inner.currentBlinkScale(500)).toBeCloseTo(1, 5);
-    expect(inner.currentBlinkScale(999)).toBeCloseTo(1, 5);
-    expect(inner.currentBlinkScale(1000)).toBeCloseTo(1, 5);
-    expect(inner.currentBlinkScale(1070)).toBeLessThan(0.1);
-    expect(inner.currentBlinkScale(1200)).toBeCloseTo(1, 5);
-    expect(inner.currentBlinkScale(1300)).toBeCloseTo(1, 5);
-    inner.currentBlinkScale(1000 + 7000);
-    expect(inner.blinkStartAt).toBeGreaterThan(1000);
-  });
-
-  it('update() advances the blink animation independently of setVisemes calls', () => {
-    // The face must keep blinking even when nothing is driving its
-    // mouth shape — that's the point of being a Script with its own
-    // update() loop.
-    const m = new StylizedFace();
-    type Internal = {
-      nextBlinkAt: number;
-      blinkStartAt: number;
-      lastDrawnBlinkScale: number;
-    };
-    const inner = m as unknown as Internal;
-    inner.nextBlinkAt = performance.now() - 1;
-    inner.blinkStartAt = -Infinity;
-    const versionBefore = m.texture.version;
-    m.update();
-    // The blink schedule has been advanced and a redraw happened.
-    expect(inner.blinkStartAt).toBeGreaterThan(-Infinity);
-    expect(m.texture.version).toBeGreaterThanOrEqual(versionBefore);
-  });
-
-  it('dispose() releases texture, geometry, and material', () => {
+  it('dispose() releases resources once', () => {
     const m = new StylizedFace();
     const geom = m.mesh.geometry;
     const mat = m.mesh.material;
@@ -190,20 +70,14 @@ describe('StylizedFace', () => {
       mat as {addEventListener: (e: string, cb: () => void) => void}
     ).addEventListener('dispose', () => (matDisposed = true));
     tex.addEventListener('dispose', () => (texDisposed = true));
-    m.dispose();
-    expect(geomDisposed).toBe(true);
-    expect(matDisposed).toBe(true);
-    expect(texDisposed).toBe(true);
-  });
-
-  it('dispose() is idempotent (xrblocks ScriptsManager + a host can both call it)', () => {
-    const m = new StylizedFace();
-    const tex = m.texture;
     let texDisposes = 0;
     tex.addEventListener('dispose', () => texDisposes++);
     m.dispose();
+    expect(geomDisposed).toBe(true);
+    expect(matDisposed).toBe(true);
     m.dispose();
     m.dispose();
+    expect(texDisposed).toBe(true);
     expect(texDisposes).toBe(1);
   });
 });

--- a/src/addons/agenthands/AgentGestureAnimator.test.ts
+++ b/src/addons/agenthands/AgentGestureAnimator.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, vi} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 
 vi.hoisted(() => {
   vi.stubGlobal('AudioContext', function () {
@@ -12,8 +12,6 @@ import {SimulatorHandPose} from 'xrblocks';
 import {AgentGestureAnimator} from './AgentGestureAnimator';
 import {AgentHands} from './AgentHands';
 
-// Aims are no-op'd because the hand rig is unloaded in tests; we assert on the
-// animator's state and the calls it makes, not on the rig geometry.
 function makeHands() {
   const hands = new AgentHands();
   hands.updateMatrixWorld(true);
@@ -23,97 +21,40 @@ function makeHands() {
 }
 
 describe('AgentGestureAnimator', () => {
-  it('fires a static pose and clears any aim', () => {
+  it('applies a static pose and clears an active orientation', () => {
     const hands = makeHands();
-    const anim = new AgentGestureAnimator(hands);
-    const gesture = vi.spyOn(hands, 'gesture');
-    const clear = vi.spyOn(hands, 'clearOrientation');
-    anim.fireStep({at: 0, charIndex: 0, pose: SimulatorHandPose.VICTORY});
-    expect(gesture).toHaveBeenCalledWith(SimulatorHandPose.VICTORY);
-    expect(clear).toHaveBeenCalled();
-    expect(anim.pointing).toBe(false);
+    const animator = new AgentGestureAnimator(hands);
+    animator.fireStep({at: 0, charIndex: 0, pose: SimulatorHandPose.VICTORY});
+
+    expect(hands.left.currentPose).toBe(SimulatorHandPose.VICTORY);
+    expect(hands.right.currentPose).toBe(SimulatorHandPose.VICTORY);
   });
 
-  it('dispatches a beat motion to the hands', () => {
+  it('translates motion markup into hand actions', () => {
     const hands = makeHands();
-    const anim = new AgentGestureAnimator(hands);
+    const animator = new AgentGestureAnimator(hands);
     const beat = vi.spyOn(hands, 'beat');
-    anim.fireStep({at: 0, charIndex: 0, motion: 'beat'});
-    expect(beat).toHaveBeenCalled();
+    const size = vi.spyOn(hands, 'showSize');
+    const count = vi.spyOn(hands, 'showCount');
+
+    animator.fireStep({at: 0, charIndex: 0, motion: 'beat'});
+    animator.fireStep({at: 0, charIndex: 0, motion: 'size', param: 'big'});
+    animator.fireStep({at: 0, charIndex: 0, motion: 'count', param: '2'});
+
+    expect(beat).toHaveBeenCalledOnce();
+    expect(size).toHaveBeenCalledWith(0.55);
+    expect(count).toHaveBeenCalledWith(2);
   });
 
-  it('maps size params to a separation width', () => {
-    const anim = new AgentGestureAnimator(makeHands());
-    expect(anim.sizeWidth('small')).toBeCloseTo(0.18);
-    expect(anim.sizeWidth('big')).toBeCloseTo(0.55);
-    expect(anim.sizeWidth('0.4')).toBeCloseTo(0.4);
-    expect(anim.sizeWidth('nonsense')).toBeCloseTo(0.35);
-  });
-
-  it('shows size using the mapped width', () => {
+  it('aims at a point on the matching side and rests after the gesture', () => {
     const hands = makeHands();
-    const anim = new AgentGestureAnimator(hands);
-    const showSize = vi.spyOn(hands, 'showSize');
-    anim.fireStep({at: 0, charIndex: 0, motion: 'size', param: 'big'});
-    expect(showSize).toHaveBeenCalledWith(anim.sizeWidth('big'));
-  });
-
-  it('counts via showCount', () => {
-    const hands = makeHands();
-    const anim = new AgentGestureAnimator(hands);
-    const showCount = vi.spyOn(hands, 'showCount');
-    anim.fireStep({at: 0, charIndex: 0, motion: 'count', param: '2'});
-    expect(showCount).toHaveBeenCalledWith(2);
-  });
-
-  it('flattens the right hand to neutral for a wave', () => {
-    const hands = makeHands();
-    const anim = new AgentGestureAnimator(hands);
-    const gesture = vi.spyOn(hands, 'gesture');
-    anim.fireStep({at: 0, charIndex: 0, motion: 'wave'});
-    expect(gesture).toHaveBeenCalledWith(SimulatorHandPose.NEUTRAL, 'right');
-  });
-
-  it('points at a world target and tracks the active hand', () => {
-    const hands = makeHands();
-    const anim = new AgentGestureAnimator(hands);
+    const animator = new AgentGestureAnimator(hands);
     const target = new THREE.Vector3(2, 1, -1);
-    anim.fireStep({at: 0, charIndex: 0, point: target});
-    expect(anim.pointing).toBe(true);
-    expect(anim.target).toBe(target);
-    // Target on the +x side, hands unrotated: the right hand points.
-    expect(anim.activeHand).toBe(hands.right);
-  });
 
-  it('re-aims the active hand at the current target', () => {
-    const hands = makeHands();
-    const anim = new AgentGestureAnimator(hands);
-    const target = new THREE.Vector3(2, 1, -1);
-    anim.pointAt(target);
-    const rightAim = hands.right.aimAt as ReturnType<typeof vi.fn>;
-    rightAim.mockClear();
-    anim.reaim();
-    expect(rightAim).toHaveBeenCalledWith(target);
-  });
+    animator.fireStep({at: 0, charIndex: 0, point: target});
+    expect(hands.right.aimAt).toHaveBeenCalledWith(target);
 
-  it('stops pointing when a non-point gesture follows a point', () => {
-    const hands = makeHands();
-    const anim = new AgentGestureAnimator(hands);
-    anim.pointAt(new THREE.Vector3(2, 1, -1));
-    anim.fireStep({at: 0, charIndex: 0, motion: 'beat'});
-    expect(anim.pointing).toBe(false);
-    expect(anim.target).toBeNull();
-    expect(anim.activeHand).toBeNull();
-  });
-
-  it('rest() relaxes the hands and clears pointing', () => {
-    const hands = makeHands();
-    const anim = new AgentGestureAnimator(hands);
-    const rest = vi.spyOn(hands, 'rest');
-    anim.pointAt(new THREE.Vector3(2, 1, -1));
-    anim.rest();
-    expect(rest).toHaveBeenCalled();
-    expect(anim.pointing).toBe(false);
-    expect(anim.target).toBeNull();
+    animator.rest();
+    expect(hands.right.currentPose).toBe(SimulatorHandPose.RELAXED);
   });
 });

--- a/src/addons/agenthands/AgentGestures.test.ts
+++ b/src/addons/agenthands/AgentGestures.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, vi} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 
 vi.hoisted(() => {
   vi.stubGlobal('AudioContext', function () {
@@ -6,9 +6,8 @@ vi.hoisted(() => {
   });
 });
 
-import {SimulatorHandPose} from 'xrblocks';
-
 import * as THREE from 'three';
+import {SimulatorHandPose} from 'xrblocks';
 
 import {
   buildGestureSteps,
@@ -17,159 +16,100 @@ import {
   parseAgentGestures,
 } from './AgentGestures';
 
-describe('gestureNameToPose', () => {
-  it('maps direct names', () => {
+describe('AgentGestures', () => {
+  it('normalizes supported pose names and rejects unknown names', () => {
     expect(gestureNameToPose('point')).toBe(SimulatorHandPose.POINTING);
     expect(gestureNameToPose('fist')).toBe(SimulatorHandPose.FIST);
-    expect(gestureNameToPose('victory')).toBe(SimulatorHandPose.VICTORY);
-  });
-
-  it('normalizes spaces, hyphens, and case', () => {
     expect(gestureNameToPose('Thumbs Up')).toBe(SimulatorHandPose.THUMBS_UP);
     expect(gestureNameToPose('thumbs-up')).toBe(SimulatorHandPose.THUMBS_UP);
-    expect(gestureNameToPose('THUMBSUP')).toBe(SimulatorHandPose.THUMBS_UP);
-  });
-
-  it('returns undefined for unknown names', () => {
     expect(gestureNameToPose('wiggle')).toBeUndefined();
   });
-});
 
-describe('parseAgentGestures', () => {
-  it('strips markup and returns clean text', () => {
-    const {text} = parseAgentGestures('Look [gesture:point] over there.');
-    expect(text).toBe('Look over there.');
-  });
-
-  it('captures gestures in order with their text index', () => {
-    const {gestures} = parseAgentGestures(
-      'Yes [gesture:thumbs_up] and that [gesture:point] one.'
+  it('removes pose markup and schedules poses in text order', () => {
+    const {text, gestures} = parseAgentGestures(
+      'Yes [gesture:thumbs_up] and [gesture:point] there.'
     );
-    expect(gestures.map((g) => g.pose)).toEqual([
+
+    expect(text).toBe('Yes and there.');
+    expect(gestures.map((gesture) => gesture.pose)).toEqual([
       SimulatorHandPose.THUMBS_UP,
       SimulatorHandPose.POINTING,
     ]);
     expect(gestures[0].index).toBeLessThan(gestures[1].index);
   });
 
-  it('accepts bare [name] markup without the gesture: prefix', () => {
-    const {text, gestures} = parseAgentGestures('Great [thumbs up]!');
-    expect(text).toBe('Great !');
-    expect(gestures[0].pose).toBe(SimulatorHandPose.THUMBS_UP);
-  });
-
-  it('drops unknown gesture markup but keeps surrounding text', () => {
-    const {text, gestures} = parseAgentGestures('Hmm [gesture:wiggle] ok.');
-    expect(text).toBe('Hmm ok.');
-    expect(gestures).toHaveLength(0);
-  });
-
-  it('returns no gestures for plain text', () => {
-    const {text, gestures} = parseAgentGestures('Just talking.');
-    expect(text).toBe('Just talking.');
-    expect(gestures).toHaveLength(0);
-  });
-
-  it('captures a point target from [point:label] markup', () => {
-    const {text, gestures} = parseAgentGestures(
-      'It is right [point:the table] there.'
+  it('accepts bare markup and safely removes unknown markup', () => {
+    const parsed = parseAgentGestures(
+      'Great [thumbs up]! Hmm [gesture:wiggle].'
     );
-    expect(text).toBe('It is right there.');
-    expect(gestures).toHaveLength(1);
-    expect(gestures[0].pose).toBe(SimulatorHandPose.POINTING);
-    expect(gestures[0].target).toBe('the table');
+
+    expect(parsed.text).toBe('Great ! Hmm .');
+    expect(parsed.gestures).toHaveLength(1);
+    expect(parsed.gestures[0].pose).toBe(SimulatorHandPose.THUMBS_UP);
   });
 
-  it('captures a target from the gesture: prefixed form too', () => {
-    const {gestures} = parseAgentGestures('Over [gesture:point:sofa] here.');
-    expect(gestures[0].pose).toBe(SimulatorHandPose.POINTING);
-    expect(gestures[0].target).toBe('sofa');
-  });
-
-  it('leaves target undefined for gestures without one', () => {
-    const {gestures} = parseAgentGestures('Nice [gesture:thumbs_up]!');
-    expect(gestures[0].target).toBeUndefined();
-  });
-
-  it('anchors gesture index to the normalized (collapsed) text', () => {
-    // Leading/!double spaces around the markup must not shift the index past
-    // the end of the collapsed text the caller schedules against.
+  it('preserves normalized text indexes for gesture scheduling', () => {
     const {text, gestures} = parseAgentGestures(
       '  Look   over [gesture:point] there  '
     );
+
     expect(text).toBe('Look over there');
-    expect(gestures[0].index).toBeLessThanOrEqual(text.length);
-    // "Look over " -> index 10 in the normalized string.
     expect(text.slice(0, gestures[0].index)).toBe('Look over ');
   });
 
-  it('parses motion gestures with and without a parameter', () => {
+  it('parses motion gestures and their parameters', () => {
     const {text, gestures} = parseAgentGestures(
-      'Hi [wave] it was [size:big] huge and [count:2] options [beat] done.'
+      'Hi [wave] [size:big] [count:2] [beat].'
     );
-    expect(text).toBe('Hi it was huge and options done.');
-    expect(gestures.map((g) => g.motion)).toEqual([
-      'wave',
-      'size',
-      'count',
-      'beat',
+
+    expect(text).toBe('Hi .');
+    expect(gestures.map((gesture) => [gesture.motion, gesture.param])).toEqual([
+      ['wave', undefined],
+      ['size', 'big'],
+      ['count', '2'],
+      ['beat', undefined],
     ]);
-    expect(gestures[1].param).toBe('big');
-    expect(gestures[2].param).toBe('2');
-    // Motion events carry no pose.
-    expect(gestures[0].pose).toBeUndefined();
-  });
-
-  it('maps motion synonyms', () => {
-    expect(gestureNameToMotion('hello')).toBe('wave');
     expect(gestureNameToMotion('emphasize')).toBe('beat');
-    expect(gestureNameToMotion('this big')).toBe('size');
-    expect(gestureNameToMotion('thumbs_up')).toBeUndefined();
   });
-});
 
-describe('buildGestureSteps', () => {
-  it('places each gesture on the timeline by its character offset', () => {
+  it('turns gesture character offsets into a bounded timeline', () => {
     const {text, gestures} = parseAgentGestures(
       'Hi there [wave] and welcome [beat] friend.'
     );
-    const duration = 4;
-    const steps = buildGestureSteps(text, gestures, duration);
-    expect(steps).toHaveLength(2);
-    expect(steps[0].motion).toBe('wave');
-    expect(steps[1].motion).toBe('beat');
-    // Timeline is monotonic and bounded by the duration.
+    const steps = buildGestureSteps(text, gestures, 4);
+
+    expect(steps.map((step) => step.motion)).toEqual(['wave', 'beat']);
     expect(steps[0].at).toBeLessThan(steps[1].at);
-    expect(steps[1].at).toBeLessThanOrEqual(duration);
-    expect(steps[0].charIndex).toBe(gestures[0].index);
+    expect(steps[1].at).toBeLessThanOrEqual(4);
   });
 
-  it('carries pose, motion, and param through to the step', () => {
-    const {text, gestures} = parseAgentGestures(
-      'about [size:big] this and [gesture:victory] that'
-    );
-    const steps = buildGestureSteps(text, gestures, 2);
-    expect(steps[0].motion).toBe('size');
-    expect(steps[0].param).toBe('big');
-    expect(steps[1].pose).toBe(gestures[1].pose);
-    expect(steps[1].param).toBeUndefined();
-  });
-
-  it('grounds a point gesture to the resolved world position (cloned)', () => {
+  it('grounds point markup to a copied world position', () => {
     const {text, gestures} = parseAgentGestures('over [point:the lamp] there');
     const lamp = new THREE.Vector3(1, 2, -3);
-    const steps = buildGestureSteps(text, gestures, 2, (target) =>
+    const [step] = buildGestureSteps(text, gestures, 2, (target) =>
       target === 'the lamp' ? lamp : null
     );
-    expect(steps[0].point).toBeInstanceOf(THREE.Vector3);
-    expect(steps[0].point!.equals(lamp)).toBe(true);
-    // Cloned, so the caller can mutate without affecting the source.
-    expect(steps[0].point).not.toBe(lamp);
+
+    expect(step.point?.equals(lamp)).toBe(true);
+    expect(step.point).not.toBe(lamp);
   });
 
-  it('leaves a point gesture without a point when it does not resolve', () => {
+  it('extracts the named target from point markup', () => {
+    const {text, gestures} = parseAgentGestures(
+      'It is right [gesture:point:the table] there.'
+    );
+
+    expect(text).toBe('It is right there.');
+    expect(gestures[0]).toMatchObject({
+      pose: SimulatorHandPose.POINTING,
+      target: 'the table',
+    });
+  });
+
+  it('leaves unresolved point markup without a target point', () => {
     const {text, gestures} = parseAgentGestures('over [point:the moon] there');
-    const steps = buildGestureSteps(text, gestures, 2, () => null);
-    expect(steps[0].point).toBeUndefined();
+    const [step] = buildGestureSteps(text, gestures, 2, () => null);
+
+    expect(step.point).toBeUndefined();
   });
 });

--- a/src/addons/agenthands/AgentHand.test.ts
+++ b/src/addons/agenthands/AgentHand.test.ts
@@ -1,8 +1,5 @@
-import {describe, it, expect, vi} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 
-// Importing from 'xrblocks' boots the Core singleton, which constructs a
-// THREE.AudioListener (and thus an AudioContext) jsdom can't provide. Stub it
-// before the barrel import, matching src/core/Core.test.ts.
 vi.hoisted(() => {
   vi.stubGlobal('AudioContext', function () {
     return {createGain: () => ({connect: () => {}}), destination: {}};
@@ -10,94 +7,35 @@ vi.hoisted(() => {
 });
 
 import * as THREE from 'three';
-import {
-  Handedness,
-  SimulatorHandPose,
-  type SimulatorHandPoseJoints,
-} from 'xrblocks';
+import type {SimulatorHandPoseJoints} from 'xrblocks';
 
-import {
-  AgentHand,
-  applyAgentHandAppearance,
-  lerpBonesToJoints,
-} from './AgentHand';
+import {applyAgentHandAppearance, lerpBonesToJoints} from './AgentHand';
 
-describe('lerpBonesToJoints', () => {
-  it('moves a bone fully to the target when lerp is 1', () => {
+describe('AgentHand helpers', () => {
+  it('interpolates matching bones and ignores incomplete hand data', () => {
     const bone = new THREE.Object3D();
-    const joints: SimulatorHandPoseJoints = [{t: [1, 2, 3], r: [0, 0, 0, 1]}];
-    lerpBonesToJoints([bone], joints, 1);
-    expect(bone.position.x).toBeCloseTo(1);
-    expect(bone.position.y).toBeCloseTo(2);
-    expect(bone.position.z).toBeCloseTo(3);
-  });
-
-  it('moves a bone partway when lerp is 0.5', () => {
-    const bone = new THREE.Object3D();
-    bone.position.set(0, 0, 0);
     const joints: SimulatorHandPoseJoints = [{t: [2, 0, 0], r: [0, 0, 0, 1]}];
-    lerpBonesToJoints([bone], joints, 0.5);
+
+    lerpBonesToJoints([bone, undefined], joints, 0.5);
+
     expect(bone.position.x).toBeCloseTo(1);
   });
 
-  it('skips undefined bones without throwing', () => {
-    const joints: SimulatorHandPoseJoints = [{t: [1, 1, 1], r: [0, 0, 0, 1]}];
-    expect(() => lerpBonesToJoints([undefined], joints, 1)).not.toThrow();
-  });
-
-  it('ignores joints with no matching bone', () => {
-    const bone = new THREE.Object3D();
-    const joints: SimulatorHandPoseJoints = [{t: [1, 0, 0], r: [0, 0, 0, 1]}];
-    // Two bones, one joint -> the second bone is left untouched.
-    const second = new THREE.Object3D();
-    lerpBonesToJoints([bone, second], joints, 1);
-    expect(bone.position.x).toBeCloseTo(1);
-    expect(second.position.x).toBeCloseTo(0);
-  });
-});
-
-describe('AgentHand', () => {
-  it('defaults to a relaxed pose before loading', () => {
-    const hand = new AgentHand(Handedness.RIGHT);
-    expect(hand.currentPose).toBe(SimulatorHandPose.RELAXED);
-    expect(hand.loaded).toBe(false);
-  });
-
-  it('setPose updates the target pose', () => {
-    const hand = new AgentHand(Handedness.LEFT);
-    hand.setPose(SimulatorHandPose.POINTING);
-    expect(hand.currentPose).toBe(SimulatorHandPose.POINTING);
-  });
-
-  it('animate is a no-op until loaded', () => {
-    const hand = new AgentHand(Handedness.RIGHT);
-    expect(() => hand.animate()).not.toThrow();
-  });
-});
-
-describe('applyAgentHandAppearance', () => {
-  it('makes every mesh a semi-transparent blue material', () => {
+  it('makes hand meshes translucent and transparent to selection rays', () => {
     const root = new THREE.Group();
     const mesh = new THREE.Mesh(
       new THREE.BoxGeometry(1, 1, 1),
       new THREE.MeshStandardMaterial({color: 0xffffff})
     );
     root.add(mesh);
+
     applyAgentHandAppearance(root);
-    const mat = mesh.material as THREE.MeshStandardMaterial;
-    expect(mat.transparent).toBe(true);
-    expect(mat.opacity).toBeLessThan(1);
-    expect(mat.color.b).toBeGreaterThan(mat.color.r);
-    // The hands must not block the UI selection beam behind them.
+
+    const material = mesh.material as THREE.MeshStandardMaterial;
+    expect(material.transparent).toBe(true);
+    expect(material.opacity).toBeLessThan(1);
     const hits: THREE.Intersection[] = [];
     mesh.raycast(new THREE.Raycaster(), hits);
     expect(hits).toHaveLength(0);
-  });
-
-  it('leaves non-mesh objects untouched', () => {
-    const root = new THREE.Group();
-    const group = new THREE.Group();
-    root.add(group);
-    expect(() => applyAgentHandAppearance(root)).not.toThrow();
   });
 });

--- a/src/addons/agenthands/AgentHands.test.ts
+++ b/src/addons/agenthands/AgentHands.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, vi} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 
 vi.hoisted(() => {
   vi.stubGlobal('AudioContext', function () {
@@ -12,113 +12,51 @@ import {SimulatorHandPose} from 'xrblocks';
 import {AgentHands} from './AgentHands';
 
 describe('AgentHands', () => {
-  it('starts unloaded with relaxed hands', () => {
-    const hands = new AgentHands();
-    expect(hands.loaded).toBe(false);
-    expect(hands.left.currentPose).toBe(SimulatorHandPose.RELAXED);
-    expect(hands.right.currentPose).toBe(SimulatorHandPose.RELAXED);
-  });
-
-  it('gesture() applies a pose to both hands by default', () => {
-    const hands = new AgentHands();
-    hands.gesture(SimulatorHandPose.POINTING);
-    expect(hands.left.currentPose).toBe(SimulatorHandPose.POINTING);
-    expect(hands.right.currentPose).toBe(SimulatorHandPose.POINTING);
-  });
-
-  it('gesture() can target a single hand', () => {
-    const hands = new AgentHands();
-    hands.gesture(SimulatorHandPose.THUMBS_UP, 'right');
-    expect(hands.right.currentPose).toBe(SimulatorHandPose.THUMBS_UP);
-    expect(hands.left.currentPose).toBe(SimulatorHandPose.RELAXED);
-  });
-
-  it('rest() relaxes both hands', () => {
+  it('applies and clears poses for both hands', () => {
     const hands = new AgentHands();
     hands.gesture(SimulatorHandPose.FIST);
+    expect(hands.left.currentPose).toBe(SimulatorHandPose.FIST);
+    expect(hands.right.currentPose).toBe(SimulatorHandPose.FIST);
+
     hands.rest();
     expect(hands.left.currentPose).toBe(SimulatorHandPose.RELAXED);
     expect(hands.right.currentPose).toBe(SimulatorHandPose.RELAXED);
   });
 
-  it('orient() applies a presentation orientation to both hands', () => {
+  it('can direct a gesture to one hand', () => {
     const hands = new AgentHands();
-    const left = vi.spyOn(hands.left, 'orient');
-    const right = vi.spyOn(hands.right, 'orient');
-    const q = new THREE.Quaternion().setFromAxisAngle(
-      new THREE.Vector3(1, 0, 0),
-      -Math.PI / 2
-    );
-    hands.orient(q);
-    expect(left).toHaveBeenCalledWith(q);
-    expect(right).toHaveBeenCalledWith(q);
+    hands.gesture(SimulatorHandPose.THUMBS_UP, 'right');
+
+    expect(hands.right.currentPose).toBe(SimulatorHandPose.THUMBS_UP);
+    expect(hands.left.currentPose).toBe(SimulatorHandPose.RELAXED);
   });
 
-  it('orient() can target a single hand', () => {
-    const hands = new AgentHands();
-    const left = vi.spyOn(hands.left, 'orient');
-    const right = vi.spyOn(hands.right, 'orient');
-    hands.orient(new THREE.Quaternion(), 'right');
-    expect(right).toHaveBeenCalledOnce();
-    expect(left).not.toHaveBeenCalled();
-  });
-
-  it('clearOrientation() clears the aim on both hands', () => {
-    const hands = new AgentHands();
-    const left = vi.spyOn(hands.left, 'clearAim');
-    const right = vi.spyOn(hands.right, 'clearAim');
-    hands.clearOrientation();
-    expect(left).toHaveBeenCalledOnce();
-    expect(right).toHaveBeenCalledOnce();
-  });
-
-  it('pointAt() routes to the named hand', () => {
-    const hands = new AgentHands();
-    const left = vi.spyOn(hands.left, 'aimAt').mockImplementation(() => {});
-    const right = vi.spyOn(hands.right, 'aimAt').mockImplementation(() => {});
-    const target = new THREE.Vector3(0, 1, -1);
-    hands.pointAt(target, 'left');
-    expect(left).toHaveBeenCalledWith(target);
-    expect(right).not.toHaveBeenCalled();
-  });
-
-  it('pointAt() relaxes the hand that is not pointing', () => {
-    const hands = new AgentHands();
-    vi.spyOn(hands.left, 'aimAt').mockImplementation(() => {});
-    vi.spyOn(hands.right, 'aimAt').mockImplementation(() => {});
-    // Point with the right hand, then with the left: the previously raised
-    // right hand must drop back to rest so only one hand ever points.
-    hands.pointAt(new THREE.Vector3(2, 1, -1), 'right');
-    hands.right.setPose(SimulatorHandPose.POINTING);
-    hands.pointAt(new THREE.Vector3(-2, 1, -1), 'left');
-    expect(hands.right.currentPose).toBe(SimulatorHandPose.RELAXED);
-  });
-
-  it('pointAt("both") picks the hand on the target side', () => {
-    const hands = new AgentHands();
-    const left = vi.spyOn(hands.left, 'aimAt').mockImplementation(() => {});
-    const right = vi.spyOn(hands.right, 'aimAt').mockImplementation(() => {});
-    hands.pointAt(new THREE.Vector3(2, 1, -1), 'both');
-    expect(right).toHaveBeenCalledOnce();
-    expect(left).not.toHaveBeenCalled();
-    hands.pointAt(new THREE.Vector3(-2, 1, -1), 'both');
-    expect(left).toHaveBeenCalledOnce();
-  });
-
-  it('pointAt("both") chooses the side in the hands local frame', () => {
-    // Rotate the pair 180 degrees so world +x maps to local -x. A world target
-    // on the +x side should then be the LEFT hand.
+  it('chooses the pointing hand from the target side in local space', () => {
     const hands = new AgentHands();
     hands.rotation.y = Math.PI;
     hands.updateMatrixWorld(true);
     const left = vi.spyOn(hands.left, 'aimAt').mockImplementation(() => {});
     const right = vi.spyOn(hands.right, 'aimAt').mockImplementation(() => {});
+
     hands.pointAt(new THREE.Vector3(2, 1, 0), 'both');
+
     expect(left).toHaveBeenCalledOnce();
     expect(right).not.toHaveBeenCalled();
   });
 
-  it('showCount() holds up the matching pose', () => {
+  it('rests the hand that stops pointing', () => {
+    const hands = new AgentHands();
+    vi.spyOn(hands.left, 'aimAt').mockImplementation(() => {});
+    vi.spyOn(hands.right, 'aimAt').mockImplementation(() => {});
+    hands.pointAt(new THREE.Vector3(2, 1, -1), 'right');
+    hands.right.setPose(SimulatorHandPose.POINTING);
+
+    hands.pointAt(new THREE.Vector3(-2, 1, -1), 'left');
+
+    expect(hands.right.currentPose).toBe(SimulatorHandPose.RELAXED);
+  });
+
+  it('selects count poses and returns to rest for unsupported counts', () => {
     const hands = new AgentHands();
     hands.showCount(1);
     expect(hands.right.currentPose).toBe(SimulatorHandPose.POINTING);
@@ -128,41 +66,41 @@ describe('AgentHands', () => {
     expect(hands.right.currentPose).toBe(SimulatorHandPose.RELAXED);
   });
 
-  it('beat() bobs both hands down over its duration', () => {
+  it('animates hand motion over time', () => {
     const hands = new AgentHands();
     hands.updateMatrixWorld(true);
+    let now = 1_000;
+    const clock = vi.spyOn(performance, 'now').mockImplementation(() => now);
     hands.beat('both');
-    // Drive the internal motion timer by stubbing the clock the update reads.
-    let now = 1000;
-    const spy = vi.spyOn(performance, 'now').mockImplementation(() => now);
     let maxDrop = 0;
     for (let i = 0; i < 20; i++) {
       now += 30;
       hands.update();
       maxDrop = Math.max(maxDrop, Math.abs(hands.left.motionOffset.y));
     }
-    spy.mockRestore();
+    clock.mockRestore();
+
     expect(maxDrop).toBeGreaterThan(0.02);
   });
 
-  it('showSize() spreads the two hands apart then settles', () => {
+  it('shows a requested size by separating both hands', () => {
     const hands = new AgentHands();
     hands.left.root.position.set(-0.16, 0, 0);
     hands.right.root.position.set(0.16, 0, 0);
-    hands.updateMatrixWorld(true);
+    let now = 2_000;
+    const clock = vi.spyOn(performance, 'now').mockImplementation(() => now);
     hands.showSize(0.5);
-    let now = 2000;
-    const spy = vi.spyOn(performance, 'now').mockImplementation(() => now);
-    let maxSpread = 0;
+    let maxSeparation = 0;
     for (let i = 0; i < 40; i++) {
       now += 30;
       hands.update();
-      maxSpread = Math.max(
-        maxSpread,
+      maxSeparation = Math.max(
+        maxSeparation,
         hands.left.motionOffset.distanceTo(hands.right.motionOffset)
       );
     }
-    spy.mockRestore();
-    expect(maxSpread).toBeGreaterThan(0.2);
+    clock.mockRestore();
+
+    expect(maxSeparation).toBeGreaterThan(0.2);
   });
 });

--- a/src/addons/agenthands/AgentHead.test.ts
+++ b/src/addons/agenthands/AgentHead.test.ts
@@ -11,12 +11,6 @@ import * as THREE from 'three';
 import {AgentHead} from './AgentHead';
 
 describe('AgentHead', () => {
-  it('builds an orb under its root', () => {
-    const head = new AgentHead();
-    expect(head.root).toBeInstanceOf(THREE.Object3D);
-    expect(head.root.children.length).toBeGreaterThan(0);
-  });
-
   it('clamps the speaking level and smooths toward it', () => {
     const head = new AgentHead();
     head.setSpeaking(5); // out of range, should clamp to 1

--- a/src/addons/agenthands/AgentSpeechConductor.test.ts
+++ b/src/addons/agenthands/AgentSpeechConductor.test.ts
@@ -152,11 +152,4 @@ describe('AgentSpeechConductor', () => {
     expect(() => conductor.speak('some words here', steps, 2)).not.toThrow();
     expect(boundary).toBeUndefined();
   });
-
-  it('does nothing when ticked with an empty timeline', () => {
-    const {conductor, fired, state} = harness();
-    expect(() => conductor.tick(5)).not.toThrow();
-    expect(fired).toHaveLength(0);
-    expect(state.rests).toBe(0);
-  });
 });

--- a/src/addons/agenthands/AgentWorld.test.ts
+++ b/src/addons/agenthands/AgentWorld.test.ts
@@ -127,28 +127,6 @@ describe('AgentWorld', () => {
     expect(restored.objects[0].point!.equals(hit)).toBe(true);
   });
 
-  it('marks scanned only after a scan completes, not on load', async () => {
-    const hit = new THREE.Vector3(1, 2, -3);
-    const detector = {
-      runDetection: vi.fn().mockResolvedValue([detected('lamp')]),
-    };
-    const opts = {
-      getDetector: () => detector,
-      getCamera: camera,
-      getDepthMesh: () => meshHitting(hit),
-      storageKey: 'agent_hands.scanned',
-    };
-    const world = new AgentWorld(opts);
-    expect(world.scanned).toBe(false);
-    await world.scan();
-    expect(world.scanned).toBe(true);
-
-    // A world restored from persisted objects has not scanned this session.
-    const restored = new AgentWorld(opts);
-    expect(restored.objects).toHaveLength(1);
-    expect(restored.scanned).toBe(false);
-  });
-
   it('auto-scans after moving past the threshold, not while stationary', async () => {
     const hit = new THREE.Vector3(0, 0, -1);
     const detector = {

--- a/src/addons/lipsync/BlendshapeReducer.test.ts
+++ b/src/addons/lipsync/BlendshapeReducer.test.ts
@@ -24,34 +24,23 @@ describe('blendshapesToVisemes', () => {
     expect(out).toEqual(ZERO_VISEME);
   });
 
-  it('jawOpen alone drives the aa channel and leaves oo / ee at zero', () => {
+  it('maps jaw, pucker, and stretch signals to their visible mouth shapes', () => {
     const out = blendshapesToVisemes(makeBlend({jawOpen: 0.8}));
     expect(out.aa).toBeGreaterThan(0.3);
     expect(out.jawOpen).toBeGreaterThan(0.3);
     expect(out.oo).toBe(0);
     expect(out.ee).toBe(0);
-  });
-
-  it('mouthPucker alone drives oo and leaves aa near zero', () => {
-    const out = blendshapesToVisemes(makeBlend({mouthPucker: 0.9}));
-    expect(out.oo).toBeGreaterThan(0.5);
-    expect(out.aa).toBe(0);
-  });
-
-  it('jawOpen + mouthPucker together produces the oh channel', () => {
-    const out = blendshapesToVisemes(
+    const pucker = blendshapesToVisemes(makeBlend({mouthPucker: 0.9}));
+    expect(pucker.oo).toBeGreaterThan(0.5);
+    expect(pucker.aa).toBe(0);
+    const rounded = blendshapesToVisemes(
       makeBlend({jawOpen: 0.7, mouthPucker: 0.7})
     );
-    expect(out.oh).toBeGreaterThan(0.2);
-  });
-
-  it('mouthStretch (not mouthSmile) drives the ee channel', () => {
+    expect(rounded.oh).toBeGreaterThan(0.2);
     const stretch = blendshapesToVisemes(
       makeBlend({mouthStretchLeft: 0.8, mouthStretchRight: 0.8})
     );
     expect(stretch.ee).toBeGreaterThan(0.4);
-
-    // mouthSmile is a much weaker contributor — verify it alone doesn't dominate.
     const smile = blendshapesToVisemes(
       makeBlend({mouthSmileLeft: 0.8, mouthSmileRight: 0.8})
     );

--- a/src/addons/lipsync/FormantVisemeMapper.test.ts
+++ b/src/addons/lipsync/FormantVisemeMapper.test.ts
@@ -69,13 +69,6 @@ describe('FormantVisemeMapper', () => {
     expect(out.aa).toBeGreaterThan(out.ee);
   });
 
-  it('a single frame of full input does not fully transfer (smoothing on)', () => {
-    const m = new FormantVisemeMapper();
-    const out = m.update(vowel(800, 1300), 0.016);
-    // After one ~16ms frame, jawOpen should still be well below 1.
-    expect(out.jawOpen).toBeLessThan(0.8);
-  });
-
   it('frame-rate-independent: 60 Hz and 120 Hz converge to same value at same wall-clock time', () => {
     const features = vowel(800, 1300);
     // Step at 16.67ms for 30 frames = ~500ms wall clock.
@@ -113,14 +106,5 @@ describe('FormantVisemeMapper', () => {
     const firstEe = m.update(vowel(300, 2400), 0.016);
     expect(firstEe.ee).toBeGreaterThan(firstEe.oo);
     expect(firstEe.ee).toBeGreaterThan(firstEe.aa);
-  });
-
-  it('reset() returns to zero state', () => {
-    const m = new FormantVisemeMapper();
-    settle(m, vowel(800, 1300));
-    m.reset();
-    const out = m.update(silence(), 0.016);
-    expect(out.jawOpen).toBeLessThan(0.05);
-    expect(out.aa).toBe(0);
   });
 });

--- a/src/addons/lipsync/LipsyncMouth.test.ts
+++ b/src/addons/lipsync/LipsyncMouth.test.ts
@@ -24,6 +24,9 @@ import {LipsyncMouth, VisemeTarget} from './LipsyncMouth';
 import type {VisemeWeights} from './BlendshapeReducer';
 import {ZERO_VISEME} from './BlendshapeReducer';
 
+vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue();
+vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+
 /**
  * Stand-in for an xrblocks `StylizedFace`: captures the most recent
  * viseme weights so tests can assert against them. Real consumers
@@ -112,14 +115,6 @@ beforeEach(() => {
 });
 
 describe('LipsyncMouth', () => {
-  it('is a THREE.Object3D suitable for parenting to a head pivot', () => {
-    const m = new LipsyncMouth(makeStream(), {
-      target: new FakeTarget(),
-      audioContext: ctx as unknown as AudioContext,
-    });
-    expect(m.isObject3D).toBe(true);
-  });
-
   it('constructor + init() builds the audio graph from the injected AudioContext', async () => {
     const m = new LipsyncMouth(makeStream(), {
       target: new FakeTarget(),
@@ -128,18 +123,6 @@ describe('LipsyncMouth', () => {
     await m.init();
     expect(ctx.createMediaStreamSource).toHaveBeenCalled();
     expect(ctx.createAnalyser).toHaveBeenCalled();
-  });
-
-  it('drives the supplied target instead of owning a visual itself', async () => {
-    const target = new FakeTarget();
-    const m = new LipsyncMouth(makeStream(), {
-      target,
-      audioContext: ctx as unknown as AudioContext,
-    });
-    await m.init();
-    // No visual children — the target is the only thing rendering.
-    expect(m.children.length).toBe(0);
-    expect(m.target).toBe(target);
   });
 
   it('update() drives the target visemes when audio is loud / voiced', async () => {
@@ -155,17 +138,6 @@ describe('LipsyncMouth', () => {
     analyser.__setLoudVoiced();
     for (let i = 0; i < 50; i++) m.update(i * 0.016);
     expect(target.visemes.jawOpen).toBeGreaterThan(0.05);
-  });
-
-  it('silent input → target stays at rest', async () => {
-    const target = new FakeTarget();
-    const m = new LipsyncMouth(makeStream(), {
-      target,
-      audioContext: ctx as unknown as AudioContext,
-    });
-    await m.init();
-    for (let i = 0; i < 50; i++) m.update(i * 16);
-    expect(target.visemes.jawOpen).toBeLessThan(0.05);
   });
 
   it('loud then silent: brief silence holds visemes; sustained silence decays them', async () => {
@@ -201,29 +173,6 @@ describe('LipsyncMouth', () => {
     expect(target.visemes.ee).toBeLessThan(0.02);
     expect(target.visemes.oo).toBeLessThan(0.02);
     expect(target.visemes.consonant).toBeLessThan(0.02);
-  });
-
-  it('voiced resumes mid-hold: silence timer resets, target never began decaying', async () => {
-    const target = new FakeTarget();
-    const m = new LipsyncMouth(makeStream(), {
-      target,
-      audioContext: ctx as unknown as AudioContext,
-    });
-    await m.init();
-    const analyser = ctx.createAnalyser.mock.results[0]
-      .value as MockAnalyserNode;
-    analyser.__setLoudVoiced();
-    for (let i = 0; i < 60; i++) m.update(i * 16);
-    const peakJaw = target.visemes.jawOpen;
-
-    // 100 ms silent gap (within the 150 ms hold), then voiced again.
-    analyser.__setSilent();
-    m.update(60 * 16 + 50);
-    m.update(60 * 16 + 100);
-    expect(target.visemes.jawOpen).toBe(peakJaw);
-    analyser.__setLoudVoiced();
-    m.update(60 * 16 + 116);
-    expect(target.visemes.jawOpen).toBeGreaterThan(peakJaw * 0.8);
   });
 
   it('Schmitt hysteresis: noise-floor RMS chatter around silenceThreshold still accumulates the hold timer', async () => {
@@ -270,11 +219,15 @@ describe('LipsyncMouth', () => {
     expect(target.visemes).toEqual(ZERO_VISEME);
   });
 
-  it('dispose() disconnects analyser + source but does NOT dispose the target (caller owns it)', async () => {
+  it('dispose() releases its graph but preserves caller-owned resources', async () => {
     const target = new FakeTarget();
     const disposeSpy = vi.fn();
     (target as unknown as {dispose: () => void}).dispose = disposeSpy;
-    const m = new LipsyncMouth(makeStream(), {
+    const stream = makeStream();
+    const track = {stop: vi.fn()} as unknown as MediaStreamTrack;
+    (stream as unknown as {getTracks: () => MediaStreamTrack[]}).getTracks =
+      () => [track];
+    const m = new LipsyncMouth(stream, {
       target,
       audioContext: ctx as unknown as AudioContext,
     });
@@ -287,56 +240,7 @@ describe('LipsyncMouth', () => {
     expect(source.disconnect).toHaveBeenCalled();
     expect(analyser.disconnect).toHaveBeenCalled();
     expect(disposeSpy).not.toHaveBeenCalled();
-  });
-
-  it('dispose() does NOT close the injected AudioContext (caller owns it)', async () => {
-    const m = new LipsyncMouth(makeStream(), {
-      target: new FakeTarget(),
-      audioContext: ctx as unknown as AudioContext,
-    });
-    await m.init();
-    m.dispose();
     expect(ctx.close).not.toHaveBeenCalled();
-  });
-
-  it('dispose() does NOT stop MediaStream tracks (caller owns the stream)', async () => {
-    const stream = makeStream();
-    const track = {
-      stop: vi.fn(),
-      kind: 'audio',
-      enabled: true,
-    } as unknown as MediaStreamTrack;
-    // jsdom MediaStream doesn't expose addTrack consistently; monkey-patch
-    // getTracks instead since that's what consumers iterate.
-    (stream as unknown as {getTracks: () => MediaStreamTrack[]}).getTracks =
-      () => [track];
-    const m = new LipsyncMouth(stream, {
-      target: new FakeTarget(),
-      audioContext: ctx as unknown as AudioContext,
-    });
-    await m.init();
-    m.dispose();
     expect(track.stop).not.toHaveBeenCalled();
-  });
-
-  it('two LipsyncMouths can share one AudioContext and one target each', async () => {
-    const t1 = new FakeTarget();
-    const t2 = new FakeTarget();
-    const m1 = new LipsyncMouth(makeStream(), {
-      target: t1,
-      audioContext: ctx as unknown as AudioContext,
-    });
-    const m2 = new LipsyncMouth(makeStream(), {
-      target: t2,
-      audioContext: ctx as unknown as AudioContext,
-    });
-    await m1.init();
-    await m2.init();
-    expect(ctx.createMediaStreamSource).toHaveBeenCalledTimes(2);
-    // Disposing one leaves the other working.
-    m1.dispose();
-    expect(ctx.close).not.toHaveBeenCalled();
-    expect(m2.target).toBe(t2);
-    m2.dispose();
   });
 });

--- a/src/addons/lipsync/MfccExtractor.test.ts
+++ b/src/addons/lipsync/MfccExtractor.test.ts
@@ -23,14 +23,6 @@ describe('MfccExtractor', () => {
     expect(NUM_MFCC).toBe(13);
   });
 
-  it('is deterministic: same input twice produces the same coefficients', () => {
-    const ext = new MfccExtractor({sampleRate, fftSize});
-    const input = makeTone(256, 30, -20);
-    const a = Float32Array.from(ext.extract(input));
-    const b = Float32Array.from(ext.extract(input));
-    expect(Array.from(a)).toEqual(Array.from(b));
-  });
-
   it('silence (all -120 dB) yields finite, small-magnitude coefficients', () => {
     const ext = new MfccExtractor({sampleRate, fftSize});
     const silent = new Float32Array(256).fill(-120);
@@ -54,14 +46,5 @@ describe('MfccExtractor', () => {
     for (let i = 1; i < NUM_MFCC; i++)
       totalDiff += Math.abs(lowOut[i] - highOut[i]);
     expect(totalDiff).toBeGreaterThan(1);
-  });
-
-  it('handles different FFT sizes (256 and 1024)', () => {
-    for (const size of [256, 1024]) {
-      const ext = new MfccExtractor({sampleRate, fftSize: size});
-      const out = ext.extract(makeTone(size / 2, 10, -10));
-      expect(out).toHaveLength(NUM_MFCC);
-      for (const v of out) expect(Number.isFinite(v)).toBe(true);
-    }
   });
 });

--- a/src/addons/lipsync/computeAudioFeatures.test.ts
+++ b/src/addons/lipsync/computeAudioFeatures.test.ts
@@ -25,17 +25,6 @@ describe('computeAudioFeatures', () => {
     expect(f.f2Hz).toBe(0);
   });
 
-  it('a sine wave in time-domain gives a non-zero rms', () => {
-    const inputs = silentInputs();
-    // Half-amplitude sine in [0,255] domain (128 == 0 in -1..+1 mapping).
-    for (let i = 0; i < inputs.timeData.length; i++) {
-      inputs.timeData[i] = 128 + Math.round(64 * Math.sin((i / 16) * Math.PI));
-    }
-    const f = computeAudioFeatures(inputs, SAMPLE_RATE);
-    expect(f.rms).toBeGreaterThan(0.1);
-    expect(f.rms).toBeLessThanOrEqual(1);
-  });
-
   it('energy concentrated at low frequencies → low band > high band, low centroid', () => {
     const inputs = silentInputs();
     // Crank up the first 20 bins (~< 1 kHz at this sampleRate).
@@ -71,23 +60,6 @@ describe('computeAudioFeatures', () => {
     expect(f.f2Hz).toBeLessThan(2500);
   });
 
-  it('f2 search ignores strong energy in adjacent bins outside the search range', () => {
-    // Boundary contamination check: with a wide 5-bin moving-average
-    // peak picker, a very loud single bin just below the F2 search
-    // range floor (800 Hz) could otherwise leak into the average for
-    // the lowest in-range bin and make it win against a real F2
-    // plateau higher up.
-    const inputs = silentInputs();
-    const binHz = SAMPLE_RATE / 2 / NUM_BINS;
-    const justBelowF2Bin = Math.floor(700 / binHz);
-    const realF2Bin = Math.round(2200 / binHz);
-    inputs.freqData[justBelowF2Bin] = 255;
-    for (let k = -2; k <= 2; k++) inputs.freqData[realF2Bin + k] = 140;
-    const f = computeAudioFeatures(inputs, SAMPLE_RATE);
-    expect(f.f2Hz).toBeGreaterThan(1800);
-    expect(f.f2Hz).toBeLessThan(2500);
-  });
-
   it('forwards the supplied mfcc vector through to the output', () => {
     const inputs = silentInputs();
     inputs.mfcc = Float32Array.from([
@@ -98,12 +70,5 @@ describe('computeAudioFeatures', () => {
     expect(Array.from(f.mfcc!)).toEqual([
       1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
     ]);
-  });
-
-  it('omits the mfcc field when none is supplied', () => {
-    const inputs = silentInputs();
-    inputs.mfcc = undefined;
-    const f = computeAudioFeatures(inputs, SAMPLE_RATE);
-    expect(f.mfcc).toBeUndefined();
   });
 });

--- a/src/addons/netblocks/samples/roomCode.test.ts
+++ b/src/addons/netblocks/samples/roomCode.test.ts
@@ -17,28 +17,18 @@ describe('roomCode helpers', () => {
   afterEach(() => setSearch(originalSearch));
 
   describe('getRoomCodeFromUrl', () => {
-    it('returns null when ?room is missing', () => {
-      expect(getRoomCodeFromUrl()).toBeNull();
-    });
-
-    it('returns the code uppercased when length matches', () => {
+    it('normalizes valid room codes', () => {
       setSearch('?room=abcd');
       expect(getRoomCodeFromUrl()).toBe('ABCD');
-    });
-
-    it('strips non-letters before length-checking', () => {
       setSearch('?room=AB-CD');
       expect(getRoomCodeFromUrl()).toBe('ABCD');
     });
 
-    it('returns null for codes that are the wrong length', () => {
+    it('rejects malformed room codes', () => {
       setSearch('?room=ABC');
       expect(getRoomCodeFromUrl()).toBeNull();
       setSearch('?room=ABCDE');
       expect(getRoomCodeFromUrl()).toBeNull();
-    });
-
-    it('returns null when the cleaned code is empty', () => {
       setSearch('?room=1234');
       expect(getRoomCodeFromUrl()).toBeNull();
     });
@@ -74,15 +64,6 @@ describe('roomCode helpers', () => {
       expect(text).toContain('ABCD');
       expect(text).toContain('Copy code');
       expect(text).toContain('Leave');
-    });
-
-    it('anchors the HUD top-left below the sample HUD so they do not overlap', () => {
-      buildRoomCodeHud('ABCD');
-      const root = document.body.firstElementChild as HTMLElement;
-      expect(root.style.position).toBe('fixed');
-      expect(root.style.top).toBe('90px');
-      expect(root.style.left).toBe('12px');
-      expect(root.style.bottom).toBe('');
     });
 
     it('Copy code button writes the code (not the URL) to the clipboard', async () => {

--- a/src/addons/netblocks/src/core/NetSession.test.ts
+++ b/src/addons/netblocks/src/core/NetSession.test.ts
@@ -16,6 +16,17 @@ vi.mock('xrblocks', async () => {
   };
 });
 
+vi.mock('troika-three-text', async () => {
+  const T = await import('three');
+  return {
+    Text: class extends T.Object3D {
+      text = '';
+      sync() {}
+      dispose() {}
+    },
+  };
+});
+
 import {
   decodeMessage,
   encodeMessage,
@@ -85,23 +96,6 @@ describe('NetSession hello handler', () => {
     expect(snapshot!.to).toBe('joiner');
     expect(snapshot!.msg.objects.map((o) => o.id)).toEqual(['cube-1']);
     expect(snapshot!.msg.objects[0].xform.slice(0, 3)).toEqual([1, 2, 3]);
-  });
-
-  it('does not send a snapshot when no NetObjects are dirty', async () => {
-    const transport = new FakeTransport();
-    const session = new NetSession(transport, new THREE.Group());
-    await session.open('room');
-    session.netObjects.add(new NetObject({id: 'cube-1'}));
-
-    transport.sent.length = 0;
-    transport.receive('joiner', {
-      type: 'hello',
-      protocol: NET_PROTOCOL_VERSION,
-      capabilities: {pose: true, voice: true, netobject: true},
-    } as HelloMessage);
-
-    const types = decodeSent(transport.sent).map((d) => d.msg.type);
-    expect(types).not.toContain('netobject.snapshot');
   });
 
   it('always replies with a welcome to the joiner', async () => {

--- a/src/addons/netblocks/src/core/Peers.test.ts
+++ b/src/addons/netblocks/src/core/Peers.test.ts
@@ -14,6 +14,17 @@ vi.mock('xrblocks', async () => {
   };
 });
 
+vi.mock('troika-three-text', async () => {
+  const T = await import('three');
+  return {
+    Text: class extends T.Object3D {
+      text = '';
+      sync() {}
+      dispose() {}
+    },
+  };
+});
+
 import {encodeMessage, HelloMessage, NetMessage} from './codec/MessageCodec';
 import {NET_PROTOCOL_VERSION} from './constants/NetConstants';
 import {NetCore} from './NetCore';
@@ -58,12 +69,6 @@ describe('Peers facade', () => {
     net = new NetCore(root);
   });
 
-  it('list() is empty before joinRoom and after leaveRoom', () => {
-    expect(net.peers.list()).toEqual([]);
-    expect(net.peers.remoteUsers).toEqual([]);
-    expect(net.user.peerId).toBeUndefined();
-  });
-
   it('subscriptions registered before joinRoom fire on remote join', async () => {
     const onJoin = vi.fn();
     const onLeave = vi.fn();
@@ -88,19 +93,6 @@ describe('Peers facade', () => {
     transport.fakePeerLeave('peer-a');
     expect(onLeave).toHaveBeenCalledTimes(1);
     expect(net.peers.list()).toEqual([]);
-  });
-
-  it('off() unsubscribes', async () => {
-    const onJoin = vi.fn();
-    const dispose = net.peers.on('join', onJoin);
-
-    const transport = new FakeTransport();
-    await net.joinRoom('room', {transport});
-
-    dispose();
-    transport.fakePeerJoin('peer-x');
-    transport.receive('peer-x', helloFrom('peer-x'));
-    expect(onJoin).not.toHaveBeenCalled();
   });
 
   it('subscriptions persist across rejoin', async () => {

--- a/src/addons/netblocks/src/core/PresenceBroadcaster.test.ts
+++ b/src/addons/netblocks/src/core/PresenceBroadcaster.test.ts
@@ -70,12 +70,4 @@ describe('PresenceBroadcaster', () => {
     expect(sent).toHaveLength(1);
     expect(sent[0].type).toBe('pose');
   });
-
-  it('survives an empty user object (XR not yet started)', () => {
-    mockCore.camera = makeCamera();
-    mockCore.user = {hands: undefined};
-    const b = new PresenceBroadcaster(send, 60);
-    expect(() => b.update(1000)).not.toThrow();
-    expect(sent).toHaveLength(1);
-  });
 });

--- a/src/addons/netblocks/src/core/codec/MessageCodec.test.ts
+++ b/src/addons/netblocks/src/core/codec/MessageCodec.test.ts
@@ -8,7 +8,6 @@ import {
   makeHello,
   HelloMessage,
   NetObjectSnapshotMessage,
-  PoseMessage,
 } from './MessageCodec';
 
 describe('MessageCodec', () => {
@@ -21,16 +20,6 @@ describe('MessageCodec', () => {
         capabilities: {pose: true, voice: true, netobject: true},
         from: 'peer-A',
         ts: 12345,
-      };
-      const decoded = decodeMessage(encodeMessage(msg));
-      expect(decoded).toEqual(msg);
-    });
-
-    it('round-trips a pose message', () => {
-      const msg: PoseMessage = {
-        type: 'pose',
-        data: 'AAECAwQF', // arbitrary base64
-        from: 'peer-B',
       };
       const decoded = decodeMessage(encodeMessage(msg));
       expect(decoded).toEqual(msg);
@@ -59,12 +48,6 @@ describe('MessageCodec', () => {
       expect(decoded).toEqual(msg);
     });
 
-    it('decodes from a string directly', () => {
-      const json = '{"type":"ping","nonce":42}';
-      const decoded = decodeMessage(json);
-      expect(decoded.type).toBe('ping');
-    });
-
     it('decodes from an ArrayBuffer', () => {
       const bytes = encodeMessage({type: 'ping', nonce: 7});
       const buf = bytes.slice().buffer; // detach to a real ArrayBuffer
@@ -77,16 +60,6 @@ describe('MessageCodec', () => {
       // size check fires before JSON parsing.
       const bytes = new Uint8Array(MAX_MESSAGE_BYTES + 1);
       expect(() => decodeMessage(bytes)).toThrow(/MAX_MESSAGE_BYTES/);
-    });
-
-    it('throws on oversized strings too', () => {
-      const big = 'a'.repeat(MAX_MESSAGE_BYTES + 1);
-      expect(() => decodeMessage(big)).toThrow(/MAX_MESSAGE_BYTES/);
-    });
-
-    it('throws on oversized ArrayBuffer too', () => {
-      const buf = new ArrayBuffer(MAX_MESSAGE_BYTES + 1);
-      expect(() => decodeMessage(buf)).toThrow(/MAX_MESSAGE_BYTES/);
     });
 
     it('throws on malformed JSON', () => {
@@ -120,15 +93,6 @@ describe('MessageCodec', () => {
       expect(hello.protocol).toBe(1);
       expect(hello.displayName).toBe('Bob');
       expect(hello.capabilities).toEqual(caps);
-    });
-
-    it('allows undefined displayName', () => {
-      const hello = makeHello(undefined, {
-        pose: false,
-        voice: false,
-        netobject: false,
-      });
-      expect(hello.displayName).toBeUndefined();
     });
   });
 });

--- a/src/addons/netblocks/src/core/codec/PoseCodec.test.ts
+++ b/src/addons/netblocks/src/core/codec/PoseCodec.test.ts
@@ -177,23 +177,6 @@ describe('PoseCodec', () => {
       }
     });
 
-    it('produces base64 output without spaces or newlines', () => {
-      const b64 = bytesToBase64(new Uint8Array([1, 2, 3, 4, 5]));
-      expect(b64).toMatch(/^[A-Za-z0-9+/=]+$/);
-    });
-
-    it('emits the right number of pad characters', () => {
-      // 1 byte → 2 pad, 2 bytes → 1 pad, 3 bytes → 0 pad
-      expect(bytesToBase64(new Uint8Array([1])).endsWith('==')).toBe(true);
-      expect(
-        bytesToBase64(new Uint8Array([1, 2])).endsWith('=') &&
-          !bytesToBase64(new Uint8Array([1, 2])).endsWith('==')
-      ).toBe(true);
-      expect(bytesToBase64(new Uint8Array([1, 2, 3])).endsWith('=')).toBe(
-        false
-      );
-    });
-
     it('throws on invalid characters in required positions', () => {
       // First two sextets are required for any output byte.
       expect(() => base64ToBytes('!!')).toThrow();

--- a/src/addons/netblocks/src/core/objects/NetObject.test.ts
+++ b/src/addons/netblocks/src/core/objects/NetObject.test.ts
@@ -3,19 +3,9 @@ import {describe, it, expect} from 'vitest';
 import {NetObject} from './NetObject';
 
 describe('NetObject', () => {
-  it('generates a stable id when none is provided', () => {
-    const obj = new NetObject();
-    expect(obj.netId).toMatch(/^obj_/);
-    expect(obj.netId.length).toBeGreaterThan(4);
-  });
-
   it('uses an explicit id when provided', () => {
     const obj = new NetObject({id: 'cube-7'});
     expect(obj.netId).toBe('cube-7');
-  });
-
-  it('starts unowned by default', () => {
-    expect(new NetObject().ownerId).toBe('');
   });
 
   it('isOwnedBy reflects current owner', () => {
@@ -38,15 +28,6 @@ describe('NetObject', () => {
       expect(x.slice(7, 10)).toEqual([2, 3, 4]);
     });
 
-    it('setTargetXform sets target without touching local transform', () => {
-      const obj = new NetObject();
-      obj.setTargetXform([5, 5, 5, 0, 0, 0, 1, 1, 1, 1]);
-      expect(obj._targetPosition.toArray()).toEqual([5, 5, 5]);
-      expect(obj._hasTarget).toBe(true);
-      // Local transform untouched.
-      expect(obj.position.toArray()).toEqual([0, 0, 0]);
-    });
-
     it('snapToXform writes local transform and clears target', () => {
       const obj = new NetObject();
       obj.setTargetXform([5, 5, 5, 0, 0, 0, 1, 1, 1, 1]);
@@ -58,13 +39,6 @@ describe('NetObject', () => {
   });
 
   describe('stepInterpolation', () => {
-    it('does nothing when there is no target', () => {
-      const obj = new NetObject();
-      obj.position.set(1, 2, 3);
-      obj.stepInterpolation(0.5);
-      expect(obj.position.toArray()).toEqual([1, 2, 3]);
-    });
-
     it('lerps position toward target', () => {
       const obj = new NetObject();
       obj.position.set(0, 0, 0);
@@ -79,49 +53,6 @@ describe('NetObject', () => {
       obj.setTargetXform([10, 0, 0, 0, 0, 0, 1, 1, 1, 1]);
       obj.stepInterpolation(5); // way past 1
       expect(obj.position.x).toBeCloseTo(10, 5);
-    });
-  });
-
-  describe('_dirty flag', () => {
-    it('starts false on a fresh NetObject', () => {
-      expect(new NetObject()._dirty).toBe(false);
-    });
-
-    it('is set by setTargetXform', () => {
-      const obj = new NetObject();
-      obj.setTargetXform([1, 2, 3, 0, 0, 0, 1, 1, 1, 1]);
-      expect(obj._dirty).toBe(true);
-    });
-
-    it('is set by snapToXform', () => {
-      const obj = new NetObject();
-      obj.snapToXform([1, 2, 3, 0, 0, 0, 1, 1, 1, 1]);
-      expect(obj._dirty).toBe(true);
-    });
-  });
-
-  describe('_pendingFinal', () => {
-    it('starts false on a fresh NetObject', () => {
-      expect(new NetObject()._pendingFinal).toBe(false);
-    });
-
-    it('snapToXform clears _pendingFinal', () => {
-      const obj = new NetObject();
-      obj._pendingFinal = true;
-      obj.snapToXform([1, 2, 3, 0, 0, 0, 1, 1, 1, 1]);
-      expect(obj._pendingFinal).toBe(false);
-    });
-
-    it('stepInterpolation finalises and clears _pendingFinal once converged', () => {
-      const obj = new NetObject();
-      obj.position.set(0, 0, 0);
-      obj.setTargetXform([1, 0, 0, 0, 0, 0, 1, 1, 1, 1]);
-      obj._pendingFinal = true;
-      // Run enough steps for the lerp to converge below 1mm.
-      for (let i = 0; i < 200; i++) obj.stepInterpolation(0.5);
-      expect(obj._pendingFinal).toBe(false);
-      expect(obj._hasTarget).toBe(false);
-      expect(obj.position.x).toBeCloseTo(1, 6);
     });
   });
 });

--- a/src/addons/netblocks/src/core/objects/NetObjectRegistry.test.ts
+++ b/src/addons/netblocks/src/core/objects/NetObjectRegistry.test.ts
@@ -4,32 +4,7 @@ import {NetObject} from './NetObject';
 import {NetObjectRegistry} from './NetObjectRegistry';
 
 describe('NetObjectRegistry', () => {
-  it('add / get / has / remove work as expected', () => {
-    const reg = new NetObjectRegistry();
-    const obj = new NetObject({id: 'cube-1'});
-    reg.add(obj);
-    expect(reg.has('cube-1')).toBe(true);
-    expect(reg.get('cube-1')).toBe(obj);
-    reg.remove(obj);
-    expect(reg.has('cube-1')).toBe(false);
-    expect(reg.get('cube-1')).toBeUndefined();
-  });
-
-  it('values() iterates registered objects', () => {
-    const reg = new NetObjectRegistry();
-    const a = new NetObject({id: 'a'});
-    const b = new NetObject({id: 'b'});
-    reg.add(a);
-    reg.add(b);
-    expect([...reg.values()]).toEqual(expect.arrayContaining([a, b]));
-  });
-
   describe('applyClaim', () => {
-    it('returns false for unknown id', () => {
-      const reg = new NetObjectRegistry();
-      expect(reg.applyClaim('nope', 'peer-A')).toBe(false);
-    });
-
     it('grants ownership unconditionally — explicit grabs preempt', () => {
       const reg = new NetObjectRegistry();
       const obj = new NetObject({id: 'cube-1', ownerId: 'peer-A'});
@@ -37,42 +12,9 @@ describe('NetObjectRegistry', () => {
       expect(reg.applyClaim('cube-1', 'peer-B')).toBe(true);
       expect(obj.ownerId).toBe('peer-B');
     });
-
-    it('clears any pending interp target on ownership change', () => {
-      const reg = new NetObjectRegistry();
-      const obj = new NetObject({id: 'cube-1', ownerId: 'peer-A'});
-      obj.setTargetXform([1, 2, 3, 0, 0, 0, 1, 1, 1, 1]);
-      reg.add(obj);
-      reg.applyClaim('cube-1', 'peer-B');
-      expect(obj._hasTarget).toBe(false);
-    });
-
-    it('does not clear target when peer reclaims their own object', () => {
-      const reg = new NetObjectRegistry();
-      const obj = new NetObject({id: 'cube-1', ownerId: 'peer-A'});
-      obj.setTargetXform([1, 2, 3, 0, 0, 0, 1, 1, 1, 1]);
-      reg.add(obj);
-      reg.applyClaim('cube-1', 'peer-A');
-      expect(obj._hasTarget).toBe(true);
-    });
-
-    it('clears _pendingFinal when ownership transfers — the new owner is about to broadcast their own pose', () => {
-      const reg = new NetObjectRegistry();
-      const obj = new NetObject({id: 'cube-1', ownerId: 'peer-A'});
-      obj.setTargetXform([1, 2, 3, 0, 0, 0, 1, 1, 1, 1]);
-      obj._pendingFinal = true;
-      reg.add(obj);
-      reg.applyClaim('cube-1', 'peer-B');
-      expect(obj._pendingFinal).toBe(false);
-    });
   });
 
   describe('applyRelease', () => {
-    it('returns false for unknown id', () => {
-      const reg = new NetObjectRegistry();
-      expect(reg.applyRelease('nope', 'peer-A')).toBe(false);
-    });
-
     it('only the current owner may release', () => {
       const reg = new NetObjectRegistry();
       const obj = new NetObject({id: 'cube-1', ownerId: 'peer-A'});
@@ -84,11 +26,9 @@ describe('NetObjectRegistry', () => {
     it('clears ownership and pending target on success', () => {
       const reg = new NetObjectRegistry();
       const obj = new NetObject({id: 'cube-1', ownerId: 'peer-A'});
-      obj.setTargetXform([1, 2, 3, 0, 0, 0, 1, 1, 1, 1]);
       reg.add(obj);
       expect(reg.applyRelease('cube-1', 'peer-A')).toBe(true);
       expect(obj.ownerId).toBe('');
-      expect(obj._hasTarget).toBe(false);
     });
   });
 
@@ -105,14 +45,6 @@ describe('NetObjectRegistry', () => {
       expect(a.ownerId).toBe('');
       expect(b.ownerId).toBe('');
       expect(c.ownerId).toBe('peer-B');
-    });
-
-    it('is a no-op when the peer owns nothing', () => {
-      const reg = new NetObjectRegistry();
-      const a = new NetObject({id: 'a', ownerId: 'peer-A'});
-      reg.add(a);
-      reg.releaseOwnedBy('peer-Z');
-      expect(a.ownerId).toBe('peer-A');
     });
   });
 });

--- a/src/addons/netblocks/src/core/presence/InterpolatedPose.test.ts
+++ b/src/addons/netblocks/src/core/presence/InterpolatedPose.test.ts
@@ -27,19 +27,6 @@ function makeSnap(x: number): PoseSnapshot {
 }
 
 describe('InterpolatedPose', () => {
-  it('hasData is false until a snapshot is pushed', () => {
-    const ip = new InterpolatedPose();
-    expect(ip.hasData).toBe(false);
-  });
-
-  it('latestTs reflects the newest pushed snapshot', () => {
-    const ip = new InterpolatedPose();
-    ip.push(makeSnap(0), 100);
-    expect(ip.latestTs).toBe(100);
-    ip.push(makeSnap(1), 150);
-    expect(ip.latestTs).toBe(150);
-  });
-
   it('drops out-of-order snapshots', () => {
     const ip = new InterpolatedPose();
     ip.push(makeSnap(0), 100);
@@ -63,22 +50,6 @@ describe('InterpolatedPose', () => {
     expect(s.head.position.x).toBeCloseTo(5, 5);
   });
 
-  it('reaches the new snapshot at t=1', () => {
-    const ip = new InterpolatedPose();
-    ip.push(makeSnap(0), 100);
-    ip.push(makeSnap(10), 200);
-    const s = ip.sample(200);
-    expect(s.head.position.x).toBeCloseTo(10, 5);
-  });
-
-  it('clamps `now` before the prev snapshot to t=0', () => {
-    const ip = new InterpolatedPose();
-    ip.push(makeSnap(0), 100);
-    ip.push(makeSnap(10), 200);
-    const s = ip.sample(50); // before prev
-    expect(s.head.position.x).toBeCloseTo(0, 5);
-  });
-
   it('extrapolates up to MAX_EXTRAPOLATION (25%) past the latest', () => {
     const ip = new InterpolatedPose();
     ip.push(makeSnap(0), 100);
@@ -93,16 +64,6 @@ describe('InterpolatedPose', () => {
     ip.push(makeSnap(0), 100);
     ip.push(makeSnap(10), 100); // same ts
     expect(() => ip.sample(100)).not.toThrow();
-  });
-
-  it('returns the same scratch object reference across calls', () => {
-    // Documented contract: callers must clone the result if they want to keep it.
-    const ip = new InterpolatedPose();
-    ip.push(makeSnap(0), 100);
-    ip.push(makeSnap(10), 200);
-    const a = ip.sample(120);
-    const b = ip.sample(180);
-    expect(a).toBe(b);
   });
 
   describe('hand interpolation', () => {

--- a/src/addons/netblocks/src/core/presence/RemoteUserAvatar.test.ts
+++ b/src/addons/netblocks/src/core/presence/RemoteUserAvatar.test.ts
@@ -1,5 +1,4 @@
 import {describe, expect, it, vi} from 'vitest';
-import * as THREE from 'three';
 
 // RemoteUserAvatar uses `xb.StylizedFace` to attach a face to the
 // default head; stub it with a bare Object3D so the test scaffolding
@@ -32,38 +31,6 @@ vi.mock('troika-three-text', async () => {
 import {RemoteUserAvatar} from './RemoteUserAvatar';
 
 describe('RemoteUserAvatar default face', () => {
-  it('attaches a face to the default head so it inherits the head pose', () => {
-    const avatar = new RemoteUserAvatar({peerId: 'peer-1'});
-    // The face must be parented under the default head sphere — that
-    // way it follows head transforms automatically AND disappears
-    // when a host app hides the default avatar via
-    // `avatar.defaultMesh.visible = false`.
-    const headSphere = avatar.defaultMesh.children.find(
-      (c) => c instanceof THREE.Mesh
-    );
-    expect(headSphere).toBeDefined();
-    expect(headSphere!.children).toContain(avatar.face);
-  });
-
-  it('hiding the default mesh hides the face too', () => {
-    const avatar = new RemoteUserAvatar({peerId: 'peer-1'});
-    avatar.defaultMesh.visible = false;
-    avatar.defaultMesh.updateMatrixWorld(true);
-    // Three's visibility cascades down the scene graph; the face is
-    // under defaultMesh > headSphere, so the renderer will skip it
-    // whenever defaultMesh is invisible. Walk the parents to confirm.
-    let node: THREE.Object3D | null = avatar.face;
-    let hidden = false;
-    while (node) {
-      if (!node.visible) {
-        hidden = true;
-        break;
-      }
-      node = node.parent;
-    }
-    expect(hidden).toBe(true);
-  });
-
   it('dispose() releases the face', () => {
     const avatar = new RemoteUserAvatar({peerId: 'peer-1'});
     const disposeSpy = (avatar.face as unknown as {dispose: () => void})

--- a/src/addons/netblocks/src/core/rpc/NetEvents.test.ts
+++ b/src/addons/netblocks/src/core/rpc/NetEvents.test.ts
@@ -11,16 +11,12 @@ function makeEvents() {
 }
 
 describe('NetEvents', () => {
-  it('emit() sends a broadcast rpc envelope', () => {
+  it('sends broadcast and directed rpc envelopes', () => {
     const {events, sent} = makeEvents();
     events.emit('chat', {text: 'hi'});
-    expect(sent).toEqual([{type: 'rpc', topic: 'chat', payload: {text: 'hi'}}]);
-  });
-
-  it('emitTo() sets the `to` field for unicast', () => {
-    const {events, sent} = makeEvents();
     events.emitTo('peer-B', 'ping', 42);
     expect(sent).toEqual([
+      {type: 'rpc', topic: 'chat', payload: {text: 'hi'}},
       {type: 'rpc', topic: 'ping', payload: 42, to: 'peer-B'},
     ]);
   });
@@ -42,20 +38,6 @@ describe('NetEvents', () => {
     expect(b).toHaveBeenCalledWith('hello', 'peer-A');
   });
 
-  it('off() removes a handler', () => {
-    const {events} = makeEvents();
-    const handler = vi.fn();
-    events.on('chat', handler);
-    events.off('chat', handler);
-    events._dispatch({
-      type: 'rpc',
-      topic: 'chat',
-      payload: 'hi',
-      from: 'peer-A',
-    } as RpcMessage);
-    expect(handler).not.toHaveBeenCalled();
-  });
-
   it('_dispatch fans out to every subscriber of a topic', () => {
     const {events} = makeEvents();
     const a = vi.fn();
@@ -70,26 +52,6 @@ describe('NetEvents', () => {
     } as RpcMessage);
     expect(a).toHaveBeenCalledWith({text: 'yo'}, 'peer-A');
     expect(b).toHaveBeenCalledWith({text: 'yo'}, 'peer-A');
-  });
-
-  it('_dispatch ignores topics with no subscribers', () => {
-    const {events} = makeEvents();
-    expect(() =>
-      events._dispatch({
-        type: 'rpc',
-        topic: 'unknown',
-        payload: null,
-        from: 'peer-A',
-      } as RpcMessage)
-    ).not.toThrow();
-  });
-
-  it('_dispatch ignores messages with no `from`', () => {
-    const {events} = makeEvents();
-    const handler = vi.fn();
-    events.on('chat', handler);
-    events._dispatch({type: 'rpc', topic: 'chat', payload: 'x'} as RpcMessage);
-    expect(handler).not.toHaveBeenCalled();
   });
 
   it('a throwing handler does not break sibling handlers', () => {

--- a/src/addons/netblocks/src/core/transport/WebSocketTransport.test.ts
+++ b/src/addons/netblocks/src/core/transport/WebSocketTransport.test.ts
@@ -99,20 +99,6 @@ describe('WebSocketTransport', () => {
     });
   });
 
-  it('resolves connect() on welcome and adopts server-assigned peer id', async () => {
-    const t = new WebSocketTransport({
-      url: 'ws://test',
-      reconnectAttempts: 0,
-    });
-    const connected = t.connect({roomId: 'r'});
-    const ws = FakeWebSocket.last!;
-    ws.fireOpen();
-    ws.fireServerMessage({type: 'welcome', peerId: 'assigned-id', peers: []});
-    await connected;
-    expect(t.isOpen).toBe(true);
-    expect(t.localPeerId).toBe('assigned-id');
-  });
-
   it('emits peer-join for each existing peer in the welcome list', async () => {
     const t = new WebSocketTransport({
       url: 'ws://test',
@@ -180,28 +166,6 @@ describe('WebSocketTransport', () => {
     expect(frame.type).toBe('send');
     expect(frame.to).toBeUndefined();
     expect(frame.data).toBe(bytesToBase64(new Uint8Array([9, 9])));
-  });
-
-  it('send(payload, target) frames a direct send', async () => {
-    const {t, ws, connected} = makeWelcomed();
-    await connected;
-    ws.sent.length = 0;
-    t.send(new Uint8Array([7]), 'alice');
-    const frame = JSON.parse(ws.sent[0]);
-    expect(frame.to).toBe('alice');
-  });
-
-  it('send() is a no-op before the welcome frame arrives', () => {
-    const t = new WebSocketTransport({
-      url: 'ws://test',
-      reconnectAttempts: 0,
-    });
-    t.connect({roomId: 'r', peerId: 'me'});
-    const ws = FakeWebSocket.last!;
-    ws.fireOpen();
-    const sentBefore = ws.sent.length; // includes the join frame
-    t.send(new Uint8Array([1]));
-    expect(ws.sent.length).toBe(sentBefore);
   });
 
   it('emits peer-leave for known peers and a close event when the socket closes', async () => {
@@ -281,15 +245,5 @@ describe('WebSocketTransport', () => {
     ws.fireRawMessage('{not json');
     expect(errors.length).toBe(1);
     expect(errors[0]).toBeInstanceOf(Error);
-  });
-
-  it('forwards relayed error frames to the error event', async () => {
-    const {t, ws, connected} = makeWelcomed();
-    await connected;
-    const errors: Error[] = [];
-    t.on('error', (e) => errors.push((e as CustomEvent).detail.error));
-    ws.fireServerMessage({type: 'error', message: 'room is full'});
-    expect(errors.length).toBe(1);
-    expect(errors[0].message).toBe('room is full');
   });
 });

--- a/src/addons/netblocks/src/core/utils/IdUtils.test.ts
+++ b/src/addons/netblocks/src/core/utils/IdUtils.test.ts
@@ -4,12 +4,8 @@ import {makeId, hashStringToHue} from './IdUtils';
 
 describe('IdUtils', () => {
   describe('makeId', () => {
-    it('returns a 12-char string by default', () => {
-      const id = makeId();
-      expect(id).toHaveLength(12);
-    });
-
-    it('honours the requested length', () => {
+    it('uses the default and requested lengths', () => {
+      expect(makeId()).toHaveLength(12);
       expect(makeId(1)).toHaveLength(1);
       expect(makeId(32)).toHaveLength(32);
       expect(makeId(0)).toHaveLength(0);
@@ -18,14 +14,6 @@ describe('IdUtils', () => {
     it('produces only URL-safe alphanumeric characters', () => {
       const id = makeId(64);
       expect(id).toMatch(/^[a-zA-Z0-9]+$/);
-    });
-
-    it('produces different ids on consecutive calls', () => {
-      // 12 chars of 62-symbol alphabet has ~71 bits of entropy; any
-      // collision in 1000 calls would mean the RNG is broken.
-      const ids = new Set<string>();
-      for (let i = 0; i < 1000; i++) ids.add(makeId());
-      expect(ids.size).toBe(1000);
     });
   });
 
@@ -41,13 +29,6 @@ describe('IdUtils', () => {
     it('is deterministic for the same input', () => {
       expect(hashStringToHue('peer-1')).toBe(hashStringToHue('peer-1'));
       expect(hashStringToHue('xyz')).toBe(hashStringToHue('xyz'));
-    });
-
-    it('typically produces different hues for different inputs', () => {
-      const hues = new Set<number>();
-      for (let i = 0; i < 100; i++) hues.add(hashStringToHue(`peer-${i}`));
-      // FNV-1a over short strings shouldn't collide on 100 sequential ids.
-      expect(hues.size).toBeGreaterThan(95);
     });
   });
 });

--- a/src/addons/netblocks/src/core/voice/VoiceChat.test.ts
+++ b/src/addons/netblocks/src/core/voice/VoiceChat.test.ts
@@ -25,22 +25,6 @@ describe('VoiceChat subscriptions', () => {
     expect(a).toHaveBeenCalledTimes(1);
     expect(b).toHaveBeenCalledTimes(2);
   });
-
-  it('onTrackRemoved supports multiple listeners with idempotent unsubscribe', () => {
-    const vc = new VoiceChat(() => {});
-    const a = vi.fn();
-    const unsub = vc.onTrackRemoved(a);
-    const inner = vc as unknown as {
-      _onTrackRemoved: Set<(peerId: string) => void>;
-    };
-    for (const h of inner._onTrackRemoved) h('p1');
-    expect(a).toHaveBeenCalledTimes(1);
-
-    unsub();
-    unsub(); // idempotent
-    for (const h of inner._onTrackRemoved) h('p2');
-    expect(a).toHaveBeenCalledTimes(1);
-  });
 });
 
 describe('VoiceChat re-negotiation signalling', () => {
@@ -105,23 +89,6 @@ describe('VoiceChat re-negotiation signalling', () => {
     expect(peers.has('peer-b')).toBe(true);
   });
 
-  it('handleSignal(hello) is a no-op when we are not enabled', async () => {
-    const send = vi.fn();
-    const vc = new VoiceChat(send);
-    vc.setLocalPeerId('aaa'); // lower id, would normally be the offerer
-
-    await vc.handleSignal('zzz', {
-      type: 'voice',
-      to: 'aaa',
-      signal: {kind: 'hello'},
-    });
-
-    expect(send).not.toHaveBeenCalled();
-    expect((vc as unknown as {_peers: Map<string, unknown>})._peers.size).toBe(
-      0
-    );
-  });
-
   it('handleSignal(hello) is ignored when the local side is not the natural offerer', async () => {
     const send = vi.fn();
     const vc = new VoiceChat(send);
@@ -169,13 +136,6 @@ describe('VoiceChat onLocalStateChange', () => {
         value: origNav,
       });
     }
-  });
-
-  it('disable() without prior enable() does not fire onLocalStateChange', () => {
-    const onLocalStateChange = vi.fn();
-    const vc = new VoiceChat(() => {}, {onLocalStateChange});
-    vc.disable();
-    expect(onLocalStateChange).not.toHaveBeenCalled();
   });
 
   it('disable() during a pending enable() cancels it: stream stopped, no false state flip', async () => {

--- a/src/camera/CameraUtils.test.ts
+++ b/src/camera/CameraUtils.test.ts
@@ -22,23 +22,17 @@ function makeDeviceCamera(withSimulatorCamera: boolean): XRDeviceCamera {
 }
 
 describe('isDeviceCameraPoseAvailable', () => {
-  it('is false with no device camera and no XR cameras', () => {
+  it('is false before either camera source is ready', () => {
     expect(isDeviceCameraPoseAvailable(undefined, null)).toBe(false);
-  });
-
-  it('is false when the XR array camera has no cameras yet', () => {
     expect(isDeviceCameraPoseAvailable(undefined, makeXrCameras(0))).toBe(
       false
     );
   });
 
-  it('is true once the simulator camera is registered', () => {
+  it('is true when the simulator or XR camera is ready', () => {
     expect(isDeviceCameraPoseAvailable(makeDeviceCamera(true), null)).toBe(
       true
     );
-  });
-
-  it('is true once the XR session exposes cameras', () => {
     expect(isDeviceCameraPoseAvailable(undefined, makeXrCameras(2))).toBe(true);
   });
 });

--- a/src/camera/XRDeviceCamera.test.ts
+++ b/src/camera/XRDeviceCamera.test.ts
@@ -197,22 +197,6 @@ describe('XRDeviceCamera', () => {
     warnSpy.mockRestore();
   });
 
-  it('falls back to XR camera access when a renderer is available', async () => {
-    const getUserMediaError = new Error('NotReadableError');
-    vi.mocked(navigator.mediaDevices.getUserMedia).mockRejectedValue(
-      getUserMediaError
-    );
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    camera.setRenderer(createMockRenderer('immersive-vr', ['camera-access']));
-
-    await expect(camera.init()).resolves.toBeUndefined();
-    expect(camera.isUsingXRCameraAccess).toBe(true);
-    expect(camera.state).toBe(StreamState.INITIALIZING);
-
-    warnSpy.mockRestore();
-  });
-
   it('surfaces getUserMedia errors when no renderer is available', async () => {
     const getUserMediaError = new Error('NotReadableError');
     vi.mocked(navigator.mediaDevices.getUserMedia).mockRejectedValue(
@@ -227,35 +211,9 @@ describe('XRDeviceCamera', () => {
     errorSpy.mockRestore();
   });
 
-  it('falls back to XR camera access when no video devices are enumerated', async () => {
-    vi.mocked(navigator.mediaDevices.enumerateDevices).mockResolvedValue([]);
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    camera.setRenderer(createMockRenderer('immersive-ar', ['camera-access']));
-
-    await expect(camera.init()).resolves.toBeUndefined();
-    expect(camera.isUsingXRCameraAccess).toBe(true);
-    expect(camera.state).toBe(StreamState.INITIALIZING);
-
-    warnSpy.mockRestore();
-  });
-
   it('reports NO_DEVICES_FOUND when no devices and no renderer', async () => {
     vi.mocked(navigator.mediaDevices.enumerateDevices).mockResolvedValue([]);
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    await expect(camera.init()).resolves.toBeUndefined();
-    expect(camera.isUsingXRCameraAccess).toBe(false);
-    expect(camera.state).toBe(StreamState.NO_DEVICES_FOUND);
-
-    warnSpy.mockRestore();
-  });
-
-  it('reports NO_DEVICES_FOUND when camera-access was not granted', async () => {
-    vi.mocked(navigator.mediaDevices.enumerateDevices).mockResolvedValue([]);
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    camera.setRenderer(createMockRenderer('immersive-ar', []));
 
     await expect(camera.init()).resolves.toBeUndefined();
     expect(camera.isUsingXRCameraAccess).toBe(false);

--- a/src/depth/Depth.test.ts
+++ b/src/depth/Depth.test.ts
@@ -98,20 +98,7 @@ describe('Depth', () => {
   });
 
   describe('shouldUpdateDepthMesh throttling', () => {
-    it('always updates when depthMeshUpdateFps is 0', () => {
-      const depth = createDepth();
-      depth.options.depthMesh.depthMeshUpdateFps = 0;
-
-      // Access the private method via bracket notation.
-      const shouldUpdate = (depth as unknown as Record<string, () => boolean>)[
-        'shouldUpdateDepthMesh'
-      ];
-      expect(shouldUpdate.call(depth)).toBe(true);
-      expect(shouldUpdate.call(depth)).toBe(true);
-      expect(shouldUpdate.call(depth)).toBe(true);
-    });
-
-    it('throttles updates when depthMeshUpdateFps is set', () => {
+    it('throttles updates until the configured interval has passed', () => {
       const depth = createDepth();
       depth.options.depthMesh.depthMeshUpdateFps = 10; // 100ms between updates
 
@@ -124,17 +111,6 @@ describe('Depth', () => {
 
       // Immediate second call should be throttled.
       expect(shouldUpdate.call(depth)).toBe(false);
-    });
-
-    it('allows update after enough time has passed', () => {
-      const depth = createDepth();
-      depth.options.depthMesh.depthMeshUpdateFps = 10; // 100ms interval
-
-      const shouldUpdate = (depth as unknown as Record<string, () => boolean>)[
-        'shouldUpdateDepthMesh'
-      ];
-
-      expect(shouldUpdate.call(depth)).toBe(true);
 
       // Fast-forward time by 150ms.
       vi.spyOn(performance, 'now').mockReturnValue(performance.now() + 150);

--- a/src/input/GamepadBindings.test.ts
+++ b/src/input/GamepadBindings.test.ts
@@ -17,7 +17,7 @@ describe('GamepadBindings', () => {
     expect(bindings.getBinding('openSettings')).toBe(9);
   });
 
-  it('persists bindings to localStorage', () => {
+  it('persists and reloads customized bindings', () => {
     const bindings = new GamepadBindings();
     bindings.setBinding('select', 1);
 
@@ -28,36 +28,17 @@ describe('GamepadBindings', () => {
     const parsed = JSON.parse(stored!);
     expect(parsed.version).toBe(1);
     expect(parsed.bindings.select).toBe(1);
+    expect(new GamepadBindings().getBinding('select')).toBe(1);
   });
 
-  it('loads persisted bindings', () => {
-    localStorage.setItem(
-      'xrblocks:simulator:gamepad-bindings:v1',
-      JSON.stringify({version: 1, bindings: {select: 3, toggleUI: 7}})
-    );
-    const bindings = new GamepadBindings();
-    expect(bindings.getBinding('select')).toBe(3);
-    expect(bindings.getBinding('toggleUI')).toBe(7);
-    // Non-stored keys keep defaults
-    expect(bindings.getBinding('cycleHandPoseLeft')).toBe(14);
-  });
-
-  it('falls back to defaults on malformed localStorage', () => {
-    localStorage.setItem(
-      'xrblocks:simulator:gamepad-bindings:v1',
-      'not valid json'
-    );
-    const bindings = new GamepadBindings();
-    expect(bindings.getBinding('select')).toBe(0);
-  });
-
-  it('falls back to defaults on wrong version', () => {
-    localStorage.setItem(
-      'xrblocks:simulator:gamepad-bindings:v1',
-      JSON.stringify({version: 99, bindings: {select: 5}})
-    );
-    const bindings = new GamepadBindings();
-    expect(bindings.getBinding('select')).toBe(0);
+  it('falls back to defaults for invalid stored data', () => {
+    for (const stored of [
+      'not valid json',
+      JSON.stringify({version: 99, bindings: {select: 5}}),
+    ]) {
+      localStorage.setItem('xrblocks:simulator:gamepad-bindings:v1', stored);
+      expect(new GamepadBindings().getBinding('select')).toBe(0);
+    }
   });
 
   it('auto-unbinds duplicate when setting a binding', () => {
@@ -68,20 +49,10 @@ describe('GamepadBindings', () => {
     expect(bindings.getBinding('select')).toBe(-1); // unbound
   });
 
-  it('does not unbind self when re-setting same button', () => {
-    const bindings = new GamepadBindings();
-    bindings.setBinding('select', 0); // same as default
-    expect(bindings.getBinding('select')).toBe(0);
-  });
-
-  it('refuses to rebind openSettings', () => {
+  it('keeps the settings binding reserved', () => {
     const bindings = new GamepadBindings();
     bindings.setBinding('openSettings', 0);
     expect(bindings.getBinding('openSettings')).toBe(9);
-  });
-
-  it('does not unbind openSettings when another action steals its button', () => {
-    const bindings = new GamepadBindings();
     bindings.setBinding('select', 9); // openSettings is on 9
     expect(bindings.getBinding('select')).toBe(0); // refused, kept default
     expect(bindings.getBinding('openSettings')).toBe(9);
@@ -110,20 +81,17 @@ describe('GamepadBindings', () => {
     expect(bindings.getBinding('select')).toBe(0); // not affected
   });
 
-  it('handles localStorage throwing gracefully', () => {
+  it('continues when browser storage is unavailable', () => {
     const spy = vi
       .spyOn(Storage.prototype, 'getItem')
       .mockImplementation(() => {
         throw new Error('SecurityError');
       });
     // Should not throw
-    const bindings = new GamepadBindings();
-    expect(bindings.getBinding('select')).toBe(0);
+    const bindingsWithUnavailableStorage = new GamepadBindings();
+    expect(bindingsWithUnavailableStorage.getBinding('select')).toBe(0);
     spy.mockRestore();
-  });
-
-  it('handles localStorage.setItem throwing gracefully', () => {
-    const spy = vi
+    const saveSpy = vi
       .spyOn(Storage.prototype, 'setItem')
       .mockImplementation(() => {
         throw new Error('QuotaExceeded');
@@ -132,6 +100,6 @@ describe('GamepadBindings', () => {
     // Should not throw
     bindings.setBinding('select', 3);
     expect(bindings.getBinding('select')).toBe(3); // in-memory still works
-    spy.mockRestore();
+    saveSpy.mockRestore();
   });
 });

--- a/src/input/GamepadController.test.ts
+++ b/src/input/GamepadController.test.ts
@@ -11,17 +11,9 @@ describe('GamepadController', () => {
       expect(GamepadController.applyDeadzone(0.14)).toBe(0);
     });
 
-    it('returns remapped value outside deadzone', () => {
-      const result = GamepadController.applyDeadzone(1.0);
-      expect(result).toBeCloseTo(1.0, 2);
-    });
-
-    it('returns negative remapped value for negative input', () => {
-      const result = GamepadController.applyDeadzone(-1.0);
-      expect(result).toBeCloseTo(-1.0, 2);
-    });
-
-    it('remaps linearly from deadzone edge', () => {
+    it('preserves direction and remaps values outside the deadzone', () => {
+      expect(GamepadController.applyDeadzone(1.0)).toBeCloseTo(1.0, 2);
+      expect(GamepadController.applyDeadzone(-1.0)).toBeCloseTo(-1.0, 2);
       // At exactly the deadzone boundary, should be ~0
       const atEdge = GamepadController.applyDeadzone(0.15);
       expect(atEdge).toBeCloseTo(0, 1);
@@ -31,11 +23,8 @@ describe('GamepadController', () => {
       expect(mid).toBeCloseTo(0.5, 1);
     });
 
-    it('returns 0 for NaN', () => {
+    it('returns 0 for invalid input', () => {
       expect(GamepadController.applyDeadzone(NaN)).toBe(0);
-    });
-
-    it('returns 0 for Infinity', () => {
       expect(GamepadController.applyDeadzone(Infinity)).toBe(0);
       expect(GamepadController.applyDeadzone(-Infinity)).toBe(0);
     });

--- a/src/input/headGestures/gestureRecognizers/HeuristicHeadGestureRecognizer.test.ts
+++ b/src/input/headGestures/gestureRecognizers/HeuristicHeadGestureRecognizer.test.ts
@@ -12,7 +12,8 @@ type PoseAngles = {
 };
 
 describe('HeuristicHeadGestureRecognizer', () => {
-  it.each([1, -1])('recognizes a nod starting in direction %s', (direction) => {
+  it('recognizes a nod that starts upward', () => {
+    const direction = 1;
     const recognizer = new HeuristicHeadGestureRecognizer();
     const samples = createSamples(900, (time) => ({
       pitch:

--- a/src/simulator/handPoses/HandPoseIK.test.ts
+++ b/src/simulator/handPoses/HandPoseIK.test.ts
@@ -11,65 +11,55 @@ import {
 } from './HandPoseFK';
 
 describe('HandPose Inverse Kinematics (IK)', () => {
-  const poses = [
-    SimulatorHandPose.NEUTRAL,
-    SimulatorHandPose.RELAXED,
-    SimulatorHandPose.PINCHING,
-    SimulatorHandPose.FIST,
-    SimulatorHandPose.THUMBS_UP,
-    SimulatorHandPose.POINTING,
-    SimulatorHandPose.ROCK,
-    SimulatorHandPose.THUMBS_DOWN,
-    SimulatorHandPose.VICTORY,
-  ];
+  const representativePoses = [
+    [Handedness.LEFT, SimulatorHandPose.NEUTRAL, false],
+    [Handedness.RIGHT, SimulatorHandPose.NEUTRAL, false],
+    [Handedness.LEFT, SimulatorHandPose.PINCHING, true],
+    [Handedness.RIGHT, SimulatorHandPose.FIST, true],
+    [Handedness.LEFT, SimulatorHandPose.POINTING, false],
+    [Handedness.RIGHT, SimulatorHandPose.VICTORY, false],
+  ] as const;
 
-  const handednesses = [Handedness.LEFT, Handedness.RIGHT];
+  it.each(representativePoses)(
+    'roundtrips the %s %s pose (constraints: %s)',
+    (handedness, pose, applyConstraints) => {
+      const originalRotations = SIMULATOR_HAND_POSE_ROTATIONS[pose];
 
-  for (const handedness of handednesses) {
-    describe(`${handedness} hand poses`, () => {
-      for (const pose of poses) {
-        for (const applyConstraints of [false, true]) {
-          it(`should accurately roundtrip ${pose} pose (applyConstraints: ${applyConstraints})`, () => {
-            const originalRotations = SIMULATOR_HAND_POSE_ROTATIONS[pose];
+      // Run FK to get joint positions.
+      const joints = resolveSimulatorHandPoseRotations(
+        handedness,
+        originalRotations,
+        applyConstraints
+      );
+      // Run IK to get rotations back from the keypoints.
+      const computedRotations = resolveSimulatorRotationsFromKeypoints(
+        handedness,
+        joints,
+        false
+      );
 
-            // Run FK to get joint positions.
-            const joints = resolveSimulatorHandPoseRotations(
-              handedness,
-              originalRotations,
-              applyConstraints
-            );
-            // Run IK to get rotations back from the keypoints.
-            const computedRotations = resolveSimulatorRotationsFromKeypoints(
-              handedness,
-              joints,
-              false
-            );
+      // Run FK again using the computed rotations.
+      const recomputedJoints = resolveSimulatorHandPoseRotations(
+        handedness,
+        computedRotations,
+        false
+      );
 
-            // Run FK again using the computed rotations.
-            const recomputedJoints = resolveSimulatorHandPoseRotations(
-              handedness,
-              computedRotations,
-              false
-            );
+      for (let i = 0; i < HAND_JOINT_NAMES.length; i++) {
+        const jointName = HAND_JOINT_NAMES[i];
+        const originalPos = new THREE.Vector3().fromArray(joints[i].t);
+        const recomputedPos = new THREE.Vector3().fromArray(
+          recomputedJoints[i].t
+        );
 
-            for (let i = 0; i < HAND_JOINT_NAMES.length; i++) {
-              const jointName = HAND_JOINT_NAMES[i];
-              const originalPos = new THREE.Vector3().fromArray(joints[i].t);
-              const recomputedPos = new THREE.Vector3().fromArray(
-                recomputedJoints[i].t
-              );
-
-              const distance = originalPos.distanceTo(recomputedPos);
-              expect(
-                distance,
-                `Joint ${jointName} in pose ${pose} for ${handedness} hand should match original position (diff: ${distance}m)`
-              ).toBeLessThan(1e-4);
-            }
-          });
-        }
+        const distance = originalPos.distanceTo(recomputedPos);
+        expect(
+          distance,
+          `Joint ${jointName} in pose ${pose} for ${handedness} hand should match original position (diff: ${distance}m)`
+        ).toBeLessThan(1e-4);
       }
-    });
-  }
+    }
+  );
 
   it('should enforce biomechanical constraints when applyConstraints = true', () => {
     // Let's create keypoints where the index finger PIP joint is hyperextended to -45 degrees (constraint is [0, 110] degrees).

--- a/src/utils/BVHRaycast.test.ts
+++ b/src/utils/BVHRaycast.test.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import {describe, expect, it, vi} from 'vitest';
+import {describe, expect, it} from 'vitest';
 
 import {
   applyBVH,
@@ -17,16 +17,6 @@ describe('BVHRaycast', () => {
     const proto = THREE.BufferGeometry.prototype as any;
     expect(typeof proto.computeBoundsTree).toBe('function');
     expect(typeof proto.disposeBoundsTree).toBe('function');
-  });
-
-  it('is idempotent: re-calling enableAcceleratedRaycast returns same result and does not re-patch', async () => {
-    const first = await enableAcceleratedRaycast();
-    const second = await enableAcceleratedRaycast();
-    expect(first).toBe(true);
-    expect(second).toBe(true);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const proto = THREE.BufferGeometry.prototype as any;
-    expect(typeof proto.computeBoundsTree).toBe('function');
   });
 
   it('applyBVH builds a boundsTree on every mesh in the tree (recursive)', async () => {
@@ -87,37 +77,6 @@ describe('BVHRaycast', () => {
     expect((m.geometry as any).boundsTree).toBeFalsy();
   });
 
-  it('applyBVH skips SkinnedMesh subclasses (they override raycast on their own prototype, so BVH would be ignored anyway)', async () => {
-    const root = new THREE.Group();
-    const skinned = new THREE.SkinnedMesh(new THREE.BoxGeometry());
-    root.add(skinned);
-    await applyBVH(root);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((skinned.geometry as any).boundsTree).toBeUndefined();
-  });
-
-  it('applyBVH builds a boundsTree on InstancedMesh (its raycast does route through Mesh.prototype per-instance)', async () => {
-    const root = new THREE.Group();
-    const inst = new THREE.InstancedMesh(
-      new THREE.BoxGeometry(),
-      new THREE.MeshBasicMaterial(),
-      4
-    );
-    root.add(inst);
-    await applyBVH(root);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((inst.geometry as any).boundsTree).toBeDefined();
-  });
-
-  it('applyBVH skips BatchedMesh (three-mesh-bvh needs the batched-specific helpers)', async () => {
-    const root = new THREE.Group();
-    const batched = new THREE.BatchedMesh(1, 8, 12);
-    root.add(batched);
-    await applyBVH(root);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((batched.geometry as any).boundsTree).toBeUndefined();
-  });
-
   it('applyBVH applies the right policy to a mixed tree of Mesh + SkinnedMesh + InstancedMesh + BatchedMesh + non-mesh in a single call', async () => {
     const root = new THREE.Group();
     const mesh = new THREE.Mesh(new THREE.BoxGeometry());
@@ -166,20 +125,5 @@ describe('BVHRaycast', () => {
     expect(hits[0].point.x).toBeCloseTo(0, 5);
     expect(hits[0].point.y).toBeCloseTo(0, 5);
     expect(hits[0].point.z).toBeCloseTo(0, 5);
-  });
-
-  it('disposeBVH is a safe no-op when called before any BVH was built (cold module state)', async () => {
-    // Force a fresh module copy so bvhProtoPatched starts at false again,
-    // simulating an app that calls disposeBVH(root) before any
-    // enableAcceleratedRaycast / applyBVH ever resolved.
-    vi.resetModules();
-    const fresh = await import('./BVHRaycast');
-    const root = new THREE.Group();
-    const m = new THREE.Mesh(new THREE.BoxGeometry());
-    root.add(m);
-    // Must not throw; must not touch the geometry.
-    expect(() => fresh.disposeBVH(root)).not.toThrow();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((m.geometry as any).boundsTree).toBeUndefined();
   });
 });

--- a/src/video/VideoStream.test.ts
+++ b/src/video/VideoStream.test.ts
@@ -1,5 +1,5 @@
 import type {VideoTexture} from 'three';
-import {describe, expect, it} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 
 import {VideoStream} from './VideoStream';
 
@@ -45,5 +45,27 @@ describe('VideoStream', () => {
     texture.update();
 
     expect(texture.version).toBeGreaterThan(initialVersion);
+  });
+
+  it('stops active tracks and releases textures on dispose', () => {
+    const stream = new VideoStream();
+    const stop = vi.fn();
+    const mediaStream = {
+      getTracks: () => [{stop}],
+    } as unknown as MediaStream;
+    const internal = stream as unknown as {stream_: MediaStream | null};
+    internal.stream_ = mediaStream;
+    Object.defineProperty(stream.video, 'srcObject', {
+      configurable: true,
+      writable: true,
+      value: mediaStream,
+    });
+    const disposeTexture = vi.spyOn(stream.texture, 'dispose');
+
+    stream.dispose();
+
+    expect(stop).toHaveBeenCalledOnce();
+    expect(stream.video.srcObject).toBeNull();
+    expect(disposeTexture).toHaveBeenCalledOnce();
   });
 });

--- a/src/world/faces/DetectedFace.test.ts
+++ b/src/world/faces/DetectedFace.test.ts
@@ -93,17 +93,6 @@ describe('DetectedFace', () => {
     expect(face.getLandmarkPosition(FaceLandmarkName.NoseTip)).toBeNull();
   });
 
-  it('getLandmarkPosition returns a clone so callers can mutate safely', () => {
-    const landmarks = makeLandmarks({1: [0.5, 0.5, 0, [1, 2, 3]]});
-    const face = new DetectedFace(0, landmarks, makeBbox());
-    const a = face.getLandmarkPosition(FaceLandmarkName.NoseTip)!;
-    a.set(0, 0, 0);
-    const b = face.getLandmarkPosition(FaceLandmarkName.NoseTip)!;
-    expect(b.x).toBeCloseTo(1);
-    expect(b.y).toBeCloseTo(2);
-    expect(b.z).toBeCloseTo(3);
-  });
-
   it('getBlendshape looks up by ARKit category name and falls back to 0', () => {
     const landmarks = makeLandmarks({});
     const blendshapes: FaceBlendshape[] = [
@@ -116,25 +105,5 @@ describe('DetectedFace', () => {
     // Unknown / unemitted categories: 0, not undefined.
     expect(face.getBlendshape('mouthSmileRight')).toBe(0);
     expect(face.getBlendshape('notARealBlendshape')).toBe(0);
-  });
-
-  it('handles an empty blendshapes array (backend configured with output disabled)', () => {
-    const face = new DetectedFace(0, makeLandmarks({}), makeBbox());
-    expect(face.blendshapes).toHaveLength(0);
-    expect(face.getBlendshape('jawOpen')).toBe(0);
-  });
-
-  it('extends Object3D so it slots into the scene graph', () => {
-    const face = new DetectedFace(0, makeLandmarks({}), makeBbox());
-    expect(face).toBeInstanceOf(THREE.Object3D);
-    // Should be add()-able to a parent.
-    const parent = new THREE.Group();
-    parent.add(face);
-    expect(face.parent).toBe(parent);
-  });
-
-  it('preserves the faceId for tracking across frames', () => {
-    const face = new DetectedFace(42, makeLandmarks({}), makeBbox());
-    expect(face.faceId).toBe(42);
   });
 });

--- a/src/world/faces/FaceRecognizer.test.ts
+++ b/src/world/faces/FaceRecognizer.test.ts
@@ -165,25 +165,6 @@ describe('FaceRecognizer Multi-Client API', () => {
     expect(mockBackend.run).toHaveBeenCalledTimes(1);
   });
 
-  it('supports one-off runs when not started, and reuses the ongoing promise', async () => {
-    const promise1 = recognizer.runDetection();
-    expect(promise1).not.toBeNull();
-    expect(
-      (recognizer as unknown as PrivateFaceRecognizer).currentDetectionPromise
-    ).toBe(promise1);
-
-    const promise2 = recognizer.runDetection();
-    expect(promise2).toBe(promise1);
-
-    const results = await promise1;
-    expect(results.map((face) => face.faceId)).toEqual([1]);
-    expect(recognizer.detectedFaces).toEqual([]);
-    expect(mockBackend.run).toHaveBeenCalledTimes(1);
-    expect(
-      (recognizer as unknown as PrivateFaceRecognizer).currentDetectionPromise
-    ).toBeNull();
-  });
-
   it('disposes cached depth mesh snapshots when disposed', async () => {
     const geometryDispose = vi.fn();
     const materialDispose = vi.fn();
@@ -204,19 +185,6 @@ describe('FaceRecognizer Multi-Client API', () => {
 
     expect(geometryDispose).toHaveBeenCalledTimes(1);
     expect(materialDispose).toHaveBeenCalledTimes(1);
-  });
-
-  it('reuses an in-flight one-off detection when a client starts', async () => {
-    const promise = recognizer.runDetection();
-
-    recognizer.start({});
-
-    expect(
-      (recognizer as unknown as PrivateFaceRecognizer).currentDetectionPromise
-    ).toBe(promise);
-
-    await promise;
-    expect(mockBackend.run).toHaveBeenCalledTimes(1);
   });
 
   it('clear removes scene children without resetting detectedFaces', async () => {

--- a/src/world/faces/FacesOptions.test.ts
+++ b/src/world/faces/FacesOptions.test.ts
@@ -19,24 +19,6 @@ describe('FacesOptions', () => {
     );
   });
 
-  it('opts users into blendshapes and the facial transformation matrix', () => {
-    // Both are the most actionable downstream signals (lipsync, head pose).
-    // Keep them ON by default so consumers do not silently miss them.
-    const opts = new FacesOptions();
-    expect(opts.backendConfig.mediapipe.outputFaceBlendshapes).toBe(true);
-    expect(
-      opts.backendConfig.mediapipe.outputFacialTransformationMatrixes
-    ).toBe(true);
-  });
-
-  it('uses balanced confidence thresholds (0.5 across the three gates)', () => {
-    const opts = new FacesOptions();
-    const mp = opts.backendConfig.mediapipe;
-    expect(mp.minFaceDetectionConfidence).toBe(0.5);
-    expect(mp.minFacePresenceConfidence).toBe(0.5);
-    expect(mp.minTrackingConfidence).toBe(0.5);
-  });
-
   it('deep-merges constructor overrides while keeping unspecified defaults', () => {
     const opts = new FacesOptions({
       backendConfig: {

--- a/src/world/faces/backends/MediaPipeFaceWorker.test.ts
+++ b/src/world/faces/backends/MediaPipeFaceWorker.test.ts
@@ -117,15 +117,6 @@ describe('MediaPipeFaceBackend worker lifecycle', () => {
     ).toBe(true);
   });
 
-  it('spawns the worker as a classic (non-module) worker so MediaPipe wasm loader can use importScripts', async () => {
-    new MediaPipeFaceBackend(makeContext());
-    await Promise.resolve();
-    // We pass no { type: 'module' } so options is undefined. Module
-    // workers don't expose importScripts and MediaPipe's wasm bootstrap
-    // depends on it.
-    expect(FakeWorker.instances[0].options).toBeUndefined();
-  });
-
   it('routes overlapping detect requests back to the right caller by id', async () => {
     const backend = new MediaPipeFaceBackend(makeContext());
     await Promise.resolve();

--- a/src/world/humans/HumanRecognizer.test.ts
+++ b/src/world/humans/HumanRecognizer.test.ts
@@ -156,25 +156,6 @@ describe('HumanRecognizer Multi-Client API', () => {
     await runPromise;
   });
 
-  it('should support one-off runs when not started, and reuse the ongoing promise', async () => {
-    // No clients started
-    const promise1 = recognizer.runDetection();
-    expect(promise1).not.toBeNull();
-    expect(
-      (recognizer as unknown as PrivateRecognizer).currentDetectionPromise
-    ).toBe(promise1);
-
-    // A concurrent call should return the exact same promise
-    const promise2 = recognizer.runDetection();
-    expect(promise2).toBe(promise1);
-
-    const results = await promise1;
-    expect(results).toEqual([{uuid: 'pose-1'}]);
-    expect(
-      (recognizer as unknown as PrivateRecognizer).currentDetectionPromise
-    ).toBeNull();
-  });
-
   it('disposes temporary depth mesh snapshots after detection', async () => {
     const geometryDispose = vi.fn();
     const materialDispose = vi.fn();

--- a/src/world/objects/ObjectDetector.test.ts
+++ b/src/world/objects/ObjectDetector.test.ts
@@ -173,26 +173,6 @@ describe('ObjectDetector Multi-Client API', () => {
     expect(mockBackend.run).toHaveBeenCalledTimes(1);
   });
 
-  it('supports one-off runs when not started, and reuses the ongoing promise', async () => {
-    const promise1 = detector.runDetection();
-    expect(promise1).not.toBeNull();
-    expect(
-      (detector as unknown as PrivateObjectDetector).currentDetectionPromise
-    ).toBe(promise1);
-
-    const promise2 = detector.runDetection();
-    expect(promise2).toBe(promise1);
-
-    const results = await promise1;
-    expect(results.map((obj) => obj.label)).toEqual(['chair']);
-    expect(detector.detectedObjects).toEqual([]);
-    expect(detector.get().map((obj) => obj.label)).toEqual(['chair']);
-    expect(mockBackend.run).toHaveBeenCalledTimes(1);
-    expect(
-      (detector as unknown as PrivateObjectDetector).currentDetectionPromise
-    ).toBeNull();
-  });
-
   it('disposes temporary depth mesh snapshots after detection', async () => {
     const geometryDispose = vi.fn();
     const materialDispose = vi.fn();
@@ -212,19 +192,6 @@ describe('ObjectDetector Multi-Client API', () => {
 
     expect(geometryDispose).toHaveBeenCalledTimes(1);
     expect(materialDispose).toHaveBeenCalledTimes(1);
-  });
-
-  it('reuses an in-flight one-off detection when a client starts', async () => {
-    const promise = detector.runDetection();
-
-    detector.start({});
-
-    expect(
-      (detector as unknown as PrivateObjectDetector).currentDetectionPromise
-    ).toBe(promise);
-
-    await promise;
-    expect(mockBackend.run).toHaveBeenCalledTimes(1);
   });
 
   it('clears public results, tracked objects, and scene children', async () => {

--- a/src/world/segmentation/SegmentationOptions.test.ts
+++ b/src/world/segmentation/SegmentationOptions.test.ts
@@ -19,23 +19,11 @@ describe('SegmentationOptions', () => {
     );
   });
 
-  it('outputs the category mask by default', () => {
-    // The category mask is what produces a SegmentationMask, so it must be on
-    // out of the box.
-    const opts = new SegmentationOptions();
-    expect(opts.backendConfig.mediapipe.outputCategoryMask).toBe(true);
-  });
-
   it('enable() turns segmentation on and returns the instance', () => {
     const opts = new SegmentationOptions();
     const returned = opts.enable();
     expect(opts.enabled).toBe(true);
     expect(returned).toBe(opts);
-  });
-
-  it('defaults pollingIntervalMs to 66 (~15 fps)', () => {
-    const opts = new SegmentationOptions();
-    expect(opts.pollingIntervalMs).toBe(66);
   });
 
   it('deep-merges constructor overrides while keeping unspecified defaults', () => {
@@ -51,13 +39,5 @@ describe('SegmentationOptions', () => {
     // Untouched fields keep their defaults.
     expect(opts.backendConfig.mediapipe.outputCategoryMask).toBe(true);
     expect(opts.backendConfig.activeBackend).toBe('mediapipe');
-  });
-
-  it('allows overriding pollingIntervalMs via constructor', () => {
-    const opts = new SegmentationOptions({pollingIntervalMs: 100});
-    expect(opts.pollingIntervalMs).toBe(100);
-    // Other defaults are untouched.
-    expect(opts.backendConfig.activeBackend).toBe('mediapipe');
-    expect(opts.enabled).toBe(false);
   });
 });

--- a/src/world/segmentation/Segmenter.test.ts
+++ b/src/world/segmentation/Segmenter.test.ts
@@ -66,11 +66,6 @@ function flushMicrotasks() {
 
 describe('Segmenter', () => {
   describe('latestMask', () => {
-    it('is null before the first inference completes', () => {
-      const segmenter = makeSegmenter();
-      expect(segmenter.latestMask).toBeNull();
-    });
-
     it('caches the mask returned by the most recently completed inference', async () => {
       const segmenter = makeSegmenter();
       const mask = makeMask(7);
@@ -79,31 +74,6 @@ describe('Segmenter', () => {
       await segmenter.runSegmentation();
 
       expect(segmenter.latestMask).toBe(mask);
-    });
-
-    it('replaces the cache with each new completed inference', async () => {
-      const segmenter = makeSegmenter();
-      const mask1 = makeMask(1);
-      const mask2 = makeMask(2);
-      let call = 0;
-      injectMockBackend(segmenter, () =>
-        Promise.resolve(call++ === 0 ? mask1 : mask2)
-      );
-
-      await segmenter.runSegmentation();
-      expect(segmenter.latestMask).toBe(mask1);
-
-      await segmenter.runSegmentation();
-      expect(segmenter.latestMask).toBe(mask2);
-    });
-
-    it('stores null when the backend returns null', async () => {
-      const segmenter = makeSegmenter();
-      injectMockBackend(segmenter, () => Promise.resolve(null));
-
-      const result = await segmenter.runSegmentation();
-      expect(result).toBeNull();
-      expect(segmenter.latestMask).toBeNull();
     });
   });
 
@@ -144,32 +114,9 @@ describe('Segmenter', () => {
 
       expect(backend.run).toHaveBeenCalledTimes(2);
     });
-
-    it('clears the in-flight guard after a null result', async () => {
-      const segmenter = makeSegmenter();
-      const backend = injectMockBackend(segmenter, () => Promise.resolve(null));
-
-      await segmenter.runSegmentation();
-      await segmenter.runSegmentation();
-
-      // Guard was cleared even on null so a second call started a new inference.
-      expect(backend.run).toHaveBeenCalledTimes(2);
-    });
   });
 
   describe('continuous loop via update()', () => {
-    it('triggers an inference on the first update() call', async () => {
-      const segmenter = makeSegmenter();
-      const backend = injectMockBackend(segmenter, () =>
-        Promise.resolve(makeMask())
-      );
-
-      segmenter.update(0);
-      await flushMicrotasks();
-
-      expect(backend.run).toHaveBeenCalledTimes(1);
-    });
-
     it('does not trigger a second inference within the pollingIntervalMs window', async () => {
       const segmenter = makeSegmenter(); // pollingIntervalMs = 66
       const backend = injectMockBackend(segmenter, () =>
@@ -225,17 +172,6 @@ describe('Segmenter', () => {
       expect(backend.run).toHaveBeenCalledTimes(1);
     });
 
-    it('populates latestMask after a loop-driven inference completes', async () => {
-      const segmenter = makeSegmenter();
-      const mask = makeMask(9);
-      injectMockBackend(segmenter, () => Promise.resolve(mask));
-
-      segmenter.update(0);
-      await flushMicrotasks();
-
-      expect(segmenter.latestMask).toBe(mask);
-    });
-
     it('disposes cached backends and clears latestMask', async () => {
       const segmenter = makeSegmenter();
       const dispose = vi.fn();
@@ -255,39 +191,6 @@ describe('Segmenter', () => {
       expect(dispose).toHaveBeenCalledTimes(1);
       expect(segmenter.latestMask).toBeNull();
       await expect(segmenter.runSegmentation()).resolves.toBeNull();
-    });
-
-    it('respects a custom pollingIntervalMs set in options', async () => {
-      const segmenter = new Segmenter();
-      // Custom 200 ms cadence.
-      segmenter.init({
-        options: {
-          segmentation: {
-            backendConfig: {activeBackend: 'mediapipe'},
-            pollingIntervalMs: 200,
-          },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any,
-        deviceCamera: fakeCamera,
-      });
-      const backend = injectMockBackend(segmenter, () =>
-        Promise.resolve(makeMask())
-      );
-
-      segmenter.update(0);
-      await flushMicrotasks();
-
-      // Still within the 200 ms window.
-      segmenter.update(100);
-      segmenter.update(199);
-
-      expect(backend.run).toHaveBeenCalledTimes(1);
-
-      // Now outside the window.
-      segmenter.update(200);
-      await flushMicrotasks();
-
-      expect(backend.run).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/world/segmentation/backends/MediaPipeSegmenterBackend.test.ts
+++ b/src/world/segmentation/backends/MediaPipeSegmenterBackend.test.ts
@@ -29,17 +29,12 @@ describe('categoryMaskToSegmentationMask', () => {
     expect(result!.height).toBe(2);
   });
 
-  it('copies the buffer so it survives mask.close() freeing the source', () => {
-    const {mask, source} = makeMpMask([3, 4], 2, 1);
+  it('copies the buffer before closing the MediaPipe mask', () => {
+    const {mask, source, close} = makeMpMask([3, 4], 2, 1);
     const result = categoryMaskToSegmentationMask(mask as never);
     // Mutating the original source must not change the returned data.
     source[0] = 99;
     expect(result!.data[0]).toBe(3);
-  });
-
-  it('closes the MediaPipe mask to release the underlying buffer', () => {
-    const {mask, close} = makeMpMask([0, 0], 2, 1);
-    categoryMaskToSegmentationMask(mask as never);
     expect(close).toHaveBeenCalledOnce();
   });
 


### PR DESCRIPTION
# Cleaning Tests

## Description

Removing some of the SDK tests and combining things to make contributing to the sdk a bit cleaner overall
- 496 tests to 310
- removed some of the classic ai over test writing. Mostly in
  - agenthands
  - lipsync
  - netblocks
  - simulator (mostly IK checks)
- removed some probabilistic stuff
- duplicate lifecycle stuff
- overlapped tests

- 
<!-- Brief summary of changes. For new demos/samples, include the directory path (e.g., `demos/my_demo/`). -->

## Type of Change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

- **Simulator Recording**: <!-- Attach video/GIF running in desktop simulator -->
- **Device Recording**: <!-- Attach video/GIF running on physical hardware -->

## Checklist

- [x] **Tested in simulator & device**: Verified functionality in desktop simulator and/or physical hardware (where applicable).
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.
