### PR TITLE
fix(evals): run the prototype sweeps on Windows

### DIFF
--- a/evals/prototypes/ablate.py
+++ b/evals/prototypes/ablate.py
@@ -15,8 +15,10 @@ import json
 import os
 import pathlib
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 
 from google import genai
 from google.genai import types
@@ -74,10 +76,16 @@ def run_variant(
 
     label = "baseline" if ablate_idx is None else f"no-{sections[ablate_idx][0]}"
     safe_label = re.sub(r"[^a-zA-Z0-9._-]+", "-", label).strip("-")
-    workspace = pathlib.Path(f"/tmp/xrblocks-ablate-{task_id}-{safe_label}")
+    workspace = (
+        pathlib.Path(tempfile.gettempdir())
+        / f"xrblocks-ablate-{task_id}-{safe_label}"
+    )
     if workspace.exists():
-        subprocess.run(["rm", "-rf", str(workspace)], check=False)
-    subprocess.run(["cp", "-r", str(REPO_ROOT / template_rel), str(workspace)], check=True)
+        shutil.rmtree(workspace, ignore_errors=True)
+    # On Windows rmtree can empty the directory but fail to remove the
+    # directory itself, if anything is briefly holding a handle on it, so
+    # allow copying into what is left.
+    shutil.copytree(REPO_ROOT / template_rel, workspace, dirs_exist_ok=True)
 
     system_prompt = build_prompt(sections, ablate_idx)
     user_msg = (
@@ -106,7 +114,7 @@ def run_variant(
 
     scorer = REPO_ROOT / "evals" / "prototypes" / "score_proto.py"
     score = subprocess.run(
-        ["python3", str(scorer), str(task_dir), str(workspace)],
+        [sys.executable, str(scorer), str(task_dir), str(workspace)],
         capture_output=True,
         text=True,
         check=True,

--- a/evals/prototypes/runners/run_gem_api.py
+++ b/evals/prototypes/runners/run_gem_api.py
@@ -20,8 +20,10 @@ import json
 import os
 import pathlib
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 
 from google import genai
 from google.genai import types
@@ -95,10 +97,16 @@ def run_task(task_id: str, mode: str) -> dict:
     # sweeps can co-exist without overwriting each other's files (which the
     # judge needs to re-read).
     model_slug = MODEL.replace("/", "-")
-    workspace = pathlib.Path(f"/tmp/xrblocks-gem-{model_slug}-{task_id}-{mode}")
+    workspace = (
+        pathlib.Path(tempfile.gettempdir())
+        / f"xrblocks-gem-{model_slug}-{task_id}-{mode}"
+    )
     if workspace.exists():
-        subprocess.run(["rm", "-rf", str(workspace)], check=False)
-    subprocess.run(["cp", "-r", str(template_dir), str(workspace)], check=True)
+        shutil.rmtree(workspace, ignore_errors=True)
+    # On Windows rmtree can empty the directory but fail to remove the
+    # directory itself, if anything is briefly holding a handle on it, so
+    # allow copying into what is left.
+    shutil.copytree(template_dir, workspace, dirs_exist_ok=True)
 
     # Build prompt.
     task_body = (task_dir / "prompt.md").read_text()
@@ -159,7 +167,7 @@ def run_task(task_id: str, mode: str) -> dict:
     result_path = result_dir / f"{task_id}.json"
 
     score_proc = subprocess.run(
-        ["python3", str(scorer), str(task_dir), str(workspace)],
+        [sys.executable, str(scorer), str(task_dir), str(workspace)],
         capture_output=True,
         text=True,
         check=True,


### PR DESCRIPTION
## Description

You can't run the prototype sweeps on Windows at all right now. The runners shell out to `cp -r` and `rm -rf`, hardcode `/tmp`, and call `python3` by name, none of which exist there.

Swapped in `shutil` and `tempfile.gettempdir()`, and `sys.executable` instead of `python3`. That last one is worth having anywhere, not just on Windows: it keeps the scorer on the same interpreter as the runner, so a venv doesn't silently hand off to whatever `python3` resolves to system-wide.

`copytree` passes `dirs_exist_ok` because of a Windows quirk. `rmtree` will empty the workspace but then fail to remove the directory itself if anything is holding a handle on it for a moment. I hit that and checked what was left: the directory survives but it's empty, so the files really are cleared and nothing leaks from one run into the next.

`run_all.sh` is still bash, so on Windows that's Git Bash or calling the runners per task. Didn't want to rewrite the orchestration in the same change.

Verified by compiling both and exercising the copy path, including the second-copy-over-a-leftover-directory case.

## Type of Change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

Nothing visual, it's the eval runners.

## Checklist

- [x] **Tested in simulator & device**: Doesn't touch the SDK or anything that runs in XR. Verified the changed workspace setup on Windows directly.
- [x] **Large Assets ($\ge$ 1MB)**: None.
- [x] **SDK Dynamic Dependencies**: No new dependencies, `shutil` and `tempfile` are stdlib.
- [x] **Security**: No keys or secrets.
