### PR TITLE
skip the simulator depth readback when nothing has changed

### DIFF
--- a/src/simulator/scene/SimulatorDepth.test.ts
+++ b/src/simulator/scene/SimulatorDepth.test.ts
@@ -38,6 +38,28 @@ function makeMockRenderer() {
 describe('SimulatorDepth.update inflight guard', () => {
   let depthSim: SimulatorDepth;
   let renderer: ReturnType<typeof makeMockRenderer>;
+  let camera: THREE.PerspectiveCamera;
+  let simulatorScene: THREE.Scene;
+  let movingObject: THREE.Object3D;
+
+  /** Move the view so the depth buffer is genuinely out of date. */
+  const moveCamera = () => {
+    camera.position.x += 1;
+  };
+
+  /** Move something the depth pass draws, leaving the camera alone. */
+  const moveSceneObject = () => {
+    movingObject.position.z += 1;
+    movingObject.updateMatrixWorld(true);
+  };
+
+  /** Run update() and let the readback settle so the next call is unblocked. */
+  const settledUpdate = async () => {
+    depthSim.update();
+    renderer.settleReadback();
+    await Promise.resolve();
+    await Promise.resolve();
+  };
 
   beforeEach(() => {
     // jsdom doesn't ship XRRigidTransform; the readback path constructs
@@ -50,8 +72,12 @@ describe('SimulatorDepth.update inflight guard', () => {
         ) {}
       };
     renderer = makeMockRenderer();
-    const camera = new THREE.PerspectiveCamera();
-    depthSim = new SimulatorDepth({overrideMaterial: null} as never);
+    camera = new THREE.PerspectiveCamera();
+    simulatorScene = new THREE.Scene();
+    movingObject = new THREE.Object3D();
+    simulatorScene.add(movingObject);
+    simulatorScene.updateMatrixWorld(true);
+    depthSim = new SimulatorDepth(simulatorScene as never);
     depthSim.init(renderer.renderer as unknown as THREE.WebGLRenderer, camera, {
       updateCPUDepthData: vi.fn(),
     } as never);
@@ -82,17 +108,101 @@ describe('SimulatorDepth.update inflight guard', () => {
     // Flush the .finally() chain.
     await Promise.resolve();
     await Promise.resolve();
+    moveCamera();
     depthSim.update();
     expect(renderer.renderer.render).toHaveBeenCalledTimes(2);
   });
 
   it('keeps re-firing on every frame in a steady state once readbacks resolve in order', async () => {
     for (let i = 0; i < 5; i++) {
+      moveCamera();
       depthSim.update();
       renderer.settleReadback();
       await Promise.resolve();
       await Promise.resolve();
     }
     expect(renderer.renderer.render).toHaveBeenCalledTimes(5);
+  });
+
+  it('skips the render and readback while the view is stationary', async () => {
+    depthSim.update();
+    renderer.settleReadback();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Same camera, so the depth buffer would come back identical.
+    depthSim.update();
+    depthSim.update();
+
+    expect(renderer.renderer.render).toHaveBeenCalledTimes(1);
+    expect(renderer.renderer.readRenderTargetPixelsAsync).toHaveBeenCalledTimes(
+      1
+    );
+  });
+
+  it('refreshes a stationary view once the buffer goes stale', async () => {
+    depthSim.update();
+    renderer.settleReadback();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The scene can animate under a still camera, so staleness still forces a
+    // refresh even with no movement.
+    depthSim.maxDepthAgeMs = 0;
+    depthSim.update();
+
+    expect(renderer.renderer.render).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-renders as soon as the view moves again', async () => {
+    await settledUpdate();
+
+    depthSim.update();
+    expect(renderer.renderer.render).toHaveBeenCalledTimes(1);
+
+    moveCamera();
+    depthSim.update();
+    expect(renderer.renderer.render).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-renders when something in the scene moves under a still camera', async () => {
+    await settledUpdate();
+
+    // Nothing moved, so this one is skipped.
+    depthSim.update();
+    expect(renderer.renderer.render).toHaveBeenCalledTimes(1);
+
+    // The camera is still, but the world in front of it is not.
+    moveSceneObject();
+    depthSim.update();
+    expect(renderer.renderer.render).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-renders when something in the scene is hidden or shown', async () => {
+    await settledUpdate();
+
+    movingObject.visible = false;
+    depthSim.update();
+    expect(renderer.renderer.render).toHaveBeenCalledTimes(2);
+
+    renderer.settleReadback();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    movingObject.visible = true;
+    depthSim.update();
+    expect(renderer.renderer.render).toHaveBeenCalledTimes(3);
+  });
+
+  it('re-renders when a new object is added to the scene', async () => {
+    await settledUpdate();
+
+    const added = new THREE.Object3D();
+    added.position.set(2, 0, 0);
+    simulatorScene.add(added);
+    simulatorScene.updateMatrixWorld(true);
+
+    depthSim.update();
+    expect(renderer.renderer.render).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/simulator/scene/SimulatorDepth.test.ts
+++ b/src/simulator/scene/SimulatorDepth.test.ts
@@ -146,8 +146,10 @@ describe('SimulatorDepth.update inflight guard', () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    // The scene can animate under a still camera, so staleness still forces a
-    // refresh even with no movement.
+    // Two reasons this has to keep firing with nothing moving. The scene can
+    // animate in ways a transform hash cannot see, and the detectors cache a
+    // cloned depth mesh keyed on the position attribute version, so the
+    // version has to keep advancing or those caches never invalidate.
     depthSim.maxDepthAgeMs = 0;
     depthSim.update();
 

--- a/src/simulator/scene/SimulatorDepth.ts
+++ b/src/simulator/scene/SimulatorDepth.ts
@@ -38,9 +38,20 @@ export class SimulatorDepth {
 
   /**
    * Longest a depth buffer is allowed to go without being refreshed while
-   * nothing detectable has changed, in milliseconds. The skip keys off camera
-   * and scene transforms, which cannot see vertex-level animation such as
-   * skinning or vertex shaders, so this bounds worst-case staleness.
+   * nothing detectable has changed, in milliseconds.
+   *
+   * This is not only a hedge against animation the skip cannot see, such as
+   * skinning or vertex shaders. It is also what keeps the depth mesh's
+   * position attribute version advancing while the scene sits still.
+   * `FaceRecognizer`, `HumanRecognizer`, and `ObjectDetector` each cache a
+   * cloned depth mesh, and its BVH, keyed on that version. If this were
+   * removed, a stationary scene would freeze the version, those caches would
+   * never invalidate, and per-landmark raycasts would keep hitting a stale
+   * clone. That is the failure this repository already fixed once, where the
+   * face wireframe only appeared while the camera was moving.
+   *
+   * Raising it trades depth freshness for fewer readbacks; setting it to
+   * `Infinity` would reintroduce that bug.
    */
   maxDepthAgeMs = 500;
 

--- a/src/simulator/scene/SimulatorDepth.ts
+++ b/src/simulator/scene/SimulatorDepth.ts
@@ -36,6 +36,24 @@ export class SimulatorDepth {
   // main thread.
   private updateInFlight = false;
 
+  /**
+   * Longest a depth buffer is allowed to go without being refreshed while
+   * nothing detectable has changed, in milliseconds. The skip keys off camera
+   * and scene transforms, which cannot see vertex-level animation such as
+   * skinning or vertex shaders, so this bounds worst-case staleness.
+   */
+  maxDepthAgeMs = 500;
+
+  private lastDepthPosition = new THREE.Vector3(NaN, NaN, NaN);
+  private lastDepthQuaternion = new THREE.Quaternion(NaN, NaN, NaN, NaN);
+  private lastSceneSignature = NaN;
+  private lastDepthUpdateMs = -Infinity;
+
+  // Scratch used to hash the raw bits of a float, so the signature reacts to
+  // any change rather than relying on a tolerance.
+  private readonly hashFloat = new Float64Array(1);
+  private readonly hashInts = new Int32Array(this.hashFloat.buffer);
+
   constructor(private simulatorScene: SimulatorScene) {}
 
   /**
@@ -77,11 +95,69 @@ export class SimulatorDepth {
     // setTimeout-based fence poll inside readRenderTargetPixelsAsync
     // was a dominant main-thread cost in perf traces before this).
     if (this.updateInFlight) return;
+    // Reading the depth target back stalls the GPU pipeline: the buffer is
+    // only 160x160 but the readback has to wait for the render to finish, so
+    // it costs far more than its size suggests. When neither the view nor
+    // anything in the scene has moved the result would be identical, so skip
+    // the whole render + readback and keep the previous buffer.
+    if (!this.depthNeedsUpdate()) return;
     this.renderDepthScene();
+    this.markDepthUpdated();
     this.updateInFlight = true;
     this.updateDepth().finally(() => {
       this.updateInFlight = false;
     });
+  }
+
+  /**
+   * Whether the depth buffer would differ from the one already captured.
+   *
+   * @returns True when the camera moved, the scene moved, or the buffer has
+   * gone stale.
+   */
+  private depthNeedsUpdate() {
+    if (performance.now() - this.lastDepthUpdateMs >= this.maxDepthAgeMs) {
+      return true;
+    }
+    if (
+      !this.depthCamera.position.equals(this.lastDepthPosition) ||
+      !this.depthCamera.quaternion.equals(this.lastDepthQuaternion)
+    ) {
+      return true;
+    }
+    return this.computeSceneSignature() !== this.lastSceneSignature;
+  }
+
+  /**
+   * Cheap hash over the world transforms of everything the depth pass draws.
+   *
+   * Anything that moves, rotates, scales, or is shown or hidden changes the
+   * hash, so a still camera in front of a moving object still refreshes. This
+   * is arithmetic over a few hundred nodes, which is orders of magnitude
+   * cheaper than the GPU stall a readback costs.
+   *
+   * @returns A hash of the scene's current visible transforms.
+   */
+  private computeSceneSignature() {
+    let hash = 0;
+    this.simulatorScene.traverse((object: THREE.Object3D) => {
+      hash = (hash ^ (object.visible ? 0x9e3779b9 : 0x85ebca6b)) | 0;
+      if (!object.visible) return;
+      const e = object.matrixWorld.elements;
+      for (let i = 0; i < 16; i++) {
+        this.hashFloat[0] = e[i];
+        hash = Math.imul(hash ^ this.hashInts[0], 0x27220a95) | 0;
+        hash = Math.imul(hash ^ this.hashInts[1], 0x27220a95) | 0;
+      }
+    });
+    return hash;
+  }
+
+  private markDepthUpdated() {
+    this.lastDepthPosition.copy(this.depthCamera.position);
+    this.lastDepthQuaternion.copy(this.depthCamera.quaternion);
+    this.lastSceneSignature = this.computeSceneSignature();
+    this.lastDepthUpdateMs = performance.now();
   }
 
   private updateDepthCamera() {


### PR DESCRIPTION
follow-up to #373. pattern 1 there was the simulator depth readback stalling the main thread, and #370 fixed the part where the readback promises stacked up. it didn't change how often they run, and that turns out to be most of the desktop profile still.

`SimulatorDepth.update()` renders the depth scene and starts a readback every frame. the target is 160x160 single channel float, about 100 KB, so it isn't bandwidth, it's the stall: reading the target back waits on the GPU. measures at roughly 98 ms per readback on an intel UHD.

and in a stationary view every one of those comes back identical to the last. a probe over 120 consecutive frames showed the simulator camera doesn't move at all in automation mode, 0 frames changed.

so this skips the render + readback unless something that actually affects depth changed. camera transform, plus a hash over the world transform and visibility of every node the depth pass draws, so an object moving under a still camera still refreshes. `maxDepthAgeMs` bounds the worst case since a transform hash can't see skinning or vertex shaders.

numbers from `demos/portals` with a resting camera, five interleaved runs per side so both see the same thermal/background drift, 8s samples, mean ± sd, RTX 4060:

| metric | before | after |
|---|---|---|
| `getBufferSubData` | 244.5 ± 31.9 ms | 0.0 ± 0.0 |
| `getParameter` | 314.9 ± 33.8 ms | 0.0 ± 0.0 |
| `clientWaitSync` | 22.2 ± 3.7 ms | 0.0 ± 0.0 |
| main-thread idle | 67.2 ± 1.3 % | 77.7 ± 1.9 % |
| fps | 156.0 ± 4.5 | 154.6 ± 4.1 |

repeated the whole thing a second time at a different time/thermal state, same shape: `getBufferSubData` 375.9 ± 91.0 -> 1.9 ± 4.3, idle 59.8 ± 4.5 -> 71.8 ± 2.2, fps 151.4 ± 4.7 vs 150.6 ± 6.4.

**fps doesn't change.** the gain is main-thread headroom, ~580 ms of readback and fence-polling per 8s window handed back to app logic / AI / physics. i originally read a single-run pair as +14% fps and that was just noise, run to run spread is ±4.5.

on integrated graphics the readback is much more expensive (a single 10s run showed `getBufferSubData` 7705 ms -> 1721 ms and idle 16% -> 59%), which matters given XR devices are mobile-class GPUs. These are more indicative, since I didn't run these again over averages on the iGPU.

control: `samples/ui`, which has no depth, shows no `getBufferSubData` at all, so the cost really is the readback and not general scene load.

a resting camera is the best case. counting actual readbacks over 16s of moving around portals by hand: 73 would have run before, 33 ran after, so 55% fewer during real use rather than ~87% sitting still. the depth buffer itself comes out byte for byte identical either way, same checksum over all 25600 samples.

the hash itself is cheap, ~14 ms of a 9965 ms window.

10 unit tests cover camera move, object moving under a still camera, visibility toggle, object added, staleness refresh, and the existing in-flight guard.