### PR TITLE
clear the physics interval and free the rapier world on dispose

### DIFF
--- a/src/core/Core.test.ts
+++ b/src/core/Core.test.ts
@@ -292,6 +292,7 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
     it('should catch and emit physicsStep exceptions without crashing physics simulation', () => {
       core.physics = {
         physicsStep: vi.fn(),
+        dispose: vi.fn(),
       } as unknown as Physics;
 
       const script1 = {
@@ -337,6 +338,7 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
       core.scriptsManager.catchExceptions = false;
       core.physics = {
         physicsStep: vi.fn(),
+        dispose: vi.fn(),
       } as unknown as Physics;
 
       const script1 = {
@@ -368,6 +370,31 @@ describe('Core and ScriptsManager exception handling via EventDispatcher', () =>
       expect(script1.physicsStep).toHaveBeenCalled();
       expect(script2.physicsStep).not.toHaveBeenCalled();
       expect(events.length).toBe(0);
+    });
+
+    it('stops the physics interval and frees the world on dispose', () => {
+      vi.useFakeTimers();
+      const physicsStep = vi.fn();
+      const dispose = vi.fn();
+      core.physics = {
+        physicsStep,
+        dispose,
+        timestep: 0.01,
+      } as unknown as Physics;
+      const intervalId = setInterval(physicsStep, 10);
+      (core as unknown as {physicsIntervalId?: unknown}).physicsIntervalId =
+        intervalId;
+
+      core.dispose();
+
+      // The interval keeps physics stepping off the render loop, so leaving it
+      // running outlives the session.
+      physicsStep.mockClear();
+      vi.advanceTimersByTime(100);
+      expect(physicsStep).not.toHaveBeenCalled();
+      // Rapier holds WASM memory that GC cannot reclaim on its own.
+      expect(dispose).toHaveBeenCalled();
+      vi.useRealTimers();
     });
   });
 

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -132,6 +132,7 @@ export class Core {
   depth = new Depth();
   lighting?: Lighting;
   physics?: Physics;
+  private physicsIntervalId?: ReturnType<typeof setInterval>;
   xrButton?: XRButton;
   effects?: XREffects;
   ai = new AI();
@@ -249,6 +250,15 @@ export class Core {
   }
 
   dispose() {
+    // Physics steps off the render loop on its own interval, so it keeps
+    // running after teardown unless the handle is cleared. Freeing the Rapier
+    // world matters too: it holds WASM memory that garbage collection cannot
+    // reclaim on its own.
+    if (this.physicsIntervalId !== undefined) {
+      clearInterval(this.physicsIntervalId);
+      this.physicsIntervalId = undefined;
+    }
+    this.physics?.dispose();
     this.input.dispose();
     window.removeEventListener('resize', this.onWindowResize);
   }
@@ -505,7 +515,10 @@ export class Core {
     this.renderer.setAnimationLoop(this.update);
 
     if (this.physics) {
-      setInterval(this.physicsStep, 1000 * this.physics.timestep);
+      this.physicsIntervalId = setInterval(
+        this.physicsStep,
+        1000 * this.physics.timestep
+      );
     }
 
     if (this.options.reticles.enabled) {


### PR DESCRIPTION
`Core` starts physics with `setInterval(this.physicsStep, ...)` and throws the handle away, so nothing can stop it. it keeps stepping after the session ends and after `Core.dispose()`, and it also runs concurrently with `stepFrame()`, which is meant to give deterministic manual stepping for tests.

`Physics.dispose()` already frees the rapier event queue and world, and its own comment says that's crucial for preventing memory leaks when the XR session ends. nothing ever called it. rapier holds WASM memory that GC can't reclaim on its own.

reachable from ballpit, balloonpop, rain and measure.

measured in a real browser on ballpit: physics runs 137 steps per 3s normally. call `xb.core.dispose()` and it keeps running at exactly the same rate, 137 steps per 3s, indefinitely. with this change it drops to 0.

test uses fake timers to check the interval actually stops after dispose rather than just that `clearInterval` was called.