### PR TITLE
feat(evals): cover head gestures, lipsync, context and agent hands

### DIFF
--- a/evals/prototypes/tasks/agenthands-speaking-gestures/prompt.md
+++ b/evals/prototypes/tasks/agenthands-speaking-gestures/prompt.md
@@ -1,0 +1,7 @@
+# Give the agent a pair of gesturing hands
+
+Modify `main.js` so a pair of hands belonging to the app's agent (not the user's own tracked hands) appears floating in front of the user. On select, the hands should wave; on a later select they should play a beat gesture, then settle back to rest.
+
+Use the SDK's built-in agent embodiment rather than loading and animating your own hand rig.
+
+Only edit `main.js`. Do not touch `index.html` or the importmap.

--- a/evals/prototypes/tasks/agenthands-speaking-gestures/spec.json
+++ b/evals/prototypes/tasks/agenthands-speaking-gestures/spec.json
@@ -1,0 +1,8 @@
+{
+  "skill": "xb-agenthands",
+  "template": "templates/0_basic",
+  "edit_file": "main.js",
+  "expected_imports": ["xrblocks/addons/agenthands"],
+  "expected_apis": ["AgentHands", ".load(", ".wave(", ".beat(", ".rest("],
+  "forbidden_patterns": ["MediaPipe", "navigator\\.xr\\."]
+}

--- a/evals/prototypes/tasks/canvas-agent-buddy/prompt.md
+++ b/evals/prototypes/tasks/canvas-agent-buddy/prompt.md
@@ -1,0 +1,1 @@
+I'd like a little assistant that feels present in the room with me. Give it a pair of friendly floating hands that wave hello when it greets me and move about a bit while it's talking, then settle when it's done. It shouldn't be my own hands, it should be its own.

--- a/evals/prototypes/tasks/canvas-agent-buddy/spec.json
+++ b/evals/prototypes/tasks/canvas-agent-buddy/spec.json
@@ -1,0 +1,8 @@
+{
+  "skill": "xb-agenthands",
+  "template": "templates/0_basic",
+  "edit_file": "main.js",
+  "expected_imports": ["xrblocks/addons/agenthands"],
+  "expected_apis": ["AgentHands", ".load(", ".wave(", ".beat(", ".rest("],
+  "forbidden_patterns": ["MediaPipe", "navigator\\.xr\\."]
+}

--- a/evals/prototypes/tasks/canvas-nod-to-dismiss/prompt.md
+++ b/evals/prototypes/tasks/canvas-nod-to-dismiss/prompt.md
@@ -1,0 +1,1 @@
+I want to answer yes or no without using my hands. Make the cylinder float in front of me, and let me nod to accept it so it turns green, or shake my head to dismiss it so it fades away. My hands are full, so it should work from head movement alone.

--- a/evals/prototypes/tasks/canvas-nod-to-dismiss/spec.json
+++ b/evals/prototypes/tasks/canvas-nod-to-dismiss/spec.json
@@ -1,0 +1,8 @@
+{
+  "skill": "xb-head-gestures",
+  "template": "templates/0_basic",
+  "edit_file": "main.js",
+  "expected_imports": [],
+  "expected_apis": ["enableHeadGestures", "xb.input.headGestures"],
+  "forbidden_patterns": ["navigator\\.xr\\.", "deviceorientation", "MediaPipe"]
+}

--- a/evals/prototypes/tasks/canvas-talking-face/prompt.md
+++ b/evals/prototypes/tasks/canvas-talking-face/prompt.md
@@ -1,0 +1,1 @@
+Put a little cartoon face in the room that mouths along to whatever I say. When I talk into my mic its lips should move with my words, and when I stop talking its mouth should settle closed.

--- a/evals/prototypes/tasks/canvas-talking-face/spec.json
+++ b/evals/prototypes/tasks/canvas-talking-face/spec.json
@@ -1,0 +1,8 @@
+{
+  "skill": "xb-lipsync",
+  "template": "templates/0_basic",
+  "edit_file": "main.js",
+  "expected_imports": ["xrblocks/addons/lipsync"],
+  "expected_apis": ["LipsyncMouth", "getUserMedia", "StylizedFace"],
+  "forbidden_patterns": ["MediaPipe", "new Audio\\("]
+}

--- a/evals/prototypes/tasks/canvas-what-do-you-see/prompt.md
+++ b/evals/prototypes/tasks/canvas-what-do-you-see/prompt.md
@@ -1,0 +1,1 @@
+When I pinch, I want the app to tell me what's around me right now: the things it knows about in the room, and which of those I'm actually looking at from where I'm standing. Print that list out so I can read it.

--- a/evals/prototypes/tasks/canvas-what-do-you-see/spec.json
+++ b/evals/prototypes/tasks/canvas-what-do-you-see/spec.json
@@ -1,0 +1,8 @@
+{
+  "skill": "xb-context",
+  "template": "templates/0_basic",
+  "edit_file": "main.js",
+  "expected_imports": [],
+  "expected_apis": ["enableContext", "xb.context.scene", "runContextDetection"],
+  "forbidden_patterns": ["scene\\.traverse\\(", "MediaPipe"]
+}

--- a/evals/prototypes/tasks/context-describe-scene/prompt.md
+++ b/evals/prototypes/tasks/context-describe-scene/prompt.md
@@ -1,0 +1,7 @@
+# Log what the agent can currently see
+
+Modify `main.js` so that on every select the app captures the agent-facing scene context and logs the semantic tree nodes and which of them are currently visible to the user.
+
+Read the context from the SDK's context module rather than walking the three.js scene graph yourself.
+
+Only edit `main.js`. Do not touch `index.html` or the importmap.

--- a/evals/prototypes/tasks/context-describe-scene/spec.json
+++ b/evals/prototypes/tasks/context-describe-scene/spec.json
@@ -1,0 +1,8 @@
+{
+  "skill": "xb-context",
+  "template": "templates/0_basic",
+  "edit_file": "main.js",
+  "expected_imports": [],
+  "expected_apis": ["enableContext", "xb.context.scene", "runContextDetection"],
+  "forbidden_patterns": ["scene\\.traverse\\(", "MediaPipe"]
+}

--- a/evals/prototypes/tasks/head-gestures-nod-confirm/prompt.md
+++ b/evals/prototypes/tasks/head-gestures-nod-confirm/prompt.md
@@ -1,0 +1,5 @@
+# Build a nod-to-confirm interaction
+
+Modify `main.js` so the cylinder from the starter template responds to head gestures: when the user nods, turn it green; when the user shakes their head, turn it red.
+
+Only edit `main.js`. Do not touch `index.html` or the importmap.

--- a/evals/prototypes/tasks/head-gestures-nod-confirm/spec.json
+++ b/evals/prototypes/tasks/head-gestures-nod-confirm/spec.json
@@ -1,0 +1,8 @@
+{
+  "skill": "xb-head-gestures",
+  "template": "templates/0_basic",
+  "edit_file": "main.js",
+  "expected_imports": [],
+  "expected_apis": ["enableHeadGestures", "xb.input.headGestures"],
+  "forbidden_patterns": ["navigator\\.xr\\.", "deviceorientation", "MediaPipe"]
+}

--- a/evals/prototypes/tasks/lipsync-mic-mouth/prompt.md
+++ b/evals/prototypes/tasks/lipsync-mic-mouth/prompt.md
@@ -1,0 +1,7 @@
+# Drive an avatar mouth from the microphone
+
+Modify `main.js` so a face floats in front of the user and its mouth moves in time with the user's speech, picked up from the microphone.
+
+Drive the mouth from the SDK's own audio-to-viseme analysis rather than writing your own.
+
+Only edit `main.js`. Do not touch `index.html` or the importmap.

--- a/evals/prototypes/tasks/lipsync-mic-mouth/spec.json
+++ b/evals/prototypes/tasks/lipsync-mic-mouth/spec.json
@@ -1,0 +1,8 @@
+{
+  "skill": "xb-lipsync",
+  "template": "templates/0_basic",
+  "edit_file": "main.js",
+  "expected_imports": ["xrblocks/addons/lipsync"],
+  "expected_apis": ["LipsyncMouth", "getUserMedia", "StylizedFace"],
+  "forbidden_patterns": ["MediaPipe", "blendshape\\s*=", "new Audio\\("]
+}


### PR DESCRIPTION
## Description

Eight tasks for four skills that had no coverage at all: head gestures, lipsync, context and agent hands. That takes it from 20 tasks over 10 of the 26 skills to 28 over 14.

Two per skill, one phrased the way a developer would write a ticket and one the way someone vibe-coding in a Gem would ask for it. The wording changes what a model reaches for, so both seemed worth having.

None of the prompts name an API. Telling it to "use `enableHeadGestures`" hands over the exact thing the task is trying to measure, so the nod one just asks for a cylinder that goes green when you nod and red when you shake your head, and lipsync asks for a face whose mouth follows your voice.

The `expected_apis` needed a bit of care given #509. These four skills are full of ordinary English words, nod, shake, wave, beat, rest, and a bare "nod" would be satisfied by a comment. So they're all written as calls: `.wave(`, `.beat(`, `.rest(`. Checked it does what I wanted, a file calling `createAgentHands` and `playAnimation` (neither exists) with a comment mentioning wave, beat and rest gets 1 of 5 APIs and 0.55 composite, against 5 of 5 and 1.0 for a correct one.

Also verified every symbol in these specs is real, which turned up something worth knowing: the MCP search from #508 reported `AgentHands`, `LipsyncMouth`, `xb.input.headGestures` and `xb.context.scene` as not existing. All four are fine, it only indexes the core `build/xrblocks.d.ts` so it misses addons, and it matches bare symbol names so dotted paths never hit. That's the false negative case I said mattered most in that PR, will fix separately.

Not run through a sweep yet, so treat the scoring as unvalidated against a real model.

## Type of Change

- [ ] Bug fix
- [ ] New feature / enhancement
- [ ] New demo or sample
- [x] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

Nothing visual, these are eval task definitions.

## Checklist

- [x] **Tested in simulator & device**: Not applicable, no SDK or runtime change. Scored each spec against a correct file and a deliberately hallucinated one to check they separate.
- [x] **Large Assets ($\ge$ 1MB)**: None.
- [x] **SDK Dynamic Dependencies**: No dependencies, just prompt and spec files.
- [x] **Security**: No keys or secrets.
