### PR TITLE
feat(mcp): add a server exposing the xb-* skills and API surface

### DIFF
--- a/.github/workflows/mcp-check.yml
+++ b/.github/workflows/mcp-check.yml
@@ -43,9 +43,10 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
-      # search_api reads the generated definitions, and the test workflow does
-      # not build. Without this, a format change in the generated .d.ts would
-      # silently stop real API names resolving and nothing would notice.
+      # search_api reads the generated definitions. The test workflow only
+      # builds them as a side effect of `npm ci`, which it skips on a
+      # node_modules cache hit, so the check against the real file would run
+      # only sometimes. Building here makes it deterministic.
       - name: Build SDK
         run: npm run build:sdk
 

--- a/.github/workflows/mcp-check.yml
+++ b/.github/workflows/mcp-check.yml
@@ -1,0 +1,53 @@
+name: MCP API Index Check
+
+on:
+  push:
+    branches-ignore:
+      - 'build'
+    paths:
+      - 'src/**'
+      - 'skills/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'rollup.config.js'
+      - '.github/workflows/mcp-check.yml'
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  mcp-api-index:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Cache Node Modules
+        id: cache-node-modules
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-root-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+
+      # search_api reads the generated definitions, and the test workflow does
+      # not build. Without this, a format change in the generated .d.ts would
+      # silently stop real API names resolving and nothing would notice.
+      - name: Build SDK
+        run: npm run build:sdk
+
+      - name: Check the API index against the built definitions
+        run: npx vitest run src/addons/mcp

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "three-pathfinding": "^1.3.0"
       },
       "bin": {
+        "xrblocks-mcp": "src/addons/mcp/server/bin.js",
         "xrblocks-remote-control": "src/addons/remote-control/server/relay.js"
       },
       "devDependencies": {
@@ -23,6 +24,7 @@
         "@google/genai": "^2.7.0",
         "@mediapipe/tasks-audio": "^0.10.35",
         "@mediapipe/tasks-vision": "^0.10.34",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@pmndrs/uikit": "^1.0.64",
         "@preact/signals-core": "^1.14.0",
         "@rollup/plugin-inject": "^5.0.5",
@@ -509,6 +511,19 @@
         }
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -690,6 +705,71 @@
       }
     },
     "node_modules/@microsoft/tsdoc-config/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
@@ -2168,6 +2248,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -2217,6 +2311,48 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
@@ -2354,6 +2490,62 @@
         "node": "*"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
@@ -2393,6 +2585,16 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -2552,12 +2754,74 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/corser": {
       "version": "2.0.1",
@@ -2690,6 +2954,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2725,12 +2999,29 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -2794,6 +3085,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3138,12 +3436,45 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -3153,6 +3484,70 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/extend": {
@@ -3262,6 +3657,28 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3349,6 +3766,26 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fsevents": {
@@ -3620,6 +4057,16 @@
         "he": "bin/he"
       }
     },
+    "node_modules/hono": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -3639,6 +4086,27 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/http-proxy": {
       "version": "1.18.1",
@@ -3744,6 +4212,33 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -3794,6 +4289,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3865,6 +4367,16 @@
       "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3964,6 +4476,13 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4402,6 +4921,33 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/meshoptimizer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
@@ -4420,6 +4966,33 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/minimatch": {
@@ -4491,6 +5064,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -4531,6 +5114,16 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -4554,6 +5147,29 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/openai": {
       "version": "6.7.0",
@@ -4671,6 +5287,16 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4715,6 +5341,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -4740,6 +5377,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/portfinder": {
@@ -4835,6 +5482,20 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4859,6 +5520,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/require-from-string": {
@@ -5011,6 +5719,23 @@
         "typescript": "^4.5 || ^5.0"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -5089,6 +5814,33 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
@@ -5098,6 +5850,33 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -5275,6 +6054,16 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "4.1.0",
@@ -5459,6 +6248,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -5568,6 +6367,39 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -5625,6 +6457,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5641,6 +6483,16 @@
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vite": {
       "version": "8.0.16",
@@ -5962,6 +6814,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
@@ -6058,6 +6917,26 @@
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "build/xrblocks.d.ts",
   "type": "module",
   "bin": {
-    "xrblocks-remote-control": "./src/addons/remote-control/server/relay.js"
+    "xrblocks-remote-control": "./src/addons/remote-control/server/relay.js",
+    "xrblocks-mcp": "./src/addons/mcp/server/bin.js"
   },
   "scripts": {
     "dev": "concurrently \"npm:build:watch\" \"npm:serve\"",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@google/genai": "^2.7.0",
     "@mediapipe/tasks-audio": "^0.10.35",
     "@mediapipe/tasks-vision": "^0.10.34",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@pmndrs/uikit": "^1.0.64",
     "@preact/signals-core": "^1.14.0",
     "@rollup/plugin-inject": "^5.0.5",

--- a/skills/README.md
+++ b/skills/README.md
@@ -65,3 +65,11 @@ skill points to it; start app-generation work from the workflow layer.
 Deep references some skills link to live next to the code:
 [`../src/addons/uiblocks/SKILL.md`](../src/addons/uiblocks/SKILL.md),
 [`../src/addons/netblocks/SKILL.md`](../src/addons/netblocks/SKILL.md), [`../src/addons/lipsync/SKILL.md`](../src/addons/lipsync/SKILL.md).
+
+## Serving these to an agent
+
+These skills are files, so any agent with filesystem access can read them
+directly. For agents that reach a project over the Model Context Protocol
+instead, [`../src/addons/mcp/`](../src/addons/mcp/README.md) serves them as
+tools (`list_skills`, `get_skill`) alongside a `search_api` lookup over the
+SDK's public surface.

--- a/src/addons/mcp/README.md
+++ b/src/addons/mcp/README.md
@@ -25,7 +25,7 @@ your client's MCP config (Claude Desktop, Copilot CLI at
     "xrblocks": {
       "type": "stdio",
       "command": "npx",
-      "args": ["xrblocks-mcp"]
+      "args": ["--yes", "--package=xrblocks", "xrblocks-mcp"]
     }
   }
 }

--- a/src/addons/mcp/README.md
+++ b/src/addons/mcp/README.md
@@ -70,6 +70,12 @@ nothing, so the agent is told not to call the symbol rather than left to guess.
 `search_api` reads `build/xrblocks.d.ts`, which is generated. In a clone, run
 `npm run build:sdk` first or the tool will say so.
 
+The indexing rules are pinned against a fixture so they run without a build,
+and a separate workflow builds the SDK and runs the same tests against the real
+generated file. A fixture cannot notice the definition generator changing its
+output format, and that failure is silent: real names stop resolving and the
+tool starts calling them fake.
+
 The JSON-RPC stdio transport is implemented directly rather than via
 `@modelcontextprotocol/sdk`. This package has one runtime dependency, and a
 dependency in a shipped binary is paid by everyone who installs the SDK. The

--- a/src/addons/mcp/README.md
+++ b/src/addons/mcp/README.md
@@ -1,0 +1,76 @@
+# XR Blocks MCP server
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server that gives a
+coding agent the `xb-*` skills and the SDK's public API surface.
+
+## Why
+
+`AGENTS.md` puts it plainly: hallucinated or inconsistent APIs are the single
+biggest cause of broken generated apps. An agent with no grounding writes
+plausible-looking calls that do not exist — `createXRScene()`, `useGesture()`,
+`xr.agent.hands.playGesture()` are all real examples from eval runs.
+
+Skills answer "how do I do this in XR Blocks". This server delivers them
+on demand, and adds a way to check that a symbol is real before calling it.
+
+## Setup
+
+The server ships with the package and needs no extra dependencies. Add it to
+your client's MCP config (Claude Desktop, Copilot CLI at
+`~/.copilot/mcp-config.json`, Cursor, ...):
+
+```json
+{
+  "mcpServers": {
+    "xrblocks": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["xrblocks-mcp"]
+    }
+  }
+}
+```
+
+Working from a clone instead of the published package:
+
+```json
+{
+  "mcpServers": {
+    "xrblocks": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["/path/to/xrblocks/src/addons/mcp/server/bin.js"]
+    }
+  }
+}
+```
+
+## Tools
+
+| Tool                | Returns                                                                   |
+| ------------------- | ------------------------------------------------------------------------- |
+| `list_skills`       | Every skill with a short description of what it covers and when to use it |
+| `get_skill(name)`   | The full `SKILL.md`, including worked examples                            |
+| `search_api(query)` | Matching declarations from the SDK's type definitions                     |
+
+`list_skills` shortens each description, because it is the call an agent makes
+first and its whole output lands in the context window before any work starts.
+`get_skill` returns the untruncated text.
+
+`search_api` indexes members as well as top-level declarations. Much of the API
+an app actually calls is methods on a class rather than free functions —
+`enableDepth()` lives on `Options` — and an index that missed those would report
+a real API as missing, which is worse than not answering.
+
+When nothing matches, `search_api` says so explicitly rather than returning
+nothing, so the agent is told not to call the symbol rather than left to guess.
+
+## Notes
+
+`search_api` reads `build/xrblocks.d.ts`, which is generated. In a clone, run
+`npm run build:sdk` first or the tool will say so.
+
+The JSON-RPC stdio transport is implemented directly rather than via
+`@modelcontextprotocol/sdk`. This package has one runtime dependency, and a
+dependency in a shipped binary is paid by everyone who installs the SDK. The
+trade-off is that protocol changes have to be tracked by hand.

--- a/src/addons/mcp/server/bin.js
+++ b/src/addons/mcp/server/bin.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+/**
+ * Executable entry point for the XR Blocks MCP server.
+ *
+ * Kept separate from `index.js` so that module stays importable: a shebang at
+ * the top of an ES module breaks the transform some bundlers and test runners
+ * apply when importing it.
+ *
+ * Run with:
+ *
+ *   npx xrblocks-mcp
+ */
+import {serve} from './index.js';
+
+serve();

--- a/src/addons/mcp/server/bin.js
+++ b/src/addons/mcp/server/bin.js
@@ -8,7 +8,7 @@
  *
  * Run with:
  *
- *   npx xrblocks-mcp
+ *   npx --package=xrblocks xrblocks-mcp
  */
 import {serve} from './index.js';
 

--- a/src/addons/mcp/server/conformance.test.ts
+++ b/src/addons/mcp/server/conformance.test.ts
@@ -1,0 +1,72 @@
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
+import {afterAll, beforeAll, describe, expect, it} from 'vitest';
+
+/**
+ * Drives the server with the official MCP client rather than our own idea of
+ * the protocol.
+ *
+ * The transport here is hand-written to keep the shipped binary free of
+ * dependencies, which means spec changes are not picked up by bumping a
+ * version. The SDK is a devDependency only, so nothing reaches consumers, and
+ * bumping it turns "someone should read the changelog" into a failing test.
+ */
+describe('MCP conformance', () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    client = new Client({name: 'xrblocks-conformance', version: '0.0.0'});
+    await client.connect(
+      new StdioClientTransport({
+        command: process.execPath,
+        args: ['src/addons/mcp/server/bin.js'],
+      })
+    );
+  }, 30000);
+
+  afterAll(async () => {
+    await client?.close();
+  });
+
+  it('completes the handshake the SDK expects', () => {
+    // connect() throws if initialize is malformed, so reaching here is most of
+    // the assertion.
+    expect(client.getServerVersion()?.name).toBe('xrblocks');
+  });
+
+  it('advertises tools the SDK can parse', async () => {
+    const {tools} = await client.listTools();
+
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      'get_skill',
+      'list_skills',
+      'search_api',
+    ]);
+    for (const tool of tools) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.inputSchema.type).toBe('object');
+    }
+  });
+
+  it('returns content the SDK can read', async () => {
+    const result = await client.callTool({
+      name: 'list_skills',
+      arguments: {},
+    });
+    const content = result.content as Array<{type: string; text: string}>;
+
+    expect(result.isError).toBe(false);
+    expect(content[0].type).toBe('text');
+    expect(content[0].text).toContain('xb-depth');
+  });
+
+  it('answers ping', async () => {
+    await expect(client.ping()).resolves.toBeDefined();
+  });
+
+  it('surfaces an unknown tool as an error rather than a result', async () => {
+    await expect(
+      client.callTool({name: 'no_such_tool', arguments: {}})
+    ).rejects.toThrow();
+  });
+});

--- a/src/addons/mcp/server/index.js
+++ b/src/addons/mcp/server/index.js
@@ -32,6 +32,7 @@ const PACKAGE_ROOT = resolve(
   '../../../..'
 );
 const SKILLS_DIR = join(PACKAGE_ROOT, 'skills');
+const TYPES_FILE = join(PACKAGE_ROOT, 'build', 'xrblocks.d.ts');
 
 /**
  * Reads the `name` and `description` out of a SKILL.md YAML frontmatter block.
@@ -90,6 +91,90 @@ export function loadSkills() {
   return skills.sort((a, b) => a.name.localeCompare(b.name));
 }
 
+let cachedSymbols = null;
+
+/**
+ * Extracts the declared public symbols from the built type definitions.
+ *
+ * The barrel at `src/xrblocks.ts` is almost entirely `export * from`, so it
+ * names nothing itself. The generated `.d.ts` is the only place the real
+ * surface is enumerated.
+ *
+ * Indexes members as well as top-level declarations, because much of the API
+ * an app actually calls is methods on a class rather than free functions:
+ * `enableDepth()` is a method on `Options`, not a top-level export, and an
+ * index that missed it would tell an agent a real API does not exist.
+ *
+ * @returns {Array<{name: string, kind: string, owner: string|null, signature: string}>} Symbols.
+ */
+export function loadSymbols() {
+  if (cachedSymbols) return cachedSymbols;
+  cachedSymbols = [];
+  if (!existsSync(TYPES_FILE)) return cachedSymbols;
+
+  const topLevel =
+    /^(?:export\s+)?(?:declare\s+)?(abstract class|class|function|const|let|var|interface|type|enum)\s+([A-Za-z_$][\w$]*)/;
+  // Indented members: methods, properties, getters. Skips private/# members.
+  const member =
+    /^\s+(?:(?:public|protected|readonly|static|abstract|get|set)\s+)*([A-Za-z_$][\w$]*)\s*[(<:?]/;
+
+  const seen = new Set();
+  let owner = null;
+  let depth = 0;
+
+  for (const raw of readFileSync(TYPES_FILE, 'utf8').split(/\r?\n/)) {
+    const line = raw.replace(/\s+$/, '');
+    if (!line.trim()) continue;
+
+    const top = line.match(topLevel);
+    if (top) {
+      const [, kind, name] = top;
+      owner = /class|interface/.test(kind) ? name : null;
+      depth = 0;
+      const key = `${kind}:${name}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        cachedSymbols.push({
+          name,
+          kind,
+          owner: null,
+          signature: line.trim().replace(/\s+/g, ' '),
+        });
+      }
+      continue;
+    }
+
+    if (owner) {
+      // Track nesting so we only take direct members of the type.
+      const opens = (line.match(/\{/g) || []).length;
+      const closes = (line.match(/\}/g) || []).length;
+      if (/^\}/.test(line.trim()) && depth === 0) {
+        owner = null;
+        continue;
+      }
+      if (depth === 0) {
+        const mem = line.match(member);
+        if (mem && !mem[1].startsWith('_')) {
+          const name = mem[1];
+          const key = `member:${owner}.${name}`;
+          if (!seen.has(key)) {
+            seen.add(key);
+            cachedSymbols.push({
+              name,
+              kind: 'member',
+              owner,
+              signature: `${owner}.${line.trim().replace(/\s+/g, ' ')}`,
+            });
+          }
+        }
+      }
+      depth += opens - closes;
+      if (depth < 0) depth = 0;
+    }
+  }
+  return cachedSymbols;
+}
+
 export const TOOLS = [
   {
     name: 'list_skills',
@@ -107,6 +192,23 @@ export const TOOLS = [
         name: {type: 'string', description: 'Skill name, e.g. xb-depth.'},
       },
       required: ['name'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'search_api',
+    description:
+      "Search the XR Blocks public API surface for a symbol. Use this to confirm a class, function, or option actually exists before writing code that calls it, rather than guessing. Returns matching declarations from the SDK's type definitions.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Symbol name or fragment, e.g. enableDepth or Reticle.',
+        },
+        limit: {type: 'number', description: 'Max results, default 25.'},
+      },
+      required: ['query'],
       additionalProperties: false,
     },
   },
@@ -147,6 +249,44 @@ export function callTool(name, args = {}) {
       };
     }
     return {text: readFileSync(skill.path, 'utf8')};
+  }
+
+  if (name === 'search_api') {
+    const query = String(args.query || '').trim();
+    if (!query) {
+      return {text: 'Missing required argument: query.', isError: true};
+    }
+    const symbols = loadSymbols();
+    if (!symbols.length) {
+      return {
+        text:
+          `No type definitions found at ${TYPES_FILE}. Run "npm run build:sdk" ` +
+          `so the API surface can be searched.`,
+        isError: true,
+      };
+    }
+    const needle = query.toLowerCase();
+    const limit = Number(args.limit) > 0 ? Number(args.limit) : 25;
+    const exact = [];
+    const partial = [];
+    for (const s of symbols) {
+      const lower = s.name.toLowerCase();
+      if (lower === needle) exact.push(s);
+      else if (lower.includes(needle)) partial.push(s);
+    }
+    const hits = [...exact, ...partial].slice(0, limit);
+    if (!hits.length) {
+      return {
+        text:
+          `No XR Blocks API matches "${query}". It is likely not a real symbol, ` +
+          `so do not call it. Use list_skills to find the right area instead.`,
+      };
+    }
+    return {
+      text:
+        `${hits.length} match(es) for "${query}":\n\n` +
+        hits.map((s) => `${s.kind} ${s.name}\n    ${s.signature}`).join('\n'),
+    };
   }
 
   return {text: `Unknown tool: ${name}`, isError: true};

--- a/src/addons/mcp/server/index.js
+++ b/src/addons/mcp/server/index.js
@@ -175,6 +175,35 @@ export function loadSymbols() {
   return cachedSymbols;
 }
 
+/**
+ * Shortens a skill description for the listing.
+ *
+ * `list_skills` is the tool an agent calls first, so its whole output lands in
+ * the context window before any real work starts. The full descriptions run to
+ * a thousand characters each and mostly enumerate covered APIs, which only
+ * matters once a skill has been chosen. Keeping the leading sentences answers
+ * "is this the one I want", and `get_skill` still returns everything.
+ *
+ * @param {string} description - Full frontmatter description.
+ * @param {number} maxLength - Soft character budget.
+ * @returns {string} A shortened description.
+ */
+export function summarize(description, maxLength = 220) {
+  const text = (description || '').trim();
+  if (!text) return '(no description)';
+  if (text.length <= maxLength) return text;
+
+  // Prefer cutting on a sentence boundary so the result reads as prose. Avoid
+  // splitting on the dot in an API name like `xb.core.sound`.
+  let out = '';
+  for (const sentence of text.split(/(?<=[.!?])\s+(?=[A-Z(`])/)) {
+    if (out && (out + ' ' + sentence).length > maxLength) break;
+    out = out ? `${out} ${sentence}` : sentence;
+  }
+  if (!out) out = text.slice(0, maxLength).replace(/\s+\S*$/, '');
+  return out.length < text.length ? `${out} …` : out;
+}
+
 export const TOOLS = [
   {
     name: 'list_skills',
@@ -228,9 +257,13 @@ export function callTool(name, args = {}) {
       return {text: `No skills found under ${SKILLS_DIR}.`, isError: true};
     }
     const body = skills
-      .map((s) => `## ${s.name}\n${s.description || '(no description)'}`)
+      .map((s) => `## ${s.name}\n${summarize(s.description)}`)
       .join('\n\n');
-    return {text: `${skills.length} XR Blocks skills:\n\n${body}`};
+    return {
+      text:
+        `${skills.length} XR Blocks skills. Descriptions are shortened here; ` +
+        `call get_skill for the full text and code examples.\n\n${body}`,
+    };
   }
 
   if (name === 'get_skill') {

--- a/src/addons/mcp/server/index.js
+++ b/src/addons/mcp/server/index.js
@@ -1,0 +1,248 @@
+/**
+ * Model Context Protocol server for XR Blocks.
+ *
+ * Exposes the `xb-*` skills and the SDK's public API surface to any MCP-capable
+ * agent, so a coding agent can look up how to do something and check that a
+ * symbol actually exists before emitting it.
+ *
+ * The motivation is the failure mode called out in AGENTS.md: hallucinated or
+ * inconsistent APIs are the single biggest cause of broken generated apps. An
+ * agent with no grounding invents plausible-looking calls; this gives it a way
+ * to check.
+ *
+ * Run with:
+ *
+ *   npx xrblocks-mcp
+ *
+ * or point an MCP client at this file directly. Speaks JSON-RPC 2.0 over
+ * stdio, which is the MCP stdio transport, with no runtime dependencies so it
+ * adds nothing to an app's install.
+ */
+import {existsSync, readdirSync, readFileSync} from 'node:fs';
+import {dirname, join, resolve} from 'node:path';
+import {createInterface} from 'node:readline';
+import {fileURLToPath} from 'node:url';
+
+const PROTOCOL_VERSION = '2024-11-05';
+const SERVER_NAME = 'xrblocks';
+
+// src/addons/mcp/server/index.js -> package root
+const PACKAGE_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../..'
+);
+const SKILLS_DIR = join(PACKAGE_ROOT, 'skills');
+
+/**
+ * Reads the `name` and `description` out of a SKILL.md YAML frontmatter block.
+ *
+ * Deliberately hand-rolled rather than pulling in a YAML parser: the block is
+ * two known keys, and a dependency here would be paid by every consumer of the
+ * SDK, which has one runtime dependency today.
+ *
+ * @param {string} text - Full SKILL.md contents.
+ * @returns {{name: string|null, description: string}} Parsed fields.
+ */
+export function parseFrontmatter(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {name: null, description: ''};
+  const block = match[1];
+
+  const nameMatch = block.match(/^name:\s*(.+)$/m);
+  const name = nameMatch ? nameMatch[1].trim() : null;
+
+  // `description` is usually a folded block scalar (`description: >-`) with
+  // indented continuation lines.
+  let description = '';
+  const descMatch = block.match(
+    /^description:\s*(>-|>|\|-|\|)?[ \t]*\r?\n?([\s\S]*)$/m
+  );
+  if (descMatch) {
+    if (descMatch[1]) {
+      const body = [];
+      for (const line of descMatch[2].split(/\r?\n/)) {
+        if (/^\S/.test(line)) break; // a non-indented line starts the next key
+        body.push(line.trim());
+      }
+      description = body.join(' ').trim();
+    } else {
+      description = (descMatch[2].split(/\r?\n/)[0] || '').trim();
+    }
+  }
+  return {name, description};
+}
+
+/**
+ * Loads every skill in the package.
+ *
+ * @returns {Array<{name: string, description: string, path: string}>} Skills.
+ */
+export function loadSkills() {
+  if (!existsSync(SKILLS_DIR)) return [];
+  const skills = [];
+  for (const entry of readdirSync(SKILLS_DIR, {withFileTypes: true})) {
+    if (!entry.isDirectory()) continue;
+    const file = join(SKILLS_DIR, entry.name, 'SKILL.md');
+    if (!existsSync(file)) continue;
+    const {name, description} = parseFrontmatter(readFileSync(file, 'utf8'));
+    skills.push({name: name || entry.name, description, path: file});
+  }
+  return skills.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export const TOOLS = [
+  {
+    name: 'list_skills',
+    description:
+      'List every XR Blocks skill with its description. Each description says what the skill covers and when to use it. Call this first to find which skill matches the task, then call get_skill for the full content.',
+    inputSchema: {type: 'object', properties: {}, additionalProperties: false},
+  },
+  {
+    name: 'get_skill',
+    description:
+      'Return the full text of one XR Blocks skill, including its worked code examples and the APIs it covers. Use a name from list_skills, for example xb-depth.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: {type: 'string', description: 'Skill name, e.g. xb-depth.'},
+      },
+      required: ['name'],
+      additionalProperties: false,
+    },
+  },
+];
+
+/**
+ * Runs a tool and returns its text result.
+ *
+ * @param {string} name - Tool name.
+ * @param {object} args - Tool arguments.
+ * @returns {{text: string, isError?: boolean}} Result payload.
+ */
+export function callTool(name, args = {}) {
+  if (name === 'list_skills') {
+    const skills = loadSkills();
+    if (!skills.length) {
+      return {text: `No skills found under ${SKILLS_DIR}.`, isError: true};
+    }
+    const body = skills
+      .map((s) => `## ${s.name}\n${s.description || '(no description)'}`)
+      .join('\n\n');
+    return {text: `${skills.length} XR Blocks skills:\n\n${body}`};
+  }
+
+  if (name === 'get_skill') {
+    const wanted = String(args.name || '').trim();
+    if (!wanted) {
+      return {text: 'Missing required argument: name.', isError: true};
+    }
+    const skills = loadSkills();
+    const skill = skills.find((s) => s.name === wanted);
+    if (!skill) {
+      return {
+        text:
+          `No skill named "${wanted}". Available: ` +
+          skills.map((s) => s.name).join(', '),
+        isError: true,
+      };
+    }
+    return {text: readFileSync(skill.path, 'utf8')};
+  }
+
+  return {text: `Unknown tool: ${name}`, isError: true};
+}
+
+/** @returns {string} The package version, or 0.0.0 if it cannot be read. */
+function readVersion() {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(join(PACKAGE_ROOT, 'package.json'), 'utf8')
+    );
+    return pkg.version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+/**
+ * Writes one JSON-RPC message to stdout.
+ *
+ * @param {object} msg - Message to send.
+ */
+function send(msg) {
+  process.stdout.write(JSON.stringify(msg) + '\n');
+}
+
+/**
+ * Handles a single JSON-RPC request.
+ *
+ * @param {object} req - Parsed request.
+ */
+export function handle(req) {
+  const {id, method, params} = req;
+  // Notifications carry no id and must not be answered.
+  const isNotification = id === undefined || id === null;
+
+  if (method === 'initialize') {
+    send({
+      jsonrpc: '2.0',
+      id,
+      result: {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: {tools: {}},
+        serverInfo: {name: SERVER_NAME, version: readVersion()},
+      },
+    });
+    return;
+  }
+
+  if (method === 'tools/list') {
+    send({jsonrpc: '2.0', id, result: {tools: TOOLS}});
+    return;
+  }
+
+  if (method === 'tools/call') {
+    let result;
+    try {
+      result = callTool(params?.name, params?.arguments || {});
+    } catch (err) {
+      result = {
+        text: `Tool ${params?.name} failed: ${err.message}`,
+        isError: true,
+      };
+    }
+    send({
+      jsonrpc: '2.0',
+      id,
+      result: {
+        content: [{type: 'text', text: result.text}],
+        isError: !!result.isError,
+      },
+    });
+    return;
+  }
+
+  if (isNotification) return;
+
+  send({
+    jsonrpc: '2.0',
+    id,
+    error: {code: -32601, message: `Method not found: ${method}`},
+  });
+}
+
+/** Starts reading JSON-RPC messages from stdin. */
+export function serve() {
+  const rl = createInterface({input: process.stdin});
+  rl.on('line', (line) => {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    let req;
+    try {
+      req = JSON.parse(trimmed);
+    } catch {
+      return; // Not one of our messages; ignore rather than kill the transport.
+    }
+    handle(req);
+  });
+}

--- a/src/addons/mcp/server/index.js
+++ b/src/addons/mcp/server/index.js
@@ -23,7 +23,14 @@ import {dirname, join, resolve} from 'node:path';
 import {createInterface} from 'node:readline';
 import {fileURLToPath} from 'node:url';
 
-const PROTOCOL_VERSION = '2024-11-05';
+// Versions we will echo back if a client asks for one of them, oldest first.
+// The tool surface is the same in each; only the handshake differs.
+const SUPPORTED_PROTOCOL_VERSIONS = ['2024-11-05', '2025-03-26', '2025-06-18'];
+// What we answer with when the client asks for something we do not know. The
+// newest we speak, since replying with the oldest can make a modern client
+// disconnect even though both sides would have agreed on a later one.
+const PROTOCOL_VERSION =
+  SUPPORTED_PROTOCOL_VERSIONS[SUPPORTED_PROTOCOL_VERSIONS.length - 1];
 const SERVER_NAME = 'xrblocks';
 
 // src/addons/mcp/server/index.js -> package root
@@ -347,21 +354,57 @@ function send(msg) {
 }
 
 /**
- * Handles a single JSON-RPC request.
+ * Handles a single JSON-RPC message.
  *
- * @param {object} req - Parsed request.
+ * @param {unknown} req - Parsed message.
+ * @param {(msg: object) => void} write - Where to write the response. Defaults
+ *   to stdout; tests pass a collector.
  */
-export function handle(req) {
+export function handle(req, write = send) {
+  // A message with no `id` property is a notification and must never be
+  // answered, whatever its method. An explicit `id: null` is a request, and is
+  // answered with a null id.
+  const isNotification =
+    typeof req === 'object' && req !== null && !Object.hasOwn(req, 'id');
+
+  if (typeof req !== 'object' || req === null || Array.isArray(req)) {
+    write({
+      jsonrpc: '2.0',
+      id: null,
+      error: {code: -32600, message: 'Invalid Request'},
+    });
+    return;
+  }
+
   const {id, method, params} = req;
-  // Notifications carry no id and must not be answered.
-  const isNotification = id === undefined || id === null;
+
+  if (typeof method !== 'string') {
+    if (isNotification) return;
+    write({
+      jsonrpc: '2.0',
+      id: id ?? null,
+      error: {
+        code: -32600,
+        message: 'Invalid Request: method must be a string',
+      },
+    });
+    return;
+  }
+
+  if (isNotification) return;
 
   if (method === 'initialize') {
-    send({
+    // Echo the client's version when we speak it, otherwise answer with ours
+    // and let the client decide whether it can continue.
+    const asked = params?.protocolVersion;
+    const version = SUPPORTED_PROTOCOL_VERSIONS.includes(asked)
+      ? asked
+      : PROTOCOL_VERSION;
+    write({
       jsonrpc: '2.0',
       id,
       result: {
-        protocolVersion: PROTOCOL_VERSION,
+        protocolVersion: version,
         capabilities: {tools: {}},
         serverInfo: {name: SERVER_NAME, version: readVersion()},
       },
@@ -369,22 +412,33 @@ export function handle(req) {
     return;
   }
 
+  if (method === 'ping') {
+    write({jsonrpc: '2.0', id, result: {}});
+    return;
+  }
+
   if (method === 'tools/list') {
-    send({jsonrpc: '2.0', id, result: {tools: TOOLS}});
+    write({jsonrpc: '2.0', id, result: {tools: TOOLS}});
     return;
   }
 
   if (method === 'tools/call') {
+    const toolName = params?.name;
+    if (!TOOLS.some((t) => t.name === toolName)) {
+      write({
+        jsonrpc: '2.0',
+        id,
+        error: {code: -32602, message: `Unknown tool: ${toolName}`},
+      });
+      return;
+    }
     let result;
     try {
-      result = callTool(params?.name, params?.arguments || {});
+      result = callTool(toolName, params?.arguments || {});
     } catch (err) {
-      result = {
-        text: `Tool ${params?.name} failed: ${err.message}`,
-        isError: true,
-      };
+      result = {text: `Tool ${toolName} failed: ${err.message}`, isError: true};
     }
-    send({
+    write({
       jsonrpc: '2.0',
       id,
       result: {
@@ -395,9 +449,7 @@ export function handle(req) {
     return;
   }
 
-  if (isNotification) return;
-
-  send({
+  write({
     jsonrpc: '2.0',
     id,
     error: {code: -32601, message: `Method not found: ${method}`},
@@ -414,8 +466,22 @@ export function serve() {
     try {
       req = JSON.parse(trimmed);
     } catch {
-      return; // Not one of our messages; ignore rather than kill the transport.
+      send({
+        jsonrpc: '2.0',
+        id: null,
+        error: {code: -32700, message: 'Parse error'},
+      });
+      return;
     }
-    handle(req);
+    try {
+      handle(req);
+    } catch (err) {
+      // One bad message must not take the transport down with it.
+      send({
+        jsonrpc: '2.0',
+        id: null,
+        error: {code: -32603, message: `Internal error: ${err.message}`},
+      });
+    }
   });
 }

--- a/src/addons/mcp/server/index.js
+++ b/src/addons/mcp/server/index.js
@@ -101,7 +101,36 @@ export function loadSkills() {
 let cachedSymbols = null;
 
 /**
- * Extracts the declared public symbols from the built type definitions.
+ * Reads the names the package actually exports.
+ *
+ * The generated bundle contains every declaration rollup pulled in, including
+ * internal helpers and `sdk_`-prefixed aliases, so the declarations alone are a
+ * much wider set than the public surface. The trailing `export {...}` and
+ * `export type {...}` statements are the authoritative list, so the index is
+ * filtered against them. Without this the tool confirms internal names as real
+ * APIs, which is the failure it exists to prevent.
+ *
+ * @param {string} text - Contents of the .d.ts bundle.
+ * @returns {Set<string>} Exported names.
+ */
+export function parseExportedNames(text) {
+  const names = new Set();
+  // Only top-level statements; the ones nested in `declare namespace sdk` are
+  // indented and re-export the internal aliases.
+  for (const match of text.matchAll(/^export\s+(?:type\s+)?\{([^}]*)\}/gm)) {
+    for (const part of match[1].split(',')) {
+      const entry = part.trim();
+      if (!entry) continue;
+      // `sdk_Reticle as Reticle` is exported under the alias.
+      const as = entry.match(/\bas\s+([A-Za-z_$][\w$]*)$/);
+      names.add(as ? as[1] : entry);
+    }
+  }
+  return names;
+}
+
+/**
+ * Extracts the public API symbols from the built type definitions.
  *
  * The barrel at `src/xrblocks.ts` is almost entirely `export * from`, so it
  * names nothing itself. The generated `.d.ts` is the only place the real
@@ -116,28 +145,43 @@ let cachedSymbols = null;
  */
 export function loadSymbols() {
   if (cachedSymbols) return cachedSymbols;
+  if (!existsSync(TYPES_FILE)) return [];
+  const source = readFileSync(TYPES_FILE, 'utf8');
   cachedSymbols = [];
-  if (!existsSync(TYPES_FILE)) return cachedSymbols;
+
+  const exported = parseExportedNames(source);
 
   const topLevel =
     /^(?:export\s+)?(?:declare\s+)?(abstract class|class|function|const|let|var|interface|type|enum)\s+([A-Za-z_$][\w$]*)/;
-  // Indented members: methods, properties, getters. Skips private/# members.
+  // Indented members: methods, properties, getters, enum values. `protected`
+  // and `private` members are deliberately excluded, since an app cannot call
+  // them and reporting them invites exactly the wrong code.
   const member =
-    /^\s+(?:(?:public|protected|readonly|static|abstract|get|set)\s+)*([A-Za-z_$][\w$]*)\s*[(<:?]/;
+    /^\s+(?:(?:public|readonly|static|abstract|get|set)\s+)*([A-Za-z_$][\w$]*)\s*[(<:?,=]/;
+  const nonPublic = /^\s+(?:private|protected|#)/;
 
   const seen = new Set();
   let owner = null;
   let depth = 0;
+  // Depth at which a private/protected member started, so its nested shape is
+  // skipped too. -1 means nothing is being suppressed.
+  let suppressed = -1;
 
-  for (const raw of readFileSync(TYPES_FILE, 'utf8').split(/\r?\n/)) {
+  for (const raw of source.split(/\r?\n/)) {
     const line = raw.replace(/\s+$/, '');
     if (!line.trim()) continue;
 
     const top = line.match(topLevel);
     if (top) {
       const [, kind, name] = top;
-      owner = /class|interface/.test(kind) ? name : null;
+      // A `type X = {` alias and an `enum X {` both own members worth indexing,
+      // not just classes and interfaces.
+      const ownsMembers =
+        /class|interface|enum/.test(kind) ||
+        (kind === 'type' && /\{\s*$/.test(line));
+      owner = ownsMembers && exported.has(name) ? name : null;
       depth = 0;
+      if (!exported.has(name)) continue;
       const key = `${kind}:${name}`;
       if (!seen.has(key)) {
         seen.add(key);
@@ -152,14 +196,21 @@ export function loadSymbols() {
     }
 
     if (owner) {
-      // Track nesting so we only take direct members of the type.
+      // Track nesting so a private member's inline shape can be skipped.
       const opens = (line.match(/\{/g) || []).length;
       const closes = (line.match(/\}/g) || []).length;
       if (/^\}/.test(line.trim()) && depth === 0) {
         owner = null;
+        suppressed = -1;
         continue;
       }
-      if (depth === 0) {
+      if (suppressed < 0 && nonPublic.test(line)) suppressed = depth;
+
+      // Index at any depth, not just direct members: option bags and returned
+      // shapes are written inline in the declarations, so fields like
+      // `new ModelViewer({raycastToChildren})` or `getSessionState().toolCount`
+      // only exist nested inside a signature.
+      if (suppressed < 0) {
         const mem = line.match(member);
         if (mem && !mem[1].startsWith('_')) {
           const name = mem[1];
@@ -177,6 +228,8 @@ export function loadSymbols() {
       }
       depth += opens - closes;
       if (depth < 0) depth = 0;
+      // The private member's shape has closed, so resume indexing.
+      if (suppressed >= 0 && depth <= suppressed) suppressed = -1;
     }
   }
   return cachedSymbols;

--- a/src/addons/mcp/server/index.js
+++ b/src/addons/mcp/server/index.js
@@ -12,7 +12,7 @@
  *
  * Run with:
  *
- *   npx xrblocks-mcp
+ *   npx --package=xrblocks xrblocks-mcp
  *
  * or point an MCP client at this file directly. Speaks JSON-RPC 2.0 over
  * stdio, which is the MCP stdio transport, with no runtime dependencies so it

--- a/src/addons/mcp/server/index.js
+++ b/src/addons/mcp/server/index.js
@@ -18,7 +18,7 @@
  * stdio, which is the MCP stdio transport, with no runtime dependencies so it
  * adds nothing to an app's install.
  */
-import {existsSync, readdirSync, readFileSync} from 'node:fs';
+import {existsSync, readdirSync, readFileSync, statSync} from 'node:fs';
 import {dirname, join, resolve} from 'node:path';
 import {createInterface} from 'node:readline';
 import {fileURLToPath} from 'node:url';
@@ -99,6 +99,7 @@ export function loadSkills() {
 }
 
 let cachedSymbols = null;
+let cachedMtime = 0;
 
 /**
  * Reads the names the package actually exports.
@@ -130,7 +131,10 @@ export function parseExportedNames(text) {
 }
 
 /**
- * Extracts the public API symbols from the built type definitions.
+ * Indexes the public API symbols in a set of type definitions.
+ *
+ * Kept separate from reading the file so it can be tested against a fixture:
+ * `build/xrblocks.d.ts` is generated and is not present in a fresh clone.
  *
  * The barrel at `src/xrblocks.ts` is almost entirely `export * from`, so it
  * names nothing itself. The generated `.d.ts` is the only place the real
@@ -141,13 +145,11 @@ export function parseExportedNames(text) {
  * `enableDepth()` is a method on `Options`, not a top-level export, and an
  * index that missed it would tell an agent a real API does not exist.
  *
+ * @param {string} source - Contents of a .d.ts bundle.
  * @returns {Array<{name: string, kind: string, owner: string|null, signature: string}>} Symbols.
  */
-export function loadSymbols() {
-  if (cachedSymbols) return cachedSymbols;
-  if (!existsSync(TYPES_FILE)) return [];
-  const source = readFileSync(TYPES_FILE, 'utf8');
-  cachedSymbols = [];
+export function indexSymbols(source) {
+  const symbols = [];
 
   const exported = parseExportedNames(source);
 
@@ -185,7 +187,7 @@ export function loadSymbols() {
       const key = `${kind}:${name}`;
       if (!seen.has(key)) {
         seen.add(key);
-        cachedSymbols.push({
+        symbols.push({
           name,
           kind,
           owner: null,
@@ -217,7 +219,7 @@ export function loadSymbols() {
           const key = `member:${owner}.${name}`;
           if (!seen.has(key)) {
             seen.add(key);
-            cachedSymbols.push({
+            symbols.push({
               name,
               kind: 'member',
               owner,
@@ -232,12 +234,28 @@ export function loadSymbols() {
       if (suppressed >= 0 && depth <= suppressed) suppressed = -1;
     }
   }
+  return symbols;
+}
+
+/**
+ * Loads the public API symbols from the built type definitions.
+ *
+ * Re-indexes when the file changes, so building the SDK while a client holds
+ * the server open does not leave a freshly added API reported as fake.
+ *
+ * @returns {Array<{name: string, kind: string, owner: string|null, signature: string}>} Symbols.
+ */
+export function loadSymbols() {
+  if (!existsSync(TYPES_FILE)) return [];
+  const mtime = statSync(TYPES_FILE).mtimeMs;
+  if (cachedSymbols && cachedMtime === mtime) return cachedSymbols;
+  cachedSymbols = indexSymbols(readFileSync(TYPES_FILE, 'utf8'));
+  cachedMtime = mtime;
   return cachedSymbols;
 }
 
 /**
  * Shortens a skill description for the listing.
- *
  * `list_skills` is the tool an agent calls first, so its whole output lands in
  * the context window before any real work starts. The full descriptions run to
  * a thousand characters each and mostly enumerate covered APIs, which only

--- a/src/addons/mcp/server/index.test.ts
+++ b/src/addons/mcp/server/index.test.ts
@@ -5,6 +5,7 @@ import {
   handle,
   loadSkills,
   loadSymbols,
+  parseExportedNames,
   parseFrontmatter,
   summarize,
   TOOLS,
@@ -93,6 +94,30 @@ describe('JSON-RPC transport', () => {
     expect(result.isError).toBe(false);
     expect(result.content[0].type).toBe('text');
     expect(result.content[0].text).toContain('xb-depth');
+  });
+});
+
+describe('parseExportedNames', () => {
+  it('takes the alias rather than the internal name', () => {
+    const names = parseExportedNames(
+      'export { sdk_Reticle as Reticle, Core };'
+    );
+    expect(names.has('Reticle')).toBe(true);
+    expect(names.has('sdk_Reticle')).toBe(false);
+    expect(names.has('Core')).toBe(true);
+  });
+
+  it('reads type-only exports too', () => {
+    const names = parseExportedNames('export type { DepthOptions };');
+    expect(names.has('DepthOptions')).toBe(true);
+  });
+
+  it('ignores the indented re-exports inside the namespace block', () => {
+    const names = parseExportedNames(
+      '    export type { sdk_Foo as Foo };\nexport { Bar };'
+    );
+    expect(names.has('Bar')).toBe(true);
+    expect(names.has('Foo')).toBe(false);
   });
 });
 
@@ -196,6 +221,54 @@ describe('loadSymbols', () => {
     const symbols = loadSymbols();
 
     expect(symbols.find((s) => s.name === 'Options')).toBeDefined();
+  });
+
+  it('leaves out declarations the package does not export', () => {
+    // The generated bundle carries every declaration rollup pulled in,
+    // including internal helpers and sdk_-prefixed aliases. Reporting those as
+    // real APIs is the exact failure this tool exists to prevent.
+    const names = new Set(loadSymbols().map((s) => s.name));
+
+    expect(names.has('sdk_Reticle')).toBe(false);
+    expect(names.has('musicLibrary')).toBe(false);
+    // The alias target is the real public name and must survive.
+    expect(names.has('Reticle')).toBe(true);
+  });
+
+  it('leaves out protected members, which an app cannot call', () => {
+    const symbols = loadSymbols();
+
+    expect(
+      symbols.find((s) => s.owner === 'Gemini' && s.name === 'queryOnce')
+    ).toBeUndefined();
+  });
+
+  it('indexes members of exported type aliases and enums', () => {
+    const symbols = loadSymbols();
+    const find = (name: string) => symbols.find((s) => s.name === name);
+
+    // Property on an exported `type X = {...}` alias.
+    expect(find('hideSimulatorUi')).toBeDefined();
+    // Value on an exported enum.
+    expect(find('POINTER_LOCK')).toBeDefined();
+  });
+
+  it('indexes fields of inline option bags and returned shapes', () => {
+    // These are written inline inside a signature rather than as their own
+    // type, but they are what an app actually passes and reads:
+    // `new ModelViewer({raycastToChildren})`, `getSessionState().toolCount`.
+    const names = new Set(loadSymbols().map((s) => s.name));
+
+    expect(names.has('raycastToChildren')).toBe(true);
+    expect(names.has('toolCount')).toBe(true);
+  });
+
+  it('does not index a protected field that has no public counterpart', () => {
+    const symbols = loadSymbols();
+
+    expect(
+      symbols.find((s) => s.owner === 'ModelViewer' && s.name === 'controlBar')
+    ).toBeUndefined();
   });
 });
 

--- a/src/addons/mcp/server/index.test.ts
+++ b/src/addons/mcp/server/index.test.ts
@@ -1,0 +1,100 @@
+import {describe, expect, it} from 'vitest';
+
+import {callTool, loadSkills, parseFrontmatter, TOOLS} from './index.js';
+
+describe('parseFrontmatter', () => {
+  it('reads a folded description block', () => {
+    const {name, description} = parseFrontmatter(
+      [
+        '---',
+        'name: xb-depth',
+        'description: >-',
+        '  Add WebXR depth sensing to an app so virtual content is occluded',
+        '  by real geometry.',
+        'other: value',
+        '---',
+        '',
+        '# Body',
+      ].join('\n')
+    );
+
+    expect(name).toBe('xb-depth');
+    expect(description).toBe(
+      'Add WebXR depth sensing to an app so virtual content is occluded by real geometry.'
+    );
+  });
+
+  it('stops the description at the next key', () => {
+    const {description} = parseFrontmatter(
+      ['---', 'description: >-', '  First line.', 'name: xb-thing', '---'].join(
+        '\n'
+      )
+    );
+
+    expect(description).toBe('First line.');
+  });
+
+  it('survives a file with no frontmatter', () => {
+    expect(parseFrontmatter('# Just a heading')).toEqual({
+      name: null,
+      description: '',
+    });
+  });
+});
+
+describe('loadSkills', () => {
+  it('finds the skills that ship with the package', () => {
+    const skills = loadSkills();
+
+    expect(skills.length).toBeGreaterThan(10);
+    for (const skill of skills) {
+      expect(skill.name).toMatch(/^xb-/);
+      expect(skill.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('get_skill', () => {
+  it('returns the full text of a skill', () => {
+    const {text, isError} = callTool('get_skill', {name: 'xb-depth'});
+
+    expect(isError).toBeFalsy();
+    expect(text).toContain('name: xb-depth');
+  });
+
+  it('lists the alternatives when the name is wrong', () => {
+    const {text, isError} = callTool('get_skill', {name: 'xb-not-a-skill'});
+
+    expect(isError).toBe(true);
+    expect(text).toContain('xb-depth');
+  });
+});
+
+describe('list_skills', () => {
+  it('includes every skill', () => {
+    const {text} = callTool('list_skills');
+    const skills = loadSkills();
+
+    expect(text).toContain(`${skills.length} XR Blocks skills`);
+    expect(text).toContain('xb-depth');
+  });
+});
+
+describe('tool declarations', () => {
+  it('declares a schema for every tool', () => {
+    expect(TOOLS.map((t) => t.name).sort()).toEqual([
+      'get_skill',
+      'list_skills',
+    ]);
+    for (const tool of TOOLS) {
+      expect(tool.description.length).toBeGreaterThan(20);
+      expect(tool.inputSchema.type).toBe('object');
+    }
+  });
+
+  it('reports an unknown tool rather than throwing', () => {
+    const {isError} = callTool('nope', {});
+
+    expect(isError).toBe(true);
+  });
+});

--- a/src/addons/mcp/server/index.test.ts
+++ b/src/addons/mcp/server/index.test.ts
@@ -2,12 +2,99 @@ import {describe, expect, it} from 'vitest';
 
 import {
   callTool,
+  handle,
   loadSkills,
   loadSymbols,
   parseFrontmatter,
   summarize,
   TOOLS,
 } from './index.js';
+
+/** Collects what the server would write, instead of hitting stdout. */
+function exchange(message: unknown) {
+  const sent: Array<Record<string, unknown>> = [];
+  handle(message, (msg: Record<string, unknown>) => sent.push(msg));
+  return sent;
+}
+
+describe('JSON-RPC transport', () => {
+  it('answers initialize with the version the client asked for', () => {
+    const [res] = exchange({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {protocolVersion: '2025-06-18'},
+    });
+    expect((res.result as Record<string, unknown>).protocolVersion).toBe(
+      '2025-06-18'
+    );
+  });
+
+  it('falls back to the newest version it speaks when the client asks for an unknown one', () => {
+    const [res] = exchange({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {protocolVersion: '1999-01-01'},
+    });
+    // Answering with the oldest can make a modern client hang up even though
+    // both sides would have agreed on a later version.
+    expect((res.result as Record<string, unknown>).protocolVersion).toBe(
+      '2025-06-18'
+    );
+  });
+
+  it('never answers a notification', () => {
+    // No id means notification, whatever the method.
+    expect(exchange({jsonrpc: '2.0', method: 'tools/list'})).toHaveLength(0);
+    expect(
+      exchange({jsonrpc: '2.0', method: 'notifications/initialized'})
+    ).toHaveLength(0);
+  });
+
+  it('answers ping, which clients use as a health check', () => {
+    const [res] = exchange({jsonrpc: '2.0', id: 7, method: 'ping'});
+    expect(res).toEqual({jsonrpc: '2.0', id: 7, result: {}});
+  });
+
+  it('rejects a non-object message instead of throwing', () => {
+    for (const bad of [null, 42, 'hello', []]) {
+      const [res] = exchange(bad);
+      expect((res.error as Record<string, unknown>).code).toBe(-32600);
+    }
+  });
+
+  it('reports an unknown method as -32601', () => {
+    const [res] = exchange({jsonrpc: '2.0', id: 2, method: 'resources/list'});
+    expect((res.error as Record<string, unknown>).code).toBe(-32601);
+  });
+
+  it('reports an unknown tool as -32602', () => {
+    const [res] = exchange({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: {name: 'no_such_tool', arguments: {}},
+    });
+    expect((res.error as Record<string, unknown>).code).toBe(-32602);
+  });
+
+  it('wraps a tool result in the MCP content envelope', () => {
+    const [res] = exchange({
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'tools/call',
+      params: {name: 'list_skills', arguments: {}},
+    });
+    const result = res.result as {
+      content: Array<{type: string; text: string}>;
+      isError: boolean;
+    };
+    expect(result.isError).toBe(false);
+    expect(result.content[0].type).toBe('text');
+    expect(result.content[0].text).toContain('xb-depth');
+  });
+});
 
 describe('summarize', () => {
   it('leaves a short description alone', () => {

--- a/src/addons/mcp/server/index.test.ts
+++ b/src/addons/mcp/server/index.test.ts
@@ -13,9 +13,11 @@ import {
   TOOLS,
 } from './index.js';
 
-// `build/xrblocks.d.ts` is generated, so it is missing in a fresh clone and on
-// CI, which runs the tests without a build. Assertions against the real file
-// are skipped there; the indexing rules are covered by a fixture instead.
+// `build/xrblocks.d.ts` is generated, so it is missing in a fresh clone. On CI
+// it depends on cache state: the test workflow only runs `npm ci` on a
+// node_modules cache miss, and it is `npm ci` that triggers the `prepare`
+// build. Assertions against the real file are skipped when it is absent; the
+// indexing rules are covered by a fixture so they run either way.
 const hasTypes = existsSync('build/xrblocks.d.ts');
 
 /** Collects what the server would write, instead of hitting stdout. */

--- a/src/addons/mcp/server/index.test.ts
+++ b/src/addons/mcp/server/index.test.ts
@@ -1,8 +1,10 @@
+import {existsSync} from 'node:fs';
 import {describe, expect, it} from 'vitest';
 
 import {
   callTool,
   handle,
+  indexSymbols,
   loadSkills,
   loadSymbols,
   parseExportedNames,
@@ -10,6 +12,11 @@ import {
   summarize,
   TOOLS,
 } from './index.js';
+
+// `build/xrblocks.d.ts` is generated, so it is missing in a fresh clone and on
+// CI, which runs the tests without a build. Assertions against the real file
+// are skipped there; the indexing rules are covered by a fixture instead.
+const hasTypes = existsSync('build/xrblocks.d.ts');
 
 /** Collects what the server would write, instead of hitting stdout. */
 function exchange(message: unknown) {
@@ -204,31 +211,67 @@ describe('loadSkills', () => {
   });
 });
 
-describe('loadSymbols', () => {
+// A miniature stand-in for the generated bundle. `build/xrblocks.d.ts` is a
+// build artifact and is absent in a fresh clone and on CI, so the indexing
+// rules are pinned against this instead of the real file.
+const FIXTURE = `
+declare class Options {
+    enableDepth(): this;
+}
+declare class Gemini {
+    query(prompt: string): Promise<string>;
+    protected queryOnce(): void;
+}
+declare class ModelViewer {
+    protected controlBar?: THREE.Mesh;
+    constructor({ raycastToChildren, }: {
+        raycastToChildren?: boolean | undefined;
+    });
+    getSessionState(): {
+        toolCount: number;
+    };
+}
+declare class Reticle {
+}
+declare const musicLibrary: Record<string, string>;
+declare enum SimulatorMode {
+    POINTER_LOCK = "pointerlock"
+}
+type AutomationModeOptions = {
+    hideSimulatorUi?: boolean;
+};
+type sdk_Reticle = Reticle;
+declare namespace sdk {
+    export { sdk_Reticle as Reticle };
+}
+export { Gemini, ModelViewer, Options, Reticle, SimulatorMode };
+export type { AutomationModeOptions };
+`;
+
+describe('indexSymbols', () => {
+  const symbols = indexSymbols(FIXTURE);
+  const find = (name: string) => symbols.find((s) => s.name === name);
+  const names = new Set(symbols.map((s) => s.name));
+
   it('indexes class members, not just top-level declarations', () => {
     // enableDepth() is a method on Options rather than a free function. An
     // index that only saw top-level declarations would report a real API as
     // missing, which is worse than not answering at all.
-    const symbols = loadSymbols();
-    const enableDepth = symbols.find((s) => s.name === 'enableDepth');
+    const enableDepth = find('enableDepth');
 
     expect(enableDepth).toBeDefined();
-    expect(enableDepth.kind).toBe('member');
-    expect(enableDepth.owner).toBe('Options');
+    expect(enableDepth!.kind).toBe('member');
+    expect(enableDepth!.owner).toBe('Options');
   });
 
   it('indexes top-level classes', () => {
-    const symbols = loadSymbols();
-
-    expect(symbols.find((s) => s.name === 'Options')).toBeDefined();
+    expect(find('Options')).toBeDefined();
   });
 
   it('leaves out declarations the package does not export', () => {
     // The generated bundle carries every declaration rollup pulled in,
     // including internal helpers and sdk_-prefixed aliases. Reporting those as
     // real APIs is the exact failure this tool exists to prevent.
-    const names = new Set(loadSymbols().map((s) => s.name));
-
     expect(names.has('sdk_Reticle')).toBe(false);
     expect(names.has('musicLibrary')).toBe(false);
     // The alias target is the real public name and must survive.
@@ -236,17 +279,15 @@ describe('loadSymbols', () => {
   });
 
   it('leaves out protected members, which an app cannot call', () => {
-    const symbols = loadSymbols();
-
     expect(
       symbols.find((s) => s.owner === 'Gemini' && s.name === 'queryOnce')
+    ).toBeUndefined();
+    expect(
+      symbols.find((s) => s.owner === 'ModelViewer' && s.name === 'controlBar')
     ).toBeUndefined();
   });
 
   it('indexes members of exported type aliases and enums', () => {
-    const symbols = loadSymbols();
-    const find = (name: string) => symbols.find((s) => s.name === name);
-
     // Property on an exported `type X = {...}` alias.
     expect(find('hideSimulatorUi')).toBeDefined();
     // Value on an exported enum.
@@ -254,42 +295,46 @@ describe('loadSymbols', () => {
   });
 
   it('indexes fields of inline option bags and returned shapes', () => {
-    // These are written inline inside a signature rather than as their own
-    // type, but they are what an app actually passes and reads:
+    // Written inline inside a signature rather than as their own type, but
+    // they are what an app passes and reads:
     // `new ModelViewer({raycastToChildren})`, `getSessionState().toolCount`.
-    const names = new Set(loadSymbols().map((s) => s.name));
-
     expect(names.has('raycastToChildren')).toBe(true);
     expect(names.has('toolCount')).toBe(true);
   });
+});
 
-  it('does not index a protected field that has no public counterpart', () => {
+describe('loadSymbols', () => {
+  // Only meaningful once the SDK has been built.
+  it.skipIf(!hasTypes)('indexes the real generated definitions', () => {
     const symbols = loadSymbols();
+    const enableDepth = symbols.find((s) => s.name === 'enableDepth');
 
-    expect(
-      symbols.find((s) => s.owner === 'ModelViewer' && s.name === 'controlBar')
-    ).toBeUndefined();
+    expect(symbols.length).toBeGreaterThan(500);
+    expect(enableDepth?.owner).toBe('Options');
   });
 });
 
 describe('search_api', () => {
-  it('finds a real API', () => {
+  it.skipIf(!hasTypes)('finds a real API', () => {
     const {text, isError} = callTool('search_api', {query: 'enableDepth'});
 
     expect(isError).toBeFalsy();
     expect(text).toContain('enableDepth');
   });
 
-  it('tells the caller a hallucinated API does not exist', () => {
-    // These are APIs a model actually invented when generating xrblocks code
-    // without grounding, which is the failure this tool exists to catch.
-    for (const fake of ['createXRScene', 'useGesture', 'playGesture']) {
-      const {text} = callTool('search_api', {query: fake});
-      expect(text).toContain('No XR Blocks API matches');
+  it.skipIf(!hasTypes)(
+    'tells the caller a hallucinated API does not exist',
+    () => {
+      // These are APIs a model actually invented when generating xrblocks code
+      // without grounding, which is the failure this tool exists to catch.
+      for (const fake of ['createXRScene', 'useGesture', 'playGesture']) {
+        const {text} = callTool('search_api', {query: fake});
+        expect(text).toContain('No XR Blocks API matches');
+      }
     }
-  });
+  );
 
-  it('is case insensitive', () => {
+  it.skipIf(!hasTypes)('is case insensitive', () => {
     expect(callTool('search_api', {query: 'enabledepth'}).text).toContain(
       'enableDepth'
     );
@@ -301,11 +346,21 @@ describe('search_api', () => {
     expect(isError).toBe(true);
   });
 
-  it('honours the result limit', () => {
+  it.skipIf(!hasTypes)('honours the result limit', () => {
     const {text} = callTool('search_api', {query: 'enable', limit: 3});
 
     expect(text).toMatch(/^3 match\(es\)/);
   });
+
+  it.skipIf(hasTypes)(
+    'says to build the SDK when definitions are absent',
+    () => {
+      const {text, isError} = callTool('search_api', {query: 'enableDepth'});
+
+      expect(isError).toBe(true);
+      expect(text).toContain('npm run build:sdk');
+    }
+  );
 });
 
 describe('get_skill', () => {

--- a/src/addons/mcp/server/index.test.ts
+++ b/src/addons/mcp/server/index.test.ts
@@ -1,6 +1,12 @@
 import {describe, expect, it} from 'vitest';
 
-import {callTool, loadSkills, parseFrontmatter, TOOLS} from './index.js';
+import {
+  callTool,
+  loadSkills,
+  loadSymbols,
+  parseFrontmatter,
+  TOOLS,
+} from './index.js';
 
 describe('parseFrontmatter', () => {
   it('reads a folded description block', () => {
@@ -54,6 +60,62 @@ describe('loadSkills', () => {
   });
 });
 
+describe('loadSymbols', () => {
+  it('indexes class members, not just top-level declarations', () => {
+    // enableDepth() is a method on Options rather than a free function. An
+    // index that only saw top-level declarations would report a real API as
+    // missing, which is worse than not answering at all.
+    const symbols = loadSymbols();
+    const enableDepth = symbols.find((s) => s.name === 'enableDepth');
+
+    expect(enableDepth).toBeDefined();
+    expect(enableDepth.kind).toBe('member');
+    expect(enableDepth.owner).toBe('Options');
+  });
+
+  it('indexes top-level classes', () => {
+    const symbols = loadSymbols();
+
+    expect(symbols.find((s) => s.name === 'Options')).toBeDefined();
+  });
+});
+
+describe('search_api', () => {
+  it('finds a real API', () => {
+    const {text, isError} = callTool('search_api', {query: 'enableDepth'});
+
+    expect(isError).toBeFalsy();
+    expect(text).toContain('enableDepth');
+  });
+
+  it('tells the caller a hallucinated API does not exist', () => {
+    // These are APIs a model actually invented when generating xrblocks code
+    // without grounding, which is the failure this tool exists to catch.
+    for (const fake of ['createXRScene', 'useGesture', 'playGesture']) {
+      const {text} = callTool('search_api', {query: fake});
+      expect(text).toContain('No XR Blocks API matches');
+    }
+  });
+
+  it('is case insensitive', () => {
+    expect(callTool('search_api', {query: 'enabledepth'}).text).toContain(
+      'enableDepth'
+    );
+  });
+
+  it('reports a missing query rather than returning everything', () => {
+    const {isError} = callTool('search_api', {query: '  '});
+
+    expect(isError).toBe(true);
+  });
+
+  it('honours the result limit', () => {
+    const {text} = callTool('search_api', {query: 'enable', limit: 3});
+
+    expect(text).toMatch(/^3 match\(es\)/);
+  });
+});
+
 describe('get_skill', () => {
   it('returns the full text of a skill', () => {
     const {text, isError} = callTool('get_skill', {name: 'xb-depth'});
@@ -85,6 +147,7 @@ describe('tool declarations', () => {
     expect(TOOLS.map((t) => t.name).sort()).toEqual([
       'get_skill',
       'list_skills',
+      'search_api',
     ]);
     for (const tool of TOOLS) {
       expect(tool.description.length).toBeGreaterThan(20);

--- a/src/addons/mcp/server/index.test.ts
+++ b/src/addons/mcp/server/index.test.ts
@@ -5,8 +5,40 @@ import {
   loadSkills,
   loadSymbols,
   parseFrontmatter,
+  summarize,
   TOOLS,
 } from './index.js';
+
+describe('summarize', () => {
+  it('leaves a short description alone', () => {
+    expect(summarize('Add depth sensing.')).toBe('Add depth sensing.');
+  });
+
+  it('cuts on a sentence boundary and marks the elision', () => {
+    const text =
+      'Add depth sensing to an app. Use for occlusion and physics colliders. ' +
+      'Covers enableDepth(), the DepthOptions presets, colliderUpdateFps, and ' +
+      'showReticleOnDepthMesh, plus a great deal of further detail that only ' +
+      'matters once the skill has actually been chosen by the agent.';
+    const short = summarize(text);
+
+    expect(short.length).toBeLessThan(text.length);
+    expect(short).toContain('Add depth sensing to an app.');
+    expect(short.endsWith('…')).toBe(true);
+  });
+
+  it('does not split on the dot inside an API name', () => {
+    const text =
+      'Play audio via xb.core.sound in an app and do a number of other ' +
+      'things too, described at considerable length for the listing case.';
+
+    expect(summarize(text, 40)).not.toMatch(/xb\.$/);
+  });
+
+  it('handles an empty description', () => {
+    expect(summarize('')).toBe('(no description)');
+  });
+});
 
 describe('parseFrontmatter', () => {
   it('reads a folded description block', () => {
@@ -139,6 +171,15 @@ describe('list_skills', () => {
 
     expect(text).toContain(`${skills.length} XR Blocks skills`);
     expect(text).toContain('xb-depth');
+  });
+
+  it('stays small enough to be the first call an agent makes', () => {
+    // The full descriptions total roughly 3k tokens, which is a lot to spend
+    // before any work starts. get_skill still returns everything.
+    const {text} = callTool('list_skills');
+
+    expect(text.length).toBeLessThan(8000);
+    expect(text).toContain('call get_skill for the full text');
   });
 });
 


### PR DESCRIPTION
## Description

I've been meaning to do another eval round, but that comes out of my own API key, so I thought to improve it here before I run a whole sweep again.

`createXRScene()`, `useGesture()`, `xr.agent.hands.playGesture()`. None of those exist, they all came out of eval runs, and AGENTS.md already calls hallucinated APIs the top cause of broken generated apps.

To use it you point an MCP client at it, config is in `src/addons/mcp/README.md`. The client asks the server what tools it has on connect, so the model sees `list_skills`, `get_skill` and `search_api` in its context with a line each on when to reach for them. An agent picks `search_api` because it's the only thing that answers "is this symbol real", and `list_skills` because it's cheaper than reading 26 files to find out which one applies.

This doesn't replace the markdown though. In a clone the files are right there and AGENTS.md and GEMINI.md already point at them, so that case is already fine. it's when you've just installed the package that there's nothing, they're sat in node_modules and nothing tells an agent to go look. And checking whether a symbol is real has no answer either way, short of grepping the d.ts yourself.

So this is a stdio MCP server with three tools. `list_skills` and `get_skill` just read the markdown that already ships, so there's no second copy to drift. `search_api` looks a name up in `build/xrblocks.d.ts`, and when it doesn't match it says so outright, since "this isn't real, don't call it" is the answer worth having.

No runtime deps. The JSON-RPC framing is written out by hand rather than pulling in `@modelcontextprotocol/sdk`, because we've got one runtime dep today so I didn't want to increase that anymore. The catch is spec changes only turn up when some client refuses to talk to you, so the SDK is in as a devDependency and there's a test that drives the server with its actual client over a real stdio process: handshake, `tools/list`, a `tools/call` round trip, ping, unknown tool. Dev deps aren't installed by anyone installing xrblocks, so consumers still get zero. Bumping it now tells us if we've drifted instead of relying on someone reading a changelog. Checked it fails for the right reason by disabling ping, which the client rejects with -32601.

Most of the fiddly part was `search_api` being wrong..., since a lookup that says no to a real API is worse than no lookup. Indexing every declaration in the bundle is far too wide, it was happily confirming `sdk_Reticle` and the protected `Gemini.queryOnce`. Too narrow in the other direction as well, because option bags are declared inline, so `new ModelViewer({raycastToChildren})` came back fake. So i have made it such that it now filters through the trailing export statements and indexes members at any depth, skipping private and protected shapes. Checked 45 real APIs against 11 invented ones, nothing wrong either way.

`list_skills` shortens the descriptions, since it's the first call an agent makes and the whole thing lands in context before any work starts. Roughly 3.2k tokens down to 1.3k across 26 skills, and `get_skill` still gives you the full text.

There's a new workflow for this. `search_api` reads the generated d.ts, and whether that exists on CI depends on cache state: the test workflow only runs `npm ci` on a node_modules cache miss, and it's `npm ci` that triggers the `prepare` build. So this one builds explicitly, otherwise the check against the real file only happens on some runs, and a format change from the generator would go unnoticed with real names quietly no longer resolving.

**stdio only.** Works with anything that spawns a local process, so Gemini CLI, Copilot CLI, Claude Desktop, Cursor. Remote clients would want an HTTP transport, which isn't here.

## Type of Change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

Nothing to show, it's a dev-time server with no runtime or visual change.

## Checklist

- [x] **Tested in simulator & device**: Nothing in the SDK bundle changes, so not applicable to runtime. Tested by wiring it into an MCP client and calling all three tools, plus 43 tests over the handshake, notifications, error codes, malformed input, the symbol index, and a conformance pass driving the server with the official MCP client. Suite green at 669.
- [x] **Large Assets ($\ge$ 1MB)**: None.
- [x] **SDK Dynamic Dependencies**: No new runtime dependencies. `@modelcontextprotocol/sdk` is a devDependency used only by the conformance test, and rollup already ignores `src/addons/**/server/**` so none of this is bundled.
- [x] **Security**: No keys or secrets. `get_skill` matches names against the enumerated skill list rather than joining caller input onto a path, so it can't be walked out of `skills/`.
