### PR TITLE
feat(world/humans): let callers reject pose joints the model only guessed

### DIFF
--- a/src/world/humans/DetectedBodyPose.test.ts
+++ b/src/world/humans/DetectedBodyPose.test.ts
@@ -1,0 +1,110 @@
+import * as THREE from 'three';
+import {describe, expect, it} from 'vitest';
+
+import {
+  DetectedBodyPose,
+  PoseJointName,
+  PoseLandmark,
+} from './DetectedBodyPose';
+
+/**
+ * Builds a landmark list where every entry is projected, so tests only vary
+ * the visibility the pose model reported.
+ */
+function makeLandmarks(
+  overrides: Record<number, Partial<PoseLandmark>> = {}
+): PoseLandmark[] {
+  return Array.from({length: 33}, (_, i) => ({
+    x: 0.5,
+    y: 0.5,
+    z: 0,
+    visibility: 1,
+    worldPosition: new THREE.Vector3(i, i, i),
+    ...overrides[i],
+  }));
+}
+
+function makePose(overrides?: Record<number, Partial<PoseLandmark>>) {
+  return new DetectedBodyPose(0, makeLandmarks(overrides), new THREE.Box2());
+}
+
+describe('DetectedBodyPose.getJointPosition', () => {
+  it('returns every joint when no threshold is given', () => {
+    const pose = makePose({27: {visibility: 0.01}});
+
+    expect(pose.getJointPosition(PoseJointName.LeftAnkle)).not.toBeNull();
+  });
+
+  it('drops joints the model is not confident about', () => {
+    const pose = makePose({27: {visibility: 0.1}});
+
+    expect(
+      pose.getJointPosition(PoseJointName.LeftAnkle, {minVisibility: 0.5})
+    ).toBeNull();
+  });
+
+  it('keeps confident joints when a threshold is given', () => {
+    const pose = makePose({11: {visibility: 0.99}});
+
+    expect(
+      pose.getJointPosition(PoseJointName.LeftShoulder, {minVisibility: 0.5})
+    ).not.toBeNull();
+  });
+
+  it('treats a missing visibility as not confident', () => {
+    const pose = makePose({27: {visibility: undefined}});
+
+    expect(
+      pose.getJointPosition(PoseJointName.LeftAnkle, {minVisibility: 0.5})
+    ).toBeNull();
+  });
+
+  it('applies the threshold to the parts of a composite joint', () => {
+    // Hips averages landmarks 23 and 24. Only one is trustworthy, so the
+    // result must come from that one alone rather than the midpoint.
+    const pose = makePose({
+      23: {worldPosition: new THREE.Vector3(1, 0, 0), visibility: 0.9},
+      24: {worldPosition: new THREE.Vector3(3, 0, 0), visibility: 0.1},
+    });
+
+    const hips = pose.getJointPosition(PoseJointName.Hips, {
+      minVisibility: 0.5,
+    });
+
+    expect(hips!.x).toBeCloseTo(1);
+  });
+
+  it('drops a composite joint when none of its parts are confident', () => {
+    const pose = makePose({
+      23: {visibility: 0.1},
+      24: {visibility: 0.1},
+    });
+
+    expect(
+      pose.getJointPosition(PoseJointName.Hips, {minVisibility: 0.5})
+    ).toBeNull();
+  });
+
+  it('forwards the threshold through nested composite joints', () => {
+    // Spine is built from Hips and Chest, which are themselves composites.
+    const pose = makePose({
+      11: {visibility: 0.1},
+      12: {visibility: 0.1},
+      23: {visibility: 0.1},
+      24: {visibility: 0.1},
+    });
+
+    expect(
+      pose.getJointPosition(PoseJointName.Spine, {minVisibility: 0.5})
+    ).toBeNull();
+  });
+
+  it('still positions the object at the hips regardless of visibility', () => {
+    const pose = makePose({
+      23: {worldPosition: new THREE.Vector3(2, 0, 0), visibility: 0.01},
+      24: {worldPosition: new THREE.Vector3(4, 0, 0), visibility: 0.01},
+    });
+
+    expect(pose.position.x).toBeCloseTo(3);
+  });
+});

--- a/src/world/humans/DetectedBodyPose.ts
+++ b/src/world/humans/DetectedBodyPose.ts
@@ -103,13 +103,26 @@ export class DetectedBodyPose extends THREE.Object3D {
    * Returns the 3D world space position of a specific joint/landmark in meters.
    * Exposes both standard MediaPipe landmark mappings and composite VRM/humanoid landmarks.
    *
+   * The pose model always returns all landmarks, including ones it could not
+   * actually see, so a body that is only half in frame still reports legs. Pass
+   * `minVisibility` to drop those guesses instead of drawing them.
+   *
    * @param name - The name of the joint (standard or composite).
-   * @returns A clone of the 3D world space position vector, or `null` if the joint is undetected or unprojected.
+   * @param options - Set `minVisibility` to reject landmarks the model is not
+   *   confident about. Defaults to 0, which keeps every landmark.
+   * @returns A clone of the 3D world space position vector, or `null` if the joint is undetected, unprojected, or below `minVisibility`.
    */
-  getJointPosition(name: PoseJointName | string): THREE.Vector3 | null {
+  getJointPosition(
+    name: PoseJointName | string,
+    {minVisibility = 0}: {minVisibility?: number} = {}
+  ): THREE.Vector3 | null {
     const getMPWorldPos = (index: number): THREE.Vector3 | null => {
       const lm = this.landmarks[index];
-      return lm && lm.worldPosition ? lm.worldPosition.clone() : null;
+      if (!lm || !lm.worldPosition) return null;
+      if (minVisibility > 0 && (lm.visibility ?? 0) < minVisibility) {
+        return null;
+      }
+      return lm.worldPosition.clone();
     };
 
     switch (name) {
@@ -163,8 +176,10 @@ export class DetectedBodyPose extends THREE.Object3D {
       }
       case PoseJointName.Spine: {
         // Spine is lower center torso (between hips and chest)
-        const hips = this.getJointPosition(PoseJointName.Hips);
-        const chest = this.getJointPosition(PoseJointName.Chest);
+        const hips = this.getJointPosition(PoseJointName.Hips, {minVisibility});
+        const chest = this.getJointPosition(PoseJointName.Chest, {
+          minVisibility,
+        });
         if (hips && chest) {
           return new THREE.Vector3()
             .addVectors(hips, chest)
@@ -183,7 +198,9 @@ export class DetectedBodyPose extends THREE.Object3D {
         return lShoulder || rShoulder || null;
       }
       case PoseJointName.Neck: {
-        const chest = this.getJointPosition(PoseJointName.Chest);
+        const chest = this.getJointPosition(PoseJointName.Chest, {
+          minVisibility,
+        });
         const nose = getMPWorldPos(0);
         if (chest && nose) {
           return new THREE.Vector3()


### PR DESCRIPTION
the pose model returns all 33 landmarks whether or not it could actually see them, so someone framed from the chest up still comes back with a full set of legs, guessed from a prior. they're not just imprecise, they frequently point upward, so anything drawing the skeleton renders a body with its shins above its hips.

every landmark already carried the model's confidence and nothing read it.

`getJointPosition` takes an optional `minVisibility` now, forwarded through the composite joints so a hips or spine built out of unreliable landmarks drops out too rather than averaging junk into a plausible-looking position. defaults to 0 so existing callers are untouched: on a headset the person is part of the depth mesh and occluded joints are still worth reporting.