### PR TITLE
skip the second eye's depth readback

### DIFF
--- a/src/depth/Depth.test.ts
+++ b/src/depth/Depth.test.ts
@@ -143,4 +143,71 @@ describe('Depth', () => {
       vi.restoreAllMocks();
     });
   });
+  describe('updateGPUDepthData readback', () => {
+    /**
+     * Depth with just enough wired up to exercise the GPU depth path.
+     */
+    function createDepthWithConverter(convertGPUToCPU: () => unknown) {
+      const depth = createDepth();
+      depth.options = {
+        depthMesh: {enabled: true},
+        depthTexture: {enabled: false},
+      } as never;
+      (depth as unknown as {gpuDepthConverter: unknown}).gpuDepthConverter = {
+        convertGPUToCPU,
+      };
+      // updateDepthMatrices needs these populated per view.
+      vi.spyOn(
+        depth as unknown as {updateDepthMatrices: () => void},
+        'updateDepthMatrices'
+      ).mockImplementation(() => {});
+      return depth;
+    }
+
+    const fakeDepthData = {
+      width: 2,
+      height: 2,
+      data: new Float32Array([1, 2, 3, 4]).buffer,
+    } as unknown as XRWebGLDepthInformation;
+
+    it('reads back the first view, which is the one anything consumes', () => {
+      const convert = vi.fn(() => ({
+        width: 2,
+        height: 2,
+        data: new Float32Array([1, 2, 3, 4]).buffer,
+      }));
+      const depth = createDepthWithConverter(convert);
+
+      depth.updateGPUDepthData(fakeDepthData, 0);
+
+      expect(convert).toHaveBeenCalledTimes(1);
+      expect(depth.depthArray[0]).toBeInstanceOf(Float32Array);
+    });
+
+    it('does not read back the second view', () => {
+      // The readback is a synchronous GPU stall and nothing reads index 1, so
+      // running it for the second eye costs a stall per frame for nothing.
+      const convert = vi.fn(() => ({
+        width: 2,
+        height: 2,
+        data: new Float32Array([1, 2, 3, 4]).buffer,
+      }));
+      const depth = createDepthWithConverter(convert);
+
+      depth.updateGPUDepthData(fakeDepthData, 1);
+
+      expect(convert).not.toHaveBeenCalled();
+    });
+
+    it('still records the raw GPU depth for every view', () => {
+      // The per-view GPU data and matrices are still needed, only the CPU
+      // readback is skipped.
+      const convert = vi.fn(() => null);
+      const depth = createDepthWithConverter(convert);
+
+      depth.updateGPUDepthData(fakeDepthData, 1);
+
+      expect(depth.gpuDepthData[1]).toBe(fakeDepthData);
+    });
+  });
 });

--- a/src/depth/Depth.ts
+++ b/src/depth/Depth.ts
@@ -306,9 +306,14 @@ export class Depth {
   updateGPUDepthData(depthData: XRWebGLDepthInformation, viewId: number) {
     this.gpuDepthData[viewId] = depthData;
     this.updateDepthMatrices(depthData, viewId);
+    // Reading the depth target back is a synchronous GPU stall, and in stereo
+    // this runs once per eye. Only the first view's CPU depth is ever
+    // consumed: getDepth, getDepthInMeters, getVertex and the depth mesh all
+    // read index 0. So the second eye's readback stalls the pipeline for data
+    // nothing looks at.
     // For now, assume that we need cpu depth only if depth mesh is enabled.
     // In the future, add a separate option.
-    const needCpuDepth = this.options.depthMesh.enabled;
+    const needCpuDepth = this.options.depthMesh.enabled && viewId === 0;
     const cpuDepth =
       needCpuDepth && this.gpuDepthConverter
         ? this.gpuDepthConverter.convertGPUToCPU(depthData)


### PR DESCRIPTION
`Depth.update` loops over the views in the frame, so on a stereo headset `updateGPUDepthData` runs once per eye. each call converts the GPU depth texture by rendering it and then calling the *synchronous* `readRenderTargetPixels`, which stalls the render thread until the GPU drains.

only the first view's CPU depth is ever consumed though. `getDepth`, `getDepthInMeters` and `getVertex` all read index 0 (`Depth.ts` lines 41, 130, 143, 165, 170, 188, 203) and the depth mesh update is already gated on `viewId == 0`. nothing in the SDK, demos, samples or templates reads `depthArray[1]` or `cpuDepthData[1]`. so in stereo half of those stalls produce data nothing looks at.

one condition:

```ts
const needCpuDepth = this.options.depthMesh.enabled && viewId === 0;
```

the per-view work that's actually needed stays: depth matrices are still computed for both eyes, and the native depth texture is still updated per view. neither of those stalls.

## how much is it worth

can't measure the real path without a headset, since it needs `depthUsage === 'gpu-optimized'` and a real `XRFrame`. so this is a proxy, measured without a laptop (RTX 4060, chrome 151) through the SDK's own renderer, on an R32F target the size of the XR depth buffer:

| target | render only | readback | total |
|---|---|---|---|
| 160x160 | 0.05 ms | 0.43 ms | 0.48 ms |
| 320x320 | 0.10 ms | 0.433 ms | 0.53 ms |

the readback is ~90% of it, and it's flat across a 4x pixel increase, which says you're paying for the pipeline stall rather than the pixels. removing one per frame is worth ~0.43 ms there, about 4% of a 90Hz budget.

to be clear those are on a discrete GPU, not device numbers, and not even the same code path. on a tile-based mobile GPU a readback forces tile memory out to main memory, so i'd expect the saving to be larger on device, but that's reasoning not measurement.

**would really appreciate someone with a Galaxy XR (or any Android XR device that reports `gpu-optimized` depth) running a before/after on this.** that's the one number i can't get.

## risk

`depthArray` and `cpuDepthData` are public fields, so an app reading index 1 directly would now see stale data instead of fresh. nothing in this repo does, and it's undocumented, but worth flagging.

three tests cover it: first view reads back, second view doesn't, and the per-view GPU data/matrices are still recorded for both. i checked the second-view test actually fails without the change rather than passing vacuously.

related: the same synchronous readback pattern is why #370 exists on the simulator side. `SimulatorDepth` and `ScreenshotSynthesizer` both use `readRenderTargetPixelsAsync`; `GPUDepthConverter` is the one remaining synchronous one. making it async would be the natural follow-up, but it trades the stall for a frame or two of latency plus the fence polling that #373 flagged, so halving the count first seemed like the cheaper win.