### PR TITLE
place the pose skeleton from MediaPipe's metric landmarks

### DIFF
--- a/src/world/humans/DetectedBodyPose.ts
+++ b/src/world/humans/DetectedBodyPose.ts
@@ -54,6 +54,18 @@ export interface PoseLandmark {
    * The probability [0.0, 1.0] that the landmark is visible (not occluded).
    */
   visibility?: number;
+
+  /**
+   * Position in metres relative to the centre of the hips, straight from
+   * MediaPipe's world landmarks, with x toward the person's right, y downward
+   * and z toward the camera.
+   *
+   * Unlike {@link worldPosition} this is independent of where the person is in
+   * the room and of the camera's intrinsics, so it can be used to render a
+   * correctly proportioned skeleton anywhere. Undefined when the backend does
+   * not provide metric landmarks.
+   */
+  metricPosition?: THREE.Vector3;
   /**
    * The back-projected 3D position in WebXR world space, measured in meters.
    * Null or undefined if depth projection was unsuccessful.

--- a/src/world/humans/HumansOptions.ts
+++ b/src/world/humans/HumansOptions.ts
@@ -14,6 +14,19 @@ export class HumansOptions {
   pollingIntervalMs = 0;
 
   /**
+   * Project each landmark onto the depth mesh to find its world position.
+   *
+   * This is what you want when the people being detected are physically in
+   * front of you, since the ray lands on their actual body. Turn it off when
+   * the camera is showing someone who is not part of the depth scene, such as a
+   * webcam feed on the desktop simulator: every ray would then hit the
+   * surrounding geometry instead and the skeleton would be smeared across it.
+   * With projection off, landmarks are placed along the view ray at a fixed
+   * distance, which keeps the body correctly proportioned.
+   */
+  useDepthProjection = true;
+
+  /**
    * Configuration options for the active pose detection backend.
    */
   backendConfig = {

--- a/src/world/humans/backends/MediaPipeHumanBackend.test.ts
+++ b/src/world/humans/backends/MediaPipeHumanBackend.test.ts
@@ -59,6 +59,123 @@ beforeEach(() => {
 });
 
 describe('processPoseLandmarkerResult', () => {
+  it('builds a metric skeleton when projection is disabled', () => {
+    // With real proportions the shoulder span should be its true width, not
+    // whatever the camera's field of view implies.
+    vi.mocked(transformRgbUvToWorld).mockReturnValue(HIT as never);
+    const {depthMeshSnapshot, cameraParametersSnapshot} = makeSnapshots();
+
+    const [pose] = processPoseLandmarkerResult(
+      makeMpResult({
+        landmarks: [
+          [
+            {x: 0.4, y: 0.5, z: 0},
+            {x: 0.6, y: 0.5, z: 0},
+          ],
+        ],
+        worldLandmarks: [
+          [
+            {x: -0.2, y: 0, z: 0},
+            {x: 0.2, y: 0, z: 0},
+          ],
+        ],
+      }),
+      depthMeshSnapshot,
+      cameraParametersSnapshot,
+      {useDepthProjection: false}
+    );
+
+    const left = pose.landmarks[0].worldPosition!;
+    const right = pose.landmarks[1].worldPosition!;
+    expect(left.distanceTo(right)).toBeCloseTo(0.4);
+  });
+
+  it('puts the metric skeleton in front of the viewer', () => {
+    vi.mocked(transformRgbUvToWorld).mockReturnValue(HIT as never);
+    const {depthMeshSnapshot, cameraParametersSnapshot} = makeSnapshots();
+
+    const [pose] = processPoseLandmarkerResult(
+      makeMpResult({
+        landmarks: [[{x: 0.5, y: 0.5, z: 0}]],
+        worldLandmarks: [[{x: 0, y: 0, z: 0}]],
+      }),
+      depthMeshSnapshot,
+      cameraParametersSnapshot,
+      {useDepthProjection: false}
+    );
+
+    // Camera sits at y = 1.6 looking down -Z, so the hips land 2 m ahead.
+    const wp = pose.landmarks[0].worldPosition!;
+    expect(wp.z).toBeCloseTo(-2);
+    expect(wp.y).toBeCloseTo(1.6);
+  });
+
+  it('puts the head above the hips', () => {
+    vi.mocked(transformRgbUvToWorld).mockReturnValue(HIT as never);
+    const {depthMeshSnapshot, cameraParametersSnapshot} = makeSnapshots();
+
+    const [pose] = processPoseLandmarkerResult(
+      makeMpResult({
+        landmarks: [
+          [
+            {x: 0.5, y: 0.2, z: 0},
+            {x: 0.5, y: 0.8, z: 0},
+          ],
+        ],
+        // MediaPipe's y runs downward, so the head is negative.
+        worldLandmarks: [
+          [
+            {x: 0, y: -0.6, z: 0},
+            {x: 0, y: 0, z: 0},
+          ],
+        ],
+      }),
+      depthMeshSnapshot,
+      cameraParametersSnapshot,
+      {useDepthProjection: false}
+    );
+
+    const head = pose.landmarks[0].worldPosition!;
+    const hips = pose.landmarks[1].worldPosition!;
+    expect(head.y).toBeGreaterThan(hips.y);
+  });
+
+  it('exposes the raw metric landmark', () => {
+    vi.mocked(transformRgbUvToWorld).mockReturnValue(HIT as never);
+    const {depthMeshSnapshot, cameraParametersSnapshot} = makeSnapshots();
+
+    const [pose] = processPoseLandmarkerResult(
+      makeMpResult({
+        landmarks: [[{x: 0.5, y: 0.5, z: 0}]],
+        worldLandmarks: [[{x: 0.1, y: -0.2, z: 0.3}]],
+      }),
+      depthMeshSnapshot,
+      cameraParametersSnapshot
+    );
+
+    expect(pose.landmarks[0].metricPosition!.toArray()).toEqual([
+      0.1, -0.2, 0.3,
+    ]);
+  });
+
+  it('falls back to the view ray without metric landmarks', () => {
+    vi.mocked(transformRgbUvToWorld).mockReturnValue(HIT as never);
+    const {depthMeshSnapshot, cameraParametersSnapshot} = makeSnapshots();
+
+    const [pose] = processPoseLandmarkerResult(
+      makeMpResult({landmarks: [[{x: 0.5, y: 0.5, z: 0}]]}),
+      depthMeshSnapshot,
+      cameraParametersSnapshot,
+      {useDepthProjection: false}
+    );
+
+    const cameraOrigin = new THREE.Vector3(0, 1.6, 0);
+    expect(
+      pose.landmarks[0].worldPosition!.distanceTo(cameraOrigin)
+    ).toBeCloseTo(1.5);
+    expect(pose.landmarks[0].metricPosition).toBeUndefined();
+  });
+
   it('skips the depth raycast when projection is disabled', () => {
     // A person on a webcam feed is not part of the simulator's depth mesh, so
     // raycasting would land every joint on the surrounding room geometry.

--- a/src/world/humans/backends/MediaPipeHumanBackend.test.ts
+++ b/src/world/humans/backends/MediaPipeHumanBackend.test.ts
@@ -59,6 +59,40 @@ beforeEach(() => {
 });
 
 describe('processPoseLandmarkerResult', () => {
+  it('skips the depth raycast when projection is disabled', () => {
+    // A person on a webcam feed is not part of the simulator's depth mesh, so
+    // raycasting would land every joint on the surrounding room geometry.
+    vi.mocked(transformRgbUvToWorld).mockReturnValue(HIT as never);
+    const {depthMeshSnapshot, cameraParametersSnapshot} = makeSnapshots();
+
+    const [pose] = processPoseLandmarkerResult(
+      makeMpResult({landmarks: [[{x: 0.5, y: 0.5, z: 0}]]}),
+      depthMeshSnapshot,
+      cameraParametersSnapshot,
+      {useDepthProjection: false}
+    );
+
+    expect(transformRgbUvToWorld).not.toHaveBeenCalled();
+    // Falls back to the view ray, keeping the body correctly proportioned.
+    const cameraOrigin = new THREE.Vector3(0, 1.6, 0);
+    expect(
+      pose.landmarks[0].worldPosition!.distanceTo(cameraOrigin)
+    ).toBeCloseTo(1.5);
+  });
+
+  it('projects onto the depth mesh by default', () => {
+    vi.mocked(transformRgbUvToWorld).mockReturnValue(HIT as never);
+    const {depthMeshSnapshot, cameraParametersSnapshot} = makeSnapshots();
+
+    processPoseLandmarkerResult(
+      makeMpResult({landmarks: [[{x: 0.5, y: 0.5, z: 0}]]}),
+      depthMeshSnapshot,
+      cameraParametersSnapshot
+    );
+
+    expect(transformRgbUvToWorld).toHaveBeenCalled();
+  });
+
   it('returns one pose per detected person', () => {
     vi.mocked(transformRgbUvToWorld).mockReturnValue(HIT as never);
     const {depthMeshSnapshot, cameraParametersSnapshot} = makeSnapshots();

--- a/src/world/humans/backends/MediaPipeHumanBackend.ts
+++ b/src/world/humans/backends/MediaPipeHumanBackend.ts
@@ -32,6 +32,57 @@ async function loadMediaPipeModule() {
   }
 }
 
+/** Where the metric skeleton is placed when depth projection is off. */
+const METRIC_SKELETON_DISTANCE_METRES = 2;
+
+const cameraPosition = new THREE.Vector3();
+const cameraRight = new THREE.Vector3();
+const cameraUp = new THREE.Vector3();
+const cameraForward = new THREE.Vector3();
+
+/**
+ * Places a MediaPipe world landmark in front of the viewer, preserving the
+ * body's real proportions.
+ *
+ * World landmarks are metres from the centre of the hips, with x toward the
+ * person's right, y downward and z toward the camera. Screen landmarks cannot
+ * be used for this: they depend on camera intrinsics, and joints outside the
+ * frame are extrapolated, so a half-visible body produces legs that shoot off
+ * into the distance.
+ *
+ * x is deliberately not negated, which makes the skeleton behave like a mirror:
+ * raise your right hand and the skeleton's hand rises on the same side of the
+ * screen.
+ *
+ * @param metric - Metric landmark from MediaPipe, in metres.
+ * @param worldFromView - Camera pose.
+ * @param target - Vector to write the result into.
+ * @returns The world position for the landmark.
+ */
+function placeMetricLandmark(
+  metric: {x: number; y: number; z: number},
+  worldFromView: THREE.Matrix4,
+  target: THREE.Vector3
+): THREE.Vector3 {
+  cameraPosition.setFromMatrixPosition(worldFromView);
+  cameraRight.setFromMatrixColumn(worldFromView, 0).normalize();
+  cameraUp.setFromMatrixColumn(worldFromView, 1).normalize();
+  // Cameras look down -Z.
+  cameraForward.setFromMatrixColumn(worldFromView, 2).normalize().negate();
+
+  return (
+    target
+      .copy(cameraPosition)
+      .addScaledVector(
+        cameraForward,
+        METRIC_SKELETON_DISTANCE_METRES + (metric.z || 0)
+      )
+      .addScaledVector(cameraRight, metric.x || 0)
+      // y runs downward in MediaPipe's frame and upward in three.js.
+      .addScaledVector(cameraUp, -(metric.y || 0))
+  );
+}
+
 /**
  * Convert a raw MediaPipe `PoseLandmarkerResult` into `DetectedBodyPose`
  * objects with world-space joint positions.
@@ -92,6 +143,15 @@ export function processPoseLandmarkerResult(
       let wp: THREE.Vector3 | undefined;
       if (worldCoords) {
         wp = worldCoords.worldPosition;
+      } else if (!useDepthProjection && wLm) {
+        // Not projecting, and MediaPipe gave us a metric skeleton: use it so
+        // the body keeps its real proportions regardless of camera intrinsics
+        // or joints sitting outside the frame.
+        wp = placeMetricLandmark(
+          wLm,
+          cameraParametersSnapshot.worldFromView,
+          new THREE.Vector3()
+        );
       } else {
         // Robust fallback estimation when physical depth mesh raycast misses
         const origin = new THREE.Vector3().applyMatrix4(
@@ -115,6 +175,9 @@ export function processPoseLandmarkerResult(
         z: wLm ? wLm.z : lm.z,
         visibility: lm.visibility,
         worldPosition: wp,
+        metricPosition: wLm
+          ? new THREE.Vector3(wLm.x, wLm.y, wLm.z)
+          : undefined,
       });
     }
 

--- a/src/world/humans/backends/MediaPipeHumanBackend.ts
+++ b/src/world/humans/backends/MediaPipeHumanBackend.ts
@@ -44,15 +44,21 @@ async function loadMediaPipeModule() {
  * first; when the ray misses, the point is back-projected through the camera
  * frustum and placed ~1.5 m out, modulated by the landmark's relative z.
  *
+ * Pass `useDepthProjection: false` when the detected person is not part of the
+ * depth scene, such as a webcam feed on the desktop simulator. Every ray would
+ * otherwise hit the surrounding geometry and stretch the skeleton across it.
+ *
  * @param result - Raw result from the MediaPipe pose task.
  * @param depthMeshSnapshot - Depth mesh to raycast against.
  * @param cameraParametersSnapshot - Camera matrices for back-projection.
+ * @param options - Projection behaviour.
  * @returns One `DetectedBodyPose` per person in the result.
  */
 export function processPoseLandmarkerResult(
   result: MEDIAPIPE.PoseLandmarkerResult,
   depthMeshSnapshot: THREE.Mesh,
-  cameraParametersSnapshot: CameraParametersSnapshot
+  cameraParametersSnapshot: CameraParametersSnapshot,
+  {useDepthProjection = true}: {useDepthProjection?: boolean} = {}
 ): DetectedBodyPose[] {
   const detectedPoses: DetectedBodyPose[] = [];
 
@@ -79,11 +85,9 @@ export function processPoseLandmarkerResult(
 
       // Transform screen UV to WebXR World Position
       const uv = new THREE.Vector2(lm.x, lm.y);
-      const worldCoords = transformRgbUvToWorld(
-        uv,
-        depthMeshSnapshot,
-        cameraParametersSnapshot
-      );
+      const worldCoords = useDepthProjection
+        ? transformRgbUvToWorld(uv, depthMeshSnapshot, cameraParametersSnapshot)
+        : null;
 
       let wp: THREE.Vector3 | undefined;
       if (worldCoords) {
@@ -188,7 +192,11 @@ export class MediaPipeHumanBackend extends BaseHumanBackend {
     return processPoseLandmarkerResult(
       result,
       depthMeshSnapshot,
-      cameraParametersSnapshot
+      cameraParametersSnapshot,
+      {
+        useDepthProjection:
+          this.context.options.humans.useDepthProjection !== false,
+      }
     );
   }
 


### PR DESCRIPTION
pose landmarks are positioned by raycasting the depth mesh, and when that misses, by back-projecting through the camera. both assume the detected person is part of the scene being sensed. that holds on a headset. it doesn't on desktop with a webcam, where you're sitting outside the simulated room: the rays hit the walls and furniture and smear the skeleton across them, and the back-projection uses device intrinsics that don't match a 16:9 webcam so what survives comes out stretched.

adds `world.humans.useDepthProjection` (default true, so nothing changes for existing apps or on device). with it off, landmarks come from mediapipe's world landmarks instead, which are metres from the hip centre and independent of both the camera and whether a joint is even in frame, so the body keeps its real proportions.

also puts `metricPosition` on each landmark. it was already being computed and everything but `z` thrown away.