### PR TITLE
event.stopPropagation() on callbacks

### DIFF
--- a/demos/direct_touch/main.js
+++ b/demos/direct_touch/main.js
@@ -140,13 +140,13 @@ class DirectTouchTarget extends xb.MeshScript {
     this.activeTouches.add(event.handIndex);
     if (this.preventSelection) event.preventDefault();
     this.setEvent('TOUCH START', event, EVENT_COLORS.touch);
-    return true;
+    event.stopPropagation();
   }
 
   onObjectTouching(event) {
     this.counts.touching += 1;
     this.setEvent('TOUCHING', event, EVENT_COLORS.touch);
-    return true;
+    event.stopPropagation();
   }
 
   onObjectTouchEnd(event) {
@@ -154,20 +154,20 @@ class DirectTouchTarget extends xb.MeshScript {
     this.activeTouches.delete(event.handIndex);
     this.setEvent('TOUCH END', event, EVENT_COLORS.end);
     this.flashUntil = performance.now() + 350;
-    return true;
+    event.stopPropagation();
   }
 
   onObjectGrabStart(event) {
     this.counts.grabStart += 1;
     this.activeGrabs.add(event.handIndex);
     this.setEvent('GRAB START', event, EVENT_COLORS.grab);
-    return true;
+    event.stopPropagation();
   }
 
   onObjectGrabbing(event) {
     this.counts.grabbing += 1;
     this.setEvent('GRABBING', event, EVENT_COLORS.grab);
-    return true;
+    event.stopPropagation();
   }
 
   onObjectGrabEnd(event) {
@@ -175,21 +175,21 @@ class DirectTouchTarget extends xb.MeshScript {
     this.activeGrabs.delete(event.handIndex);
     this.setEvent('GRAB END', event, EVENT_COLORS.end);
     this.flashUntil = performance.now() + 350;
-    return true;
+    event.stopPropagation();
   }
 
   onObjectSelectStart(event) {
     this.counts.selectStart += 1;
     this.lastEvent = `SELECT START / ${event.source.type}`;
     this.statusDirty = true;
-    return true;
+    event.stopPropagation();
   }
 
   onObjectSelectEnd(event) {
     this.counts.selectEnd += 1;
     this.lastEvent = `SELECT END / ${event.completed ? 'PASS' : event.reason}`;
     this.statusDirty = true;
-    return true;
+    event.stopPropagation();
   }
 
   update() {

--- a/demos/interaction_playground/main.js
+++ b/demos/interaction_playground/main.js
@@ -121,13 +121,13 @@ class InteractiveObject extends xb.MeshScript {
   onHoverEnter(event) {
     this.material.emissiveIntensity = 0.22;
     report(`${this.name}: hover enter (${describeSource(event)})`, 'selection');
-    return true;
+    event.stopPropagation();
   }
 
-  onHoverExit() {
+  onHoverExit(event) {
     this.material.emissiveIntensity = 0.04;
     report(`${this.name}: hover exit`);
-    return true;
+    event.stopPropagation();
   }
 
   onObjectSelectStart(event) {
@@ -136,7 +136,7 @@ class InteractiveObject extends xb.MeshScript {
       `${this.name}: select start (${describeSource(event)})`,
       'selection'
     );
-    return true;
+    event.stopPropagation();
   }
 
   onObjectSelectEnd(event) {
@@ -146,7 +146,7 @@ class InteractiveObject extends xb.MeshScript {
       `${this.name}: select end ${event.completed}/${event.reason} (${describeSource(event)})`,
       'selection'
     );
-    return true;
+    event.stopPropagation();
   }
 
   onObjectLongSelect(event) {
@@ -155,7 +155,7 @@ class InteractiveObject extends xb.MeshScript {
       `${this.name}: long select ${event.duration.toFixed(2)}s (${describeSource(event)})`,
       'long-select'
     );
-    return true;
+    event.stopPropagation();
   }
 
   onObjectTouchStart(event) {
@@ -164,12 +164,12 @@ class InteractiveObject extends xb.MeshScript {
       `${this.name}: hand ${event.handIndex} touch start (${describeSource(event)})`,
       'touch'
     );
-    return true;
+    event.stopPropagation();
   }
 
-  onObjectTouching() {
+  onObjectTouching(event) {
     markFeature('touch');
-    return true;
+    event.stopPropagation();
   }
 
   onObjectTouchEnd(event) {
@@ -178,7 +178,7 @@ class InteractiveObject extends xb.MeshScript {
       `${this.name}: hand ${event.handIndex} touch end (${describeSource(event)})`,
       'touch'
     );
-    return true;
+    event.stopPropagation();
   }
 
   onObjectGrabStart(event) {
@@ -208,7 +208,8 @@ class InteractiveObject extends xb.MeshScript {
         `${this.name}: prevented ${event.action} (${describeSource(event)})`,
         'manipulation'
       );
-      return true;
+      event.stopPropagation();
+      return;
     }
     if (event.phase !== 'update') {
       report(
@@ -216,7 +217,7 @@ class InteractiveObject extends xb.MeshScript {
         'manipulation'
       );
     }
-    return true;
+    event.stopPropagation();
   }
 }
 
@@ -295,12 +296,12 @@ class ReticleTarget extends xb.MeshScript {
       `${this.name}: ${this.xb.reticleMode} reticle (${describeSource(event)})`,
       'reticle'
     );
-    return true;
+    event.stopPropagation();
   }
 
-  onHoverExit() {
+  onHoverExit(event) {
     this.material.emissiveIntensity = 0.08;
-    return true;
+    event.stopPropagation();
   }
 }
 
@@ -322,12 +323,12 @@ class InstrumentedPanel extends xb.UIButton {
       `${this.diagnosticLabel}: UI hover enter (${describeSource(event)})`,
       'ui'
     );
-    return true;
+    event.stopPropagation();
   }
 
-  onHoverExit() {
+  onHoverExit(event) {
     report(`${this.diagnosticLabel}: UI hover exit`);
-    return true;
+    event.stopPropagation();
   }
 
   onObjectSelectStart(event) {
@@ -335,7 +336,7 @@ class InstrumentedPanel extends xb.UIButton {
       `${this.diagnosticLabel}: UI select start (${describeSource(event)})`,
       'selection'
     );
-    return true;
+    event.stopPropagation();
   }
 
   onObjectSelectEnd(event) {
@@ -343,7 +344,7 @@ class InstrumentedPanel extends xb.UIButton {
       `${this.diagnosticLabel}: UI select end ${event.completed}/${event.reason} (${describeSource(event)})`,
       'ui'
     );
-    return super.onObjectSelectEnd(event);
+    super.onObjectSelectEnd(event);
   }
 
   onObjectLongSelect(event) {
@@ -351,7 +352,7 @@ class InstrumentedPanel extends xb.UIButton {
       `${this.diagnosticLabel}: UI long select ${event.duration.toFixed(2)}s (${describeSource(event)})`,
       'long-select'
     );
-    return true;
+    event.stopPropagation();
   }
 }
 

--- a/docs/docs/manual/Interaction.md
+++ b/docs/docs/manual/Interaction.md
@@ -106,10 +106,10 @@ it does not create or store a separate intersection contract.
 
 These controls solve different problems:
 
-| Control                  | Meaning                                                             | Where available                                                       |
-| ------------------------ | ------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `event.stopPropagation()` | Stop the targeted event from continuing to later ancestor scripts  | Object select, hover, touch, grab, and manipulation callback dispatch |
-| `event.preventDefault()` | Keep callbacks but suppress the framework's proposed default action | Touch start and automatic manipulation events                         |
+| Control                   | Meaning                                                             | Where available                                                       |
+| ------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `event.stopPropagation()` | Stop the targeted event from continuing to later ancestor scripts   | Object select, hover, touch, grab, and manipulation callback dispatch |
+| `event.preventDefault()`  | Keep callbacks but suppress the framework's proposed default action | Touch start and automatic manipulation events                         |
 
 For example, a child can handle touch without starting the default selection:
 

--- a/docs/docs/manual/Interaction.md
+++ b/docs/docs/manual/Interaction.md
@@ -57,13 +57,13 @@ class SelectableCube extends xb.MeshScript {
       point: event.intersection?.point,
     });
     this.material.color.set(0x4285f4);
-    return true;
+    event.stopPropagation();
   }
 
   onObjectSelectEnd(event) {
     console.log(event.completed, event.reason);
     this.material.color.set(0xfbbc04);
-    return true;
+    event.stopPropagation();
   }
 }
 ```
@@ -108,7 +108,7 @@ These controls solve different problems:
 
 | Control                  | Meaning                                                             | Where available                                                       |
 | ------------------------ | ------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| Return `true`            | Stop the targeted event from continuing to later ancestor scripts   | Object select, hover, touch, grab, and manipulation callback dispatch |
+| `event.stopPropagation()` | Stop the targeted event from continuing to later ancestor scripts  | Object select, hover, touch, grab, and manipulation callback dispatch |
 | `event.preventDefault()` | Keep callbacks but suppress the framework's proposed default action | Touch start and automatic manipulation events                         |
 
 For example, a child can handle touch without starting the default selection:
@@ -117,11 +117,11 @@ For example, a child can handle touch without starting the default selection:
 onObjectTouchStart(event) {
   event.preventDefault(); // no default touch selection or manipulation
   this.showContactFeedback();
-  return true; // parent scripts do not also handle this touch-start event
+  event.stopPropagation(); // parent scripts do not also handle this touch-start event
 }
 ```
 
-Returning `true` does not suppress a default transform. Calling
+Calling `stopPropagation()` does not suppress a default transform. Calling
 `preventDefault()` does not stop ancestor callbacks. Use each only for its own
 purpose.
 

--- a/docs/docs/manual/Scripts.md
+++ b/docs/docs/manual/Scripts.md
@@ -61,12 +61,12 @@ See the [WebXR Device API](https://immersive-web.github.io/webxr/input-explainer
 Object specific callbacks are called only when the action is performed while the user is pointing at a specific object.
 Events are propagated up the scene graph from the initial object.
 
-- `onObjectSelectStart(event)` - Called on the current object the controller starts selecting. Return true to prevent propagation.
-- `onObjectSelectEnd(event)` - Called on the previously selected object when selection ends. Return true to prevent propagation.
+- `onObjectSelectStart(event)` - Called on the current object the controller starts selecting. Call `event.stopPropagation()` to prevent propagation.
+- `onObjectSelectEnd(event)` - Called on the previously selected object when selection ends. Call `event.stopPropagation()` to prevent propagation.
 - `onObjectLongSelect(event)` - Called after a held object selection reaches the long-select delay.
 - `onObjectManipulate(event)` - Called for automatic manipulation start, move, end, and cancel phases.
 
-- `onHoverEnter(event)` / `onHovering(event)` / `onHoverExit(event)` - Hover lifecycle. Return true to stop propagation.
+- `onHoverEnter(event)` / `onHovering(event)` / `onHoverExit(event)` - Hover lifecycle. Call `event.stopPropagation()` to stop propagation.
 - `onObjectTouchStart(event)` / `onObjectTouching(event)` / `onObjectTouchEnd(event)` - Direct-touch lifecycle.
 - `onObjectGrabStart(event)` / `onObjectGrabbing(event)` / `onObjectGrabEnd(event)` - Touch-plus-pinch grab lifecycle.
 

--- a/samples/xr_ai/gemini_xrobject/ObjectQuestionCard.js
+++ b/samples/xr_ai/gemini_xrobject/ObjectQuestionCard.js
@@ -26,22 +26,22 @@ class HoldToAskButton extends xb.UIButton {
 
   onObjectSelectStart(event) {
     this.activate(event);
-    return true;
+    event.stopPropagation();
   }
 
   onObjectSelectEnd(event) {
     this.deactivate(event);
-    return true;
+    event.stopPropagation();
   }
 
   onObjectTouchStart(event) {
     this.activate(event);
-    return true;
+    event.stopPropagation();
   }
 
   onObjectTouchEnd(event) {
     this.deactivate(event);
-    return true;
+    event.stopPropagation();
   }
 
   activate(event) {

--- a/skills/xb-add-interactions/SKILL.md
+++ b/skills/xb-add-interactions/SKILL.md
@@ -57,9 +57,10 @@ handler, phase state, domain transition, feedback, and release or cancel path.
 
 ## 4. Preserve event and manipulation semantics
 
-Return `true` from a targeted callback only when its ancestor propagation must
-stop. Use `event.preventDefault()` only where the event exposes it: touch start
-can suppress the default touch selection, and manipulation start can suppress
+Call `event.stopPropagation()` from a targeted callback only when its ancestor
+propagation must stop. Use `event.preventDefault()` only where the event
+exposes it: touch start can suppress the default touch selection, and
+manipulation start can suppress
 the automatic transform. Propagation and default behavior are independent.
 
 Automatic manipulation supports independent simultaneous object owners and

--- a/skills/xb-add-interactions/references/selection-and-direct-hands.md
+++ b/skills/xb-add-interactions/references/selection-and-direct-hands.md
@@ -13,9 +13,10 @@ grab. Source declarations are in
 | Index-tip contact  | `onObjectTouchStart`, `onObjectTouching`, `onObjectTouchEnd` |
 | Contact plus pinch | `onObjectGrabStart`, `onObjectGrabbing`, `onObjectGrabEnd`   |
 
-Targeted callbacks bubble through ancestor scripts. Return `true` to stop later
-ancestors. Keep one domain transition in either the global or targeted family
-so one source action cannot apply it twice.
+Targeted callbacks bubble through ancestor scripts. Call
+`event.stopPropagation()` to stop later ancestors. Keep one domain transition
+in either the global or targeted family so one source action cannot apply it
+twice.
 
 ## Resolved fields
 

--- a/src/addons/testing/example.test.ts
+++ b/src/addons/testing/example.test.ts
@@ -27,12 +27,12 @@ class GrabbableScript extends Script {
 
   override onObjectSelectStart(event: SelectEvent) {
     this.grabbedByHand = event.source.controller.userData.id;
-    return true;
+    event.stopPropagation();
   }
 
-  override onObjectSelectEnd(_event: SelectEvent) {
+  override onObjectSelectEnd(event: SelectEvent) {
     this.grabbedByHand = null;
-    return true;
+    event.stopPropagation();
   }
 }
 

--- a/src/core/Script.ts
+++ b/src/core/Script.ts
@@ -15,6 +15,7 @@ export interface SelectEvent {
   readonly surface?: THREE.Object3D;
   /** Current ray intersection on `surface`, when the source still hits it. */
   readonly intersection?: THREE.Intersection;
+  stopPropagation(): void;
 }
 
 export type SelectionEndReason =
@@ -46,6 +47,7 @@ export interface ObjectTouchEvent {
   readonly handIndex: number;
   readonly hand?: THREE.Object3D;
   readonly touchPosition: THREE.Vector3;
+  stopPropagation(): void;
 }
 
 export interface ObjectTouchStartEvent extends ObjectTouchEvent {
@@ -62,6 +64,7 @@ export interface ObjectGrabEvent {
   readonly handIndex: number;
   readonly hand: THREE.Object3D;
   readonly touchPosition: THREE.Vector3;
+  stopPropagation(): void;
 }
 
 export interface HoverEvent extends SelectEvent {
@@ -182,77 +185,77 @@ export function ScriptMixin<TBase extends Constructor<THREE.Object3D>>(
      * Called when a source starts selecting the object this Script represents.
      * @param _event - `event.target` is the logical object and
      * `event.source.controller` identifies the controller.
-     * @returns Whether the event was handled. If true, the event will not bubble up.
+     * Call `event.stopPropagation()` to stop bubbling to ancestor Scripts.
      */
-    onObjectSelectStart(_event: SelectEvent): boolean | void {}
+    onObjectSelectStart(_event: SelectEvent): void {}
     /**
      * Called when a source stops selecting the object this Script represents.
      * @param _event - The completed state and end reason.
-     * @returns Whether the event was handled. If true, the event will not bubble up.
+     * Call `event.stopPropagation()` to stop bubbling to ancestor Scripts.
      */
-    onObjectSelectEnd(_event: SelectEndEvent): boolean | void {}
+    onObjectSelectEnd(_event: SelectEndEvent): void {}
     /**
      * Called once when a captured selection is held for the long-select delay.
      * Manipulation captures do not emit this callback.
      * @param _event - The controller and completed hold duration.
-     * @returns Whether the event was handled. If true, the event will not bubble up.
+     * Call `event.stopPropagation()` to stop bubbling to ancestor Scripts.
      */
-    onObjectLongSelect(_event: LongSelectEvent): boolean | void {}
+    onObjectLongSelect(_event: LongSelectEvent): void {}
     /**
-     * Called for each phase of an automatic object manipulation.
-     * Returning true stops propagation to later Script ancestors. Calling
-     * preventDefault() on a start event suppresses the automatic action.
+     * Called for each phase of an automatic object manipulation. Call
+     * `event.stopPropagation()` to stop bubbling. Calling `preventDefault()`
+     * on a start event suppresses the automatic action.
      */
-    onObjectManipulate(_event: ManipulationEvent): boolean | void {}
+    onObjectManipulate(_event: ManipulationEvent): void {}
     /**
      * Called when a source starts hovering over this object.
      * @param _event - The hover source, target, surface, and intersection.
-     * @returns Whether the event was handled. If true, the event will not bubble up.
+     * Call `event.stopPropagation()` to stop bubbling to ancestor Scripts.
      */
-    onHoverEnter(_event: HoverEvent): boolean | void {}
+    onHoverEnter(_event: HoverEvent): void {}
     /**
      * Called when a source stops hovering over this object.
      * @param _event - The hover source, target, surface, and intersection.
-     * @returns Whether the event was handled. If true, the event will not bubble up.
+     * Call `event.stopPropagation()` to stop bubbling to ancestor Scripts.
      */
-    onHoverExit(_event: HoverEvent): boolean | void {}
+    onHoverExit(_event: HoverEvent): void {}
     /**
      * Called while a source hovers over this object.
      * @param _event - The hover source, target, surface, and intersection.
-     * @returns Whether the event was handled. If true, the event will not bubble up.
+     * Call `event.stopPropagation()` to stop bubbling to ancestor Scripts.
      */
-    onHovering(_event: HoverEvent): boolean | void {}
+    onHovering(_event: HoverEvent): void {}
     /**
      * Called when a hand's index finger starts touching this object.
      * Direct touch starts the object's selection lifecycle by default. Call
      * `event.preventDefault()` to handle contact without selecting.
      */
-    onObjectTouchStart(_event: ObjectTouchStartEvent): boolean | void {}
+    onObjectTouchStart(_event: ObjectTouchStartEvent): void {}
     /**
      * Called every frame that a hand's index finger is touching this object.
      * The object remains selected during these frames unless touch selection
      * was prevented when contact started.
      */
-    onObjectTouching(_event: ObjectTouchEvent): boolean | void {}
+    onObjectTouching(_event: ObjectTouchEvent): void {}
     /**
      * Called when a hand's index finger stops touching this object.
      * This ends the default selection lifecycle after the touch callback.
      */
-    onObjectTouchEnd(_event: ObjectTouchEvent): boolean | void {}
+    onObjectTouchEnd(_event: ObjectTouchEvent): void {}
     /**
      * Called when a hand starts grabbing this object (touching + pinching).
      * A grab starts built-in direct-touch manipulation when enabled.
      */
-    onObjectGrabStart(_event: ObjectGrabEvent) {}
+    onObjectGrabStart(_event: ObjectGrabEvent): void {}
     /**
      * Called every frame a hand is grabbing this object.
      */
-    onObjectGrabbing(_event: ObjectGrabEvent) {}
+    onObjectGrabbing(_event: ObjectGrabEvent): void {}
     /**
      * Called when a hand stops grabbing this object.
      * This ends built-in direct-touch manipulation without ending contact.
      */
-    onObjectGrabEnd(_event: ObjectGrabEvent) {}
+    onObjectGrabEnd(_event: ObjectGrabEvent): void {}
 
     /**
      * Called when the script is removed from the scene. Opposite of init.

--- a/src/core/components/ScriptsManager.test.ts
+++ b/src/core/components/ScriptsManager.test.ts
@@ -96,7 +96,7 @@ describe('ScriptsManager lifecycle', () => {
     expect(update).toHaveBeenCalledOnce();
   });
 
-  it('isolates callback errors unless propagation is requested', () => {
+  it('isolates callback errors', () => {
     const manager = new ScriptsManager(async () => {});
     const reportError = vi.fn();
     manager.addEventListener(ScriptsManagerEventType.EXCEPTION, reportError);
@@ -105,12 +105,10 @@ describe('ScriptsManager lifecycle', () => {
     const visited: Script[] = [];
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    expect(
-      manager.callTargeted([first, second], 'update', (script) => {
-        if (script === first) throw new Error('callback failed');
-        visited.push(script);
-      })
-    ).toBe(false);
+    manager.callTargeted([first, second], 'update', (script) => {
+      if (script === first) throw new Error('callback failed');
+      visited.push(script);
+    });
     expect(visited).toEqual([second]);
     expect(reportError).toHaveBeenCalledWith(
       expect.objectContaining({context: 'update'})

--- a/src/core/components/ScriptsManager.ts
+++ b/src/core/components/ScriptsManager.ts
@@ -72,7 +72,7 @@ type TargetDispatch = {
   [Hook in TargetedInteractionHook]: (
     script: Script,
     argument: unknown
-  ) => boolean | void;
+  ) => void;
 };
 
 const TARGET_DISPATCH: TargetDispatch = {
@@ -215,11 +215,11 @@ export class ScriptsManager
     object: THREE.Object3D,
     hook: TargetedInteractionHook,
     argument: unknown
-  ): boolean => {
-    if (!this.isScript(object)) return false;
+  ): void => {
+    if (!this.isScript(object)) return;
     const script = object as Script;
-    if (!this.hasOverriddenHook(script, hook)) return false;
-    return this.callTargeted([script], hook, (target) =>
+    if (!this.hasOverriddenHook(script, hook)) return;
+    this.callTargeted([script], hook, (target) =>
       TARGET_DISPATCH[hook](target, eventForTarget(argument, target))
     );
   };
@@ -236,9 +236,9 @@ export class ScriptsManager
     else this.callSelectEnd(event as SelectEndEvent);
   };
 
-  invokeManipulation = (script: Script, event: ManipulationEvent): boolean => {
-    if (!this.hasOverriddenHook(script, 'onObjectManipulate')) return false;
-    return this.callTargeted([script], 'onObjectManipulate', (target) =>
+  invokeManipulation = (script: Script, event: ManipulationEvent): void => {
+    if (!this.hasOverriddenHook(script, 'onObjectManipulate')) return;
+    this.callTargeted([script], 'onObjectManipulate', (target) =>
       target.onObjectManipulate(event)
     );
   };
@@ -285,23 +285,21 @@ export class ScriptsManager
   }
 
   /**
-   * Calls one targeted hook along a captured Script path. Only a literal true
-   * return value stops propagation. Developer errors use the same exception
-   * policy as global Script callbacks.
+   * Calls one targeted hook along a captured Script path. Developer errors use
+   * the same exception policy as global Script callbacks.
    */
   callTargeted(
     path: Iterable<Script>,
     context: string,
-    callback: (script: Script) => boolean | void
-  ): boolean {
+    callback: (script: Script) => void
+  ): void {
     for (const script of path) {
       try {
-        if (callback(script) === true) return true;
+        callback(script);
       } catch (error: unknown) {
         this.handleScriptError(error, script, context);
       }
     }
-    return false;
   }
 
   /**
@@ -648,7 +646,10 @@ function controllerSelectEvent(controller: Controller): SelectEvent {
     : controller.userData.isMouse
       ? 'mouse'
       : 'controller-ray';
-  return {source: getInteractionSource(controller, type)};
+  return {
+    source: getInteractionSource(controller, type),
+    stopPropagation() {},
+  };
 }
 
 function eventForTarget(argument: unknown, currentTarget: Script): unknown {

--- a/src/interaction/Interaction.test.ts
+++ b/src/interaction/Interaction.test.ts
@@ -30,28 +30,28 @@ class RecordingButton extends UIButton {
   longSelects: LongSelectEvent[] = [];
   touchStarts: ObjectTouchStartEvent[] = [];
 
-  override onObjectSelectStart(event: SelectEvent): true {
+  override onObjectSelectStart(event: SelectEvent): void {
     this.starts.push(event);
-    return true;
+    event.stopPropagation();
   }
 
-  override onObjectSelectEnd(event: SelectEndEvent): true {
+  override onObjectSelectEnd(event: SelectEndEvent): void {
     this.ends.push(event);
-    return true;
+    event.stopPropagation();
   }
 
   override onSelecting(event: SelectEvent): void {
     this.selecting.push(event);
   }
 
-  override onObjectLongSelect(event: LongSelectEvent): true {
+  override onObjectLongSelect(event: LongSelectEvent): void {
     this.longSelects.push(event);
-    return true;
+    event.stopPropagation();
   }
 
-  override onObjectTouchStart(event: ObjectTouchStartEvent): true {
+  override onObjectTouchStart(event: ObjectTouchStartEvent): void {
     this.touchStarts.push(event);
-    return true;
+    event.stopPropagation();
   }
 }
 
@@ -161,7 +161,7 @@ describe('Interaction public behavior', () => {
     button.onObjectTouchStart = (event) => {
       event.preventDefault();
       button.touchStarts.push(event);
-      return true;
+      event.stopPropagation();
     };
     const physical = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1));
     const unregister = interaction.registerHitSurface(physical, button);

--- a/src/interaction/Interaction.ts
+++ b/src/interaction/Interaction.ts
@@ -72,6 +72,7 @@ interface TouchState {
 type ActiveCapture = {kind: 'none'} | {kind: 'auxiliary'} | TargetCapture;
 
 const DEFAULT_LONG_SELECT_DURATION = 0.75;
+const NOOP_PROPAGATION = (): void => {};
 
 /** Owns all logical target, hover, capture, completion, and cancellation state. */
 export class Interaction {
@@ -803,24 +804,21 @@ export class Interaction {
 
   private dispatchTouchStart(touch: TouchState): boolean {
     const state = {prevented: false};
-    for (const script of touch.selection.scriptPath) {
-      const event: ObjectTouchStartEvent = {
-        ...this.createTouchEvent(touch),
-        currentTarget: script,
-        get defaultPrevented() {
-          return state.prevented;
-        },
-        preventDefault() {
-          state.prevented = true;
-        },
-      };
-      if (
-        this.callbacks.invokeTarget(script, 'onObjectTouchStart', event) ===
-        true
-      ) {
-        break;
-      }
-    }
+    const event: ObjectTouchStartEvent = {
+      ...this.createTouchEvent(touch),
+      get defaultPrevented() {
+        return state.prevented;
+      },
+      preventDefault() {
+        state.prevented = true;
+      },
+    };
+    dispatchInteractionPath(
+      this.callbacks,
+      touch.selection.scriptPath,
+      'onObjectTouchStart',
+      event
+    );
     return state.prevented;
   }
 
@@ -844,6 +842,7 @@ export class Interaction {
       handIndex: touch.handIndex,
       hand: touch.hand,
       touchPosition: touch.point.clone(),
+      stopPropagation: NOOP_PROPAGATION,
     };
   }
 
@@ -1055,6 +1054,7 @@ export class Interaction {
       intersection: value?.intersection
         ? clonePublicIntersection(value.intersection, value.surface)
         : undefined,
+      stopPropagation: NOOP_PROPAGATION,
     });
     dispatchInteractionPath(
       this.callbacks,
@@ -1132,6 +1132,7 @@ export class Interaction {
       target: targetCapture?.selection.target,
       surface,
       intersection,
+      stopPropagation: NOOP_PROPAGATION,
     };
   }
 

--- a/src/interaction/InteractionTypes.ts
+++ b/src/interaction/InteractionTypes.ts
@@ -211,13 +211,13 @@ export interface InteractionCallbackDispatch {
     script: THREE.Object3D,
     hook: TargetedInteractionHook,
     argument: unknown
-  ): unknown;
+  ): void;
   invokeSemantic(object: THREE.Object3D, callback: () => void): void;
   invokeGlobal<Hook extends GlobalInteractionHook>(
     hook: Hook,
     event: GlobalInteractionEvent<Hook>
   ): void;
-  invokeManipulation(script: Script, event: ManipulationEvent): boolean;
+  invokeManipulation(script: Script, event: ManipulationEvent): void;
 }
 
 export interface ReticlePresentationObserver {

--- a/src/interaction/InteractionUtils.ts
+++ b/src/interaction/InteractionUtils.ts
@@ -12,9 +12,32 @@ export function dispatchInteractionPath(
   hook: TargetedInteractionHook,
   argument: unknown
 ): void {
+  const state = {stopped: false};
+  const event = eventWithPropagation(argument, state);
   for (const script of path) {
-    if (callbacks.invokeTarget(script, hook, argument) === true) return;
+    callbacks.invokeTarget(script, hook, event);
+    if (state.stopped) return;
   }
+}
+
+function eventWithPropagation(
+  argument: unknown,
+  state: {stopped: boolean}
+): unknown {
+  if (!argument || typeof argument !== 'object') return argument;
+  const event = Object.create(Object.getPrototypeOf(argument)) as Record<
+    PropertyKey,
+    unknown
+  >;
+  Object.defineProperties(event, Object.getOwnPropertyDescriptors(argument));
+  Object.defineProperty(event, 'stopPropagation', {
+    enumerable: true,
+    configurable: true,
+    value() {
+      state.stopped = true;
+    },
+  });
+  return event;
 }
 
 export function selectionInvalidReason(

--- a/src/interaction/manipulation/ManipulationManager.ts
+++ b/src/interaction/manipulation/ManipulationManager.ts
@@ -39,7 +39,7 @@ import {TranslateDriver} from './drivers/TranslateDriver';
 export type DispatchManipulationEvent = (
   script: Script,
   event: ManipulationEvent
-) => boolean | void;
+) => void;
 
 interface PrimaryRole {
   capture: SelectionCapture;
@@ -572,9 +572,18 @@ export class ManipulationManager {
   ): void {
     if (!proposal) return;
     const preventState = {value: active.defaultPrevented};
+    const propagationState = {stopped: false};
     for (const script of session.primary.capture.scriptPath) {
-      const event = createEvent(session, script, phase, proposal, preventState);
-      if (this.dispatch(script, event) === true) break;
+      const event = createEvent(
+        session,
+        script,
+        phase,
+        proposal,
+        preventState,
+        propagationState
+      );
+      this.dispatch(script, event);
+      if (propagationState.stopped) break;
     }
     if (phase === 'start') active.defaultPrevented = preventState.value;
   }
@@ -601,7 +610,8 @@ function createEvent(
   currentTarget: Script,
   phase: ManipulationPhase,
   proposal: Proposal,
-  preventState: {value: boolean}
+  preventState: {value: boolean},
+  propagationState: {stopped: boolean}
 ): ManipulationEvent {
   const common = {
     phase,
@@ -619,6 +629,9 @@ function createEvent(
     defaultPrevented: preventState.value,
     preventDefault() {
       if (phase === 'start') preventState.value = true;
+    },
+    stopPropagation() {
+      propagationState.stopped = true;
     },
   };
 

--- a/src/interaction/manipulation/ManipulationTypes.ts
+++ b/src/interaction/manipulation/ManipulationTypes.ts
@@ -65,6 +65,7 @@ export interface BaseManipulationEvent {
   readonly currentTarget: Script;
   readonly defaultPrevented: boolean;
   preventDefault(): void;
+  stopPropagation(): void;
 }
 
 export interface TranslateManipulationEvent extends BaseManipulationEvent {

--- a/src/ui/components/UIButton.ts
+++ b/src/ui/components/UIButton.ts
@@ -119,12 +119,12 @@ export class UIButton extends UIElement {
     this.markUIDirty();
   }
 
-  onObjectSelectStart(_event: SelectEvent): true {
-    return true;
+  onObjectSelectStart(event: SelectEvent): void {
+    event.stopPropagation();
   }
 
-  onObjectSelectEnd(_event: SelectEvent): true {
-    return true;
+  onObjectSelectEnd(event: SelectEvent): void {
+    event.stopPropagation();
   }
 
   override add(...objects: THREE.Object3D[]): this {

--- a/src/ui/components/UISlider.ts
+++ b/src/ui/components/UISlider.ts
@@ -121,12 +121,12 @@ export class UISlider extends UIElement {
     this.markUIDirty();
   }
 
-  onObjectSelectStart(_event: SelectEvent): true {
-    return true;
+  onObjectSelectStart(event: SelectEvent): void {
+    event.stopPropagation();
   }
 
-  onObjectSelectEnd(_event: SelectEvent): true {
-    return true;
+  onObjectSelectEnd(event: SelectEvent): void {
+    event.stopPropagation();
   }
 
   private beginInput(input: SemanticControlInput): void {

--- a/templates/02_object_interaction/main.js
+++ b/templates/02_object_interaction/main.js
@@ -20,26 +20,26 @@ class ObjectInteraction extends xb.MeshScript {
     if (event.source.type !== 'direct-touch') {
       this.material.color.set(0x4285f4);
     }
-    return true;
+    event.stopPropagation();
   }
 
   onObjectSelectEnd(event) {
     if (event.source.type !== 'direct-touch') {
       this.material.color.set(0xfbbc04);
     }
-    return true;
+    event.stopPropagation();
   }
 
-  onObjectTouchStart() {
+  onObjectTouchStart(event) {
     // Keep the default selection enabled because automatic manipulation uses
     // that capture when grab starts. Prevent it only for touch-only objects.
     this.material.color.set(0x34a853);
-    return true;
+    event.stopPropagation();
   }
 
-  onObjectTouchEnd() {
+  onObjectTouchEnd(event) {
     this.material.color.set(0xfbbc04);
-    return true;
+    event.stopPropagation();
   }
 
   dispose() {


### PR DESCRIPTION
# Replacing Bool returns
Small interface thing to change callbacks into pure void + event functions which removes that small point of misunderstanding. allows us to do more callback functions and such later if needed 
## Description

Small interface thing to change callbacks into pure void + event functions which removes that small point of misunderstanding. allows us to do more callback functions and such later if needed 

```
event.stopPropagation()
```

## Type of Change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

- **Simulator Recording**: <!-- Attach video/GIF running in desktop simulator -->
- **Device Recording**: <!-- Attach video/GIF running on physical hardware -->

## Checklist

- [x] **Tested in simulator & device**: Verified functionality in desktop simulator and/or physical hardware (where applicable).
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.
