### PR TITLE
Realigned Physics Stepping When Pause 

### DIFF
--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -59,6 +59,7 @@ export type CoreLifecycleState =
 
 type SimulatorModule = typeof import('../simulator/Simulator.js');
 type SimulatorLoader = () => Promise<SimulatorModule>;
+const EPSILON = 1e-9;
 
 function loadSimulatorModule(): Promise<SimulatorModule> {
   return import('../simulator/Simulator.js');
@@ -238,7 +239,7 @@ export class Core {
       if (this.physics) {
         this.manualPhysicsAccumulatorMs += scaledDtMs;
         const physicsStepMs = this.physics.timestep * 1000;
-        while (this.manualPhysicsAccumulatorMs >= physicsStepMs - 1e-9) {
+        while (this.manualPhysicsAccumulatorMs >= physicsStepMs - EPSILON) {
           this.physicsStep();
           this.manualPhysicsAccumulatorMs = Math.max(
             0,

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -122,6 +122,7 @@ export class Core {
   private reticlePresenter = new ReticlePresenter(this.reticleOptions);
   private uiRenderer!: UIRenderer;
   private physicsInterval?: ReturnType<typeof setInterval>;
+  private manualPhysicsAccumulatorMs = 0;
   private rendererContainer?: HTMLDivElement;
   private lifecycleState: CoreLifecycleState = 'new';
   private initializationPromise?: Promise<void>;
@@ -203,6 +204,10 @@ export class Core {
     return this._isPaused;
   }
 
+  get elapsedTime() {
+    return this.simulationTimer.getElapsedMs() / 1000;
+  }
+
   /** Current state of this terminal Core lifetime. */
   get lifecycle(): CoreLifecycleState {
     return this.lifecycleState;
@@ -226,11 +231,20 @@ export class Core {
 
     this.isSteppingFrame = true;
     try {
+      const scaledDtMs = dtMs * this.timer.getTimescale();
       this.simulationTimer.step(dtMs, this.timer.getTimescale());
       this.manualStepTime += dtMs;
       this.update(this.manualStepTime, undefined as unknown as XRFrame);
       if (this.physics) {
-        this.physicsStep();
+        this.manualPhysicsAccumulatorMs += scaledDtMs;
+        const physicsStepMs = this.physics.timestep * 1000;
+        while (this.manualPhysicsAccumulatorMs >= physicsStepMs - 1e-9) {
+          this.physicsStep();
+          this.manualPhysicsAccumulatorMs = Math.max(
+            0,
+            this.manualPhysicsAccumulatorMs - physicsStepMs
+          );
+        }
       }
     } finally {
       this.isSteppingFrame = false;

--- a/src/singletons.ts
+++ b/src/singletons.ts
@@ -127,7 +127,7 @@ export function getDeltaTime() {
 /**
  * Gets elapsed time in seconds from the simulation or render clock.
  * Simulation time excludes pauses and is the default.
- * @param clock Clock used to measure elapsed time.
+ * @param clock - Clock used to measure elapsed time.
  * @returns The elapsed time in seconds.
  */
 export function getElapsedTime(clock: 'simulation' | 'render' = 'simulation') {

--- a/src/singletons.ts
+++ b/src/singletons.ts
@@ -125,13 +125,13 @@ export function getDeltaTime() {
 }
 
 /**
- * A shortcut for `core.timer.getElapsed()`. Gets the total time in seconds
- * since the application started.
+ * Gets elapsed time in seconds from the simulation or render clock.
+ * Simulation time excludes pauses and is the default.
+ * @param clock Clock used to measure elapsed time.
  * @returns The elapsed time in seconds.
- * @see {@link THREE.Timer.getElapsed}
  */
-export function getElapsedTime() {
-  return core.timer.getElapsed();
+export function getElapsedTime(clock: 'simulation' | 'render' = 'simulation') {
+  return clock === 'simulation' ? core.elapsedTime : core.timer.getElapsed();
 }
 
 /**


### PR DESCRIPTION
# Realigned Physics Stepping When Paused

## Description

Aligned manually stepped frame physics via an accumulator since it doesn't run at the normal 16.67ms on frames.

Added a small addition to elapsedTime to pull simulator or render time. At runtime they're the same thing, but if we run this thru simulator with pausing simulator time only tracks unpaused time while render time tracks everything.

Doesn't ever affect the actual runtime, only comes into play when we're manually stepping.

## Type of Change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

- **Simulator Recording**: <!-- Attach video/GIF running in desktop simulator -->
- **Device Recording**: <!-- Attach video/GIF running on physical hardware -->

## Checklist

- [x] **Tested in simulator & device**: Verified functionality in desktop simulator and/or physical hardware (where applicable).
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.
