### PR TITLE
fix(evals): stop comments satisfying an expected API

### DIFF
--- a/evals/prototypes/score_proto.py
+++ b/evals/prototypes/score_proto.py
@@ -3,10 +3,12 @@
 
 Scoring (simple, transparent):
   - import_match:    fraction of expected_imports the agent's main file references
-  - api_match:       fraction of expected_apis the agent's main file references
+  - api_match:       fraction of expected_apis the agent's main file uses, ignoring
+                     comments so prose cannot satisfy a task
   - forbidden_clean: 1.0 if no forbidden_patterns matched, else 0.0
   - parse_ok:        1.0 if `node --check` parses the edit_file, else 0.0
-  - composite:       0.25 * each of the four above
+  - composite:       mean of the above, dropping import_match when the task
+                     expects no imports and it would be vacuously 1.0
 
 Output: JSON line to stdout.
 
@@ -20,6 +22,54 @@ import pathlib
 import re
 import subprocess
 import sys
+
+
+def strip_comments(src: str) -> str:
+    """Remove comments, leaving code and string literals intact.
+
+    `expected_apis` are matched as substrings, so without this a task listing a
+    word like "thumbs" is satisfied by a comment reading "detect a thumbs up",
+    and code calling nothing real still scores on the API dimension.
+
+    String literals are deliberately kept. Gesture names and similar are passed
+    as strings in this SDK, so `setGestureEnabled('thumbs-up', true)` is real
+    usage rather than prose. Regex literals containing quote characters are not
+    handled, which is accepted: the result is only used for substring matching.
+    """
+    out: list[str] = []
+    i, n = 0, len(src)
+    while i < n:
+        c = src[i]
+        nxt = src[i + 1] if i + 1 < n else ""
+
+        if c == "/" and nxt == "/":
+            while i < n and src[i] != "\n":
+                i += 1
+        elif c == "/" and nxt == "*":
+            i += 2
+            while i + 1 < n and not (src[i] == "*" and src[i + 1] == "/"):
+                i += 1
+            i += 2
+        elif c in ("'", '"', "`"):
+            # Copied through, but scanned so a // or /* inside a string is not
+            # mistaken for the start of a comment.
+            quote = c
+            out.append(c)
+            i += 1
+            while i < n:
+                if src[i] == "\\":
+                    out.append(src[i : i + 2])
+                    i += 2
+                    continue
+                out.append(src[i])
+                if src[i] == quote:
+                    i += 1
+                    break
+                i += 1
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
 
 
 def main(argv: list[str]) -> int:
@@ -37,13 +87,16 @@ def main(argv: list[str]) -> int:
         return 0
 
     src = edit_path.read_text()
+    # Imports are matched against the raw source, since a module specifier
+    # such as "@dimforge/rapier3d" only ever appears inside a string.
+    code = strip_comments(src)
 
     expected_imports = spec.get("expected_imports", [])
     expected_apis = spec.get("expected_apis", [])
     forbidden = spec.get("forbidden_patterns", [])
 
     import_hits = sum(1 for imp in expected_imports if imp in src)
-    api_hits = sum(1 for api in expected_apis if api in src)
+    api_hits = sum(1 for api in expected_apis if api in code)
     forbidden_hits = [pat for pat in forbidden if re.search(pat, src)]
 
     def frac(num: int, denom: int) -> float:

--- a/evals/prototypes/tasks/ai-describe-camera/spec.json
+++ b/evals/prototypes/tasks/ai-describe-camera/spec.json
@@ -3,7 +3,7 @@
   "template": "templates/0_basic",
   "edit_file": "main.js",
   "expected_imports": [],
-  "expected_apis": ["enableAI", "xb.ai", "isAvailable", "query"],
+  "expected_apis": ["enableAI", "xb.ai", "isAvailable", ".query("],
   "forbidden_patterns": [
     "fetch\\(['\"]https://generativelanguage",
     "OPENAI_API_KEY"

--- a/evals/prototypes/tasks/canvas-pet-rock/spec.json
+++ b/evals/prototypes/tasks/canvas-pet-rock/spec.json
@@ -3,7 +3,7 @@
   "template": "templates/0_basic",
   "edit_file": "main.js",
   "expected_imports": [],
-  "expected_apis": ["enableAI", "xb.ai", "query"],
+  "expected_apis": ["enableAI", "xb.ai", ".query("],
   "forbidden_patterns": [
     "fetch\\(['\"]https://generativelanguage",
     "OPENAI_API_KEY"

--- a/evals/prototypes/tasks/canvas-thumbs-up-confetti/spec.json
+++ b/evals/prototypes/tasks/canvas-thumbs-up-confetti/spec.json
@@ -3,6 +3,6 @@
   "template": "templates/0_basic",
   "edit_file": "main.js",
   "expected_imports": [],
-  "expected_apis": ["enableGestures", "xb.core.gestureRecognition", "thumbs"],
+  "expected_apis": ["enableGestures", "xb.core.gestureRecognition", "thumbs-up"],
   "forbidden_patterns": ["navigator\\.xr\\.", "MediaPipe"]
 }

--- a/evals/prototypes/tasks/canvas-thumbs-up-confetti/spec.json
+++ b/evals/prototypes/tasks/canvas-thumbs-up-confetti/spec.json
@@ -3,6 +3,10 @@
   "template": "templates/0_basic",
   "edit_file": "main.js",
   "expected_imports": [],
-  "expected_apis": ["enableGestures", "xb.core.gestureRecognition", "thumbs-up"],
+  "expected_apis": [
+    "enableGestures",
+    "xb.core.gestureRecognition",
+    "thumbs-up"
+  ],
   "forbidden_patterns": ["navigator\\.xr\\.", "MediaPipe"]
 }

--- a/evals/prototypes/tasks/gestures-thumbs-up/spec.json
+++ b/evals/prototypes/tasks/gestures-thumbs-up/spec.json
@@ -3,6 +3,6 @@
   "template": "templates/0_basic",
   "edit_file": "main.js",
   "expected_imports": [],
-  "expected_apis": ["enableGestures", "xb.core.gestureRecognition", "thumbs"],
+  "expected_apis": ["enableGestures", "xb.core.gestureRecognition", "thumbs-up"],
   "forbidden_patterns": ["navigator\\.xr\\.", "MediaPipe"]
 }

--- a/evals/prototypes/tasks/gestures-thumbs-up/spec.json
+++ b/evals/prototypes/tasks/gestures-thumbs-up/spec.json
@@ -3,6 +3,10 @@
   "template": "templates/0_basic",
   "edit_file": "main.js",
   "expected_imports": [],
-  "expected_apis": ["enableGestures", "xb.core.gestureRecognition", "thumbs-up"],
+  "expected_apis": [
+    "enableGestures",
+    "xb.core.gestureRecognition",
+    "thumbs-up"
+  ],
   "forbidden_patterns": ["navigator\\.xr\\.", "MediaPipe"]
 }

--- a/evals/prototypes/test_score_proto.py
+++ b/evals/prototypes/test_score_proto.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Tests for the prototype scorer.
+
+Stdlib unittest so this needs nothing installed:
+
+  python -m unittest discover -s evals/prototypes -p 'test_*.py'
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from score_proto import strip_comments  # noqa: E402
+
+
+class StripCommentsTest(unittest.TestCase):
+    def test_drops_line_comments(self):
+        code = strip_comments("// detect a thumbs up\nxb.init();")
+        self.assertNotIn("thumbs", code)
+        self.assertIn("xb.init()", code)
+
+    def test_drops_block_comments(self):
+        code = strip_comments("/* thumbs up here */\nxb.init();")
+        self.assertNotIn("thumbs", code)
+        self.assertIn("xb.init()", code)
+
+    def test_keeps_string_literals(self):
+        # Gesture names are passed as strings, so this is API usage, not prose.
+        src = "options.gestures.setGestureEnabled('thumbs-up', true);"
+        self.assertIn("thumbs-up", strip_comments(src))
+
+    def test_keeps_template_literals(self):
+        src = "log(`saw ${xb.core.gestureRecognition}`);"
+        self.assertIn("xb.core.gestureRecognition", strip_comments(src))
+
+    def test_comment_markers_inside_a_string_are_not_comments(self):
+        src = "const url = 'http://example.com';\nxb.init();"
+        code = strip_comments(src)
+        self.assertIn("xb.init()", code)
+        self.assertIn("example.com", code)
+
+    def test_handles_escaped_quotes(self):
+        src = "const s = 'it\\'s here'; // thumbs\nxb.init();"
+        code = strip_comments(src)
+        self.assertNotIn("thumbs", code)
+        self.assertIn("xb.init()", code)
+
+    def test_leaves_ordinary_code_alone(self):
+        src = "const o = new xb.Options();\no.enableGestures();"
+        self.assertEqual(strip_comments(src), src)
+
+
+class ScoringRegressionTest(unittest.TestCase):
+    """The behaviour this scorer exists to get right.
+
+    An expectation like "thumbs" used to be satisfied by a comment, so code
+    calling nothing real still scored on the API dimension.
+    """
+
+    EXPECTED = ["enableGestures", "xb.core.gestureRecognition", "thumbs-up"]
+
+    HALLUCINATED = (
+        "// Detect a thumbs up gesture.\n"
+        "const d = xb.createGestureDetector({gesture: 'thumbs up'});\n"
+    )
+    GENUINE = (
+        "const o = new xb.Options();\n"
+        "o.enableGestures();\n"
+        "o.gestures.setGestureEnabled('thumbs-up', true);\n"
+        "xb.core.gestureRecognition.addEventListener('gesturestart', () => {});\n"
+    )
+
+    def hits(self, src: str) -> int:
+        code = strip_comments(src)
+        return sum(1 for api in self.EXPECTED if api in code)
+
+    def test_invented_code_scores_nothing(self):
+        self.assertEqual(self.hits(self.HALLUCINATED), 0)
+
+    def test_genuine_code_scores_everything(self):
+        # Including the gesture name, which only ever appears as a string.
+        self.assertEqual(self.hits(self.GENUINE), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

A file that calls `createGestureDetector`, `onThumbsUp` and `spawnConfetti`, none of which exist, scores 0.778 out of 1.0 on `gestures-thumbs-up`. It gets there because the task lists `"thumbs"` in `expected_apis`, matching is a substring check over the whole file, and the file has a comment reading "detect a thumbs up gesture". So it collected a third of the API dimension for prose.

That's the dimension the whole thing exists to measure, and it was being paid out for a comment.

Now only comments are stripped before matching. Same file scores 0.0 on APIs and 0.667 composite, which is just the floor for parsing and not tripping the forbidden patterns.

I did try stripping string literals too, and that was wrong. Gesture names are passed as strings here, so `setGestureEnabled('thumbs-up', true)` is real usage and correct code would have started failing. Imports were never going to work that way either, since a specifier like `@dimforge/rapier3d` only ever appears inside a string.

Second commit tightens the four tasks that listed a bare word. `"thumbs"` becomes `"thumbs-up"`, which is the actual gesture name, so invented code writing "thumbs up" with a space gets nothing. `"query"` becomes `".query("` so it has to be a call rather than the English word, and that still matches if someone aliases `const ai = xb.ai`.

On `gestures-thumbs-up` the invented file now scores 0 of 3 APIs, and one using `enableGestures`, `setGestureEnabled('thumbs-up')` and the `gestureRecognition` event target scores 3 of 3.

Tests are stdlib `unittest`, so nothing to install:

```
python -m unittest discover -s evals/prototypes -p 'test_*.py'
```

Neutering the stripper fails six of the nine, so they're actually holding something.

Worth saying plainly: these four tasks won't be comparable with the earlier published run, since that one handed out some of this credit for prose. Probably makes the with-skills vs without-skills gap look bigger than before, since invented code was sitting on a floor closer to 0.78 than 0.67.

## Type of Change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

Nothing visual, it's the scoring script for the eval prototypes.

## Checklist

- [x] **Tested in simulator & device**: Doesn't touch the SDK or anything that runs in XR. Verified by scoring an invented file and a correct one against `gestures-thumbs-up` before and after, plus 9 unit tests on the comment stripper.
- [x] **Large Assets ($\ge$ 1MB)**: None.
- [x] **SDK Dynamic Dependencies**: No new dependencies, the tests use stdlib `unittest` rather than adding pytest.
- [x] **Security**: No keys or secrets.
