### PR TITLE
Fix anchors on Galaxy XR

### DIFF
--- a/demos/anchors/main.js
+++ b/demos/anchors/main.js
@@ -212,10 +212,7 @@ class AnchorsDemo extends xb.Script {
   whyNotSaved() {
     switch (this.anchors?.capability) {
       case 'session-only':
-        return (
-          'this browser has no way to save anchors, so it will be gone ' +
-          'on reload'
-        );
+        return 'this browser only supports non-persistent anchors';
       case 'unsupported':
         return 'this browser has no anchor support';
       default: {
@@ -343,7 +340,10 @@ class AnchorsDemo extends xb.Script {
     // report their own pose, so this works with or without a live frame.
     for (const [id, mesh] of this.markers) {
       const pose = anchors.getPose(id);
-      if (!pose) continue;
+      if (!pose) {
+        THREE.warnOnce('could not get pose for anchor', id);
+        continue;
+      }
       mesh.position.set(
         pose.transform.position.x,
         pose.transform.position.y,

--- a/demos/anchors_notes/main.js
+++ b/demos/anchors_notes/main.js
@@ -256,10 +256,7 @@ class AnchorNotesDemo extends xb.Script {
   whyNotSaved() {
     switch (this.anchors?.capability) {
       case 'session-only':
-        return (
-          'this browser has no way to save anchors, so it will be gone ' +
-          'on reload'
-        );
+        return 'created session-only anchor';
       case 'unsupported':
         return 'this browser has no anchor support';
       default: {

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -48,6 +48,7 @@ import {Options, ReticleOptions} from './Options';
 import {Script} from './Script';
 import {User} from './User';
 import {PermissionsManager} from './components/PermissionsManager';
+import {XRReferenceSpaceCache} from './components/XRReferenceSpaceCache';
 import {XRSystems} from './components/XRSystems';
 
 export type CoreLifecycleState =
@@ -81,6 +82,10 @@ export class Core {
    * Component responsible for waiting for the next frame.
    */
   waitFrame = new WaitFrame();
+  /**
+   * Caches WebXR reference spaces for the active session.
+   */
+  xrReferenceSpaceCache = new XRReferenceSpaceCache();
   /**
    * Registry used for dependency injection on existing subsystems.
    */
@@ -168,7 +173,9 @@ export class Core {
   poseEstimation?: PoseEstimator;
   gestureRecognition?: GestureRecognition;
   transition?: XRTransition;
-  currentFrame?: XRFrame;
+  get currentFrame() {
+    return this.renderer.xr.getFrame();
+  }
   scriptsManager = new ScriptsManager(async (script: Script) => {
     await callInitWithDependencyInjection(script, this.registry, this);
     if (this.physics) {
@@ -293,6 +300,7 @@ export class Core {
     this.registry.register(this);
     this.registry.register(this.waitFrame);
     this.registry.register(this.screenshotSynthesizer);
+    this.registry.register(this.xrReferenceSpaceCache);
     this.registry.register(this.simulationTimer);
     this.registry.register(this.scene);
     this.registry.register(this.timer);
@@ -746,7 +754,6 @@ export class Core {
       return;
     }
 
-    this.currentFrame = frame;
     this.manualStepTime = Math.max(this.manualStepTime, time);
     if (!this.isSteppingFrame) {
       this.simulationTimer.update(time, this.timer.getTimescale());
@@ -831,6 +838,7 @@ export class Core {
    */
   private async onXRSessionStarted(session: XRSession) {
     if (!this.isLifecycleActive()) return;
+    this.xrReferenceSpaceCache.onXRSessionStart(session);
     if (this.options.deviceCamera?.enabled) {
       await this.deviceCamera!.init();
       if (!this.isLifecycleActive()) return;

--- a/src/core/Options.ts
+++ b/src/core/Options.ts
@@ -20,6 +20,12 @@ import {WorldOptions} from '../world/WorldOptions';
 import {getUrlParamBool, getUrlParameter} from '../utils/utils';
 import {Handedness} from '../input/Hands';
 
+const OPTIONAL_REFERENCE_SPACES = [
+  'local-floor', // Height/floor tracking relative to user
+  'bounded-floor', // Room-scale boundary tracking (XRBoundedReferenceSpace)
+  'unbounded', // World-scale continuous movement tracking
+] as const;
+
 /**
  * Default options for XR controllers, which encompass hands by default in
  * Android XR, mouse input on desktop, tracked controllers, and gamepads.
@@ -123,7 +129,7 @@ export class Options {
   /**
    * Any additional optional features when initializing webxr.
    */
-  webxrOptionalFeatures: string[] = [];
+  webxrOptionalFeatures: string[] = [...OPTIONAL_REFERENCE_SPACES];
 
   // "local-floor" sets the scene origin at the user's feet,
   // "local" sets the scene origin near their head.

--- a/src/core/components/WebXRSessionManager.ts
+++ b/src/core/components/WebXRSessionManager.ts
@@ -66,10 +66,7 @@ export class WebXRSessionManager extends THREE.EventDispatcher<WebXRSessionManag
       this.xrModeSupported = true;
       this.sessionOptions = {
         ...this.sessionInit,
-        optionalFeatures: [
-          'local-floor',
-          ...(this.sessionInit.optionalFeatures || []),
-        ],
+        optionalFeatures: this.sessionInit.optionalFeatures || [],
       };
 
       // Fire the 'ready' event with the sessionOptions in the data payload

--- a/src/core/components/XRReferenceSpaceCache.test.ts
+++ b/src/core/components/XRReferenceSpaceCache.test.ts
@@ -1,0 +1,132 @@
+import * as THREE from 'three';
+import {describe, expect, it, vi} from 'vitest';
+
+import {XRReferenceSpaceCache} from './XRReferenceSpaceCache';
+
+if (typeof globalThis.XRRigidTransform === 'undefined') {
+  (
+    globalThis as unknown as {
+      XRRigidTransform: new (
+        pos: {x: number; y: number; z: number},
+        orient: {x: number; y: number; z: number; w: number}
+      ) => XRRigidTransform;
+    }
+  ).XRRigidTransform = class XRRigidTransform {
+    position: DOMPointReadOnly;
+    orientation: DOMPointReadOnly;
+    matrix: Float32Array;
+    inverse: XRRigidTransform;
+
+    constructor(
+      position: {x: number; y: number; z: number},
+      orientation: {x: number; y: number; z: number; w: number}
+    ) {
+      this.position = {
+        x: position.x,
+        y: position.y,
+        z: position.z,
+        w: 1,
+      } as DOMPointReadOnly;
+      this.orientation = {
+        x: orientation.x,
+        y: orientation.y,
+        z: orientation.z,
+        w: orientation.w,
+      } as DOMPointReadOnly;
+      const mat = new THREE.Matrix4()
+        .compose(
+          new THREE.Vector3(position.x, position.y, position.z),
+          new THREE.Quaternion(
+            orientation.x,
+            orientation.y,
+            orientation.z,
+            orientation.w
+          ),
+          new THREE.Vector3(1, 1, 1)
+        )
+        .toArray();
+      this.matrix = new Float32Array(mat);
+      this.inverse = this;
+    }
+  };
+}
+
+describe('XRReferenceSpaceCache', () => {
+  it('caches reference spaces on session start', async () => {
+    const cache = new XRReferenceSpaceCache();
+    const mockSpace = {} as XRReferenceSpace;
+    const requestReferenceSpace = vi
+      .fn()
+      .mockImplementation((type: string) =>
+        type === 'local-floor' ? Promise.resolve(mockSpace) : Promise.reject()
+      );
+    const listeners: Record<string, () => void> = {};
+    const mockSession = {
+      requestReferenceSpace,
+      addEventListener: (event: string, fn: () => void) => {
+        listeners[event] = fn;
+      },
+      removeEventListener: vi.fn(),
+    } as unknown as XRSession;
+
+    cache.onXRSessionStart(mockSession);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(cache.getCached('local-floor')).toBe(mockSpace);
+    expect(cache.getCached('viewer')).toBeUndefined();
+
+    // Trigger end event
+    listeners['end']?.();
+    expect(cache.getCached('local-floor')).toBeUndefined();
+  });
+
+  it('converts a pose between reference spaces using frame', () => {
+    const cache = new XRReferenceSpaceCache();
+
+    const spaceA = {} as XRSpace;
+    const spaceB = {} as XRSpace;
+
+    // Transform mapping spaceA to spaceB: shifted by (0, 1, 0)
+    const relMatrix = new THREE.Matrix4().makeTranslation(0, 1, 0).toArray();
+    const mockFrame = {
+      getPose: vi.fn().mockImplementation((from, to) => {
+        if (from === spaceA && to === spaceB) {
+          return {
+            transform: {
+              matrix: new Float32Array(relMatrix),
+            },
+          };
+        }
+        return null;
+      }),
+    } as unknown as XRFrame;
+
+    // Pose in spaceA: shifted by (2, 0, 0)
+    const poseMatrix = new THREE.Matrix4().makeTranslation(2, 0, 0).toArray();
+    const mockPose = {
+      matrix: new Float32Array(poseMatrix),
+    } as unknown as XRRigidTransform;
+
+    const result = cache.convertPose(mockPose, spaceA, spaceB, mockFrame);
+
+    expect(result).not.toBeNull();
+    expect(result!.position.x).toBeCloseTo(2);
+    expect(result!.position.y).toBeCloseTo(1);
+    expect(result!.position.z).toBeCloseTo(0);
+  });
+
+  it('returns null if reference space is missing or unresolvable', () => {
+    const cache = new XRReferenceSpaceCache();
+    const mockFrame = {
+      getPose: vi.fn(),
+    } as unknown as XRFrame;
+    const mockPose = {
+      matrix: new Float32Array(new THREE.Matrix4().identity().toArray()),
+    } as unknown as XRRigidTransform;
+
+    // 'local' and 'viewer' are not cached yet
+    const result = cache.convertPose(mockPose, 'local', 'viewer', mockFrame);
+    expect(result).toBeNull();
+  });
+});

--- a/src/core/components/XRReferenceSpaceCache.ts
+++ b/src/core/components/XRReferenceSpaceCache.ts
@@ -1,0 +1,90 @@
+import * as THREE from 'three';
+
+const REFERENCE_SPACE_TYPES: XRReferenceSpaceType[] = [
+  'viewer',
+  'local',
+  'local-floor',
+  'bounded-floor',
+  'unbounded',
+];
+
+const tempMatRel = new THREE.Matrix4();
+const tempMatPose = new THREE.Matrix4();
+const tempPosition = new THREE.Vector3();
+const tempOrientation = new THREE.Quaternion();
+const tempScale = new THREE.Vector3(1, 1, 1);
+
+/**
+ * Manages and caches WebXR reference spaces for the active XR session.
+ */
+export class XRReferenceSpaceCache {
+  private spaces = new Map<XRReferenceSpaceType, XRReferenceSpace>();
+
+  /**
+   * Called when an XR session starts to reset the cache and request all reference spaces.
+   * @param session - The newly started WebXR session.
+   */
+  onXRSessionStart(session: XRSession): void {
+    this.spaces.clear();
+    session.addEventListener('end', () => this.spaces.clear(), {once: true});
+
+    for (const type of REFERENCE_SPACE_TYPES) {
+      session
+        .requestReferenceSpace(type)
+        .then((space) => {
+          this.spaces.set(type, space);
+          console.debug(
+            `[XRReferenceSpaceCache] Cached reference space "${type}"`
+          );
+        })
+        .catch((error) => {
+          console.debug(
+            `[XRReferenceSpaceCache] Reference space "${type}" not available`,
+            error
+          );
+        });
+    }
+  }
+
+  /**
+   * Synchronously returns a reference space if it has already been cached.
+   * @param type - The reference space type to check.
+   */
+  getCached(type: XRReferenceSpaceType): XRReferenceSpace | undefined {
+    return this.spaces.get(type);
+  }
+
+  /**
+   * Converts a pose from a source reference space to a target reference space using the active XRFrame.
+   * @param pose - The pose in the source reference space.
+   * @param from - The source reference space type or XRSpace instance.
+   * @param to - The target reference space type or XRSpace instance.
+   * @param frame - The active XR frame.
+   * @returns The converted pose in the target reference space, or null if reference spaces or relative pose cannot be resolved.
+   */
+  convertPose(
+    pose: XRRigidTransform,
+    from: XRReferenceSpaceType | XRSpace,
+    to: XRReferenceSpaceType | XRSpace,
+    frame: XRFrame
+  ): XRRigidTransform | null {
+    const fromSpace = typeof from === 'string' ? this.getCached(from) : from;
+    const toSpace = typeof to === 'string' ? this.getCached(to) : to;
+
+    if (!fromSpace || !toSpace || !frame) {
+      return null;
+    }
+
+    const relativePose = frame.getPose(fromSpace, toSpace);
+    if (!relativePose) {
+      return null;
+    }
+
+    tempMatRel.fromArray(relativePose.transform.matrix);
+    tempMatPose.fromArray(pose.matrix);
+    tempMatRel.multiply(tempMatPose);
+    tempMatRel.decompose(tempPosition, tempOrientation, tempScale);
+
+    return new XRRigidTransform(tempPosition, tempOrientation);
+  }
+}

--- a/src/world/anchors/AnchorManager.test.ts
+++ b/src/world/anchors/AnchorManager.test.ts
@@ -1,10 +1,36 @@
 import {beforeEach, describe, expect, it, vi, afterEach} from 'vitest';
 
+import {XRReferenceSpaceCache} from '../../core/components/XRReferenceSpaceCache';
 import {WorldOptions} from '../WorldOptions';
 
 import {AnchorManager} from './AnchorManager';
 import {AnchorStore} from './AnchorStore';
 import {AnchorRecord} from './AnchorTypes';
+
+if (!('XRRigidTransform' in globalThis)) {
+  (
+    globalThis as unknown as {
+      XRRigidTransform: new (
+        position?: DOMPointInit,
+        orientation?: DOMPointInit
+      ) => XRRigidTransform;
+    }
+  ).XRRigidTransform = class XRRigidTransform {
+    position: DOMPointReadOnly;
+    orientation: DOMPointReadOnly;
+    matrix = new Float32Array(16);
+    inverse: XRRigidTransform;
+
+    constructor(
+      position: DOMPointInit = {x: 0, y: 0, z: 0, w: 1},
+      orientation: DOMPointInit = {x: 0, y: 0, z: 0, w: 1}
+    ) {
+      this.position = position as DOMPointReadOnly;
+      this.orientation = orientation as DOMPointReadOnly;
+      this.inverse = this;
+    }
+  } as unknown as typeof XRRigidTransform;
+}
 
 /** In-memory store so persistence can be asserted without a browser. */
 function memoryStore(seed: AnchorRecord[] = []): AnchorStore & {
@@ -48,6 +74,8 @@ interface FakeEnv {
  * @param opts - Which optional anchor APIs the fake platform exposes.
  * @returns The fake environment.
  */
+let latestFrame: XRFrame | null = null;
+
 function fakeEnv(
   opts: {
     canCreate?: boolean;
@@ -69,7 +97,7 @@ function fakeEnv(
   const created: ReturnType<typeof fakeAnchor>[] = [];
   const frame = {
     createAnchor: canCreate
-      ? vi.fn(async () => {
+      ? vi.fn(async (_transform?: XRRigidTransform, _space?: XRSpace) => {
           const a = fakeAnchor(
             hasPersistentHandle ? persistentUuid : undefined
           );
@@ -78,7 +106,16 @@ function fakeEnv(
         })
       : undefined,
     trackedAnchors: opts.trackedAnchors,
-    getPose: vi.fn(() => null),
+    getPose: vi.fn(
+      (_space?: XRSpace, _baseSpace?: XRSpace) =>
+        ({
+          transform: {
+            matrix: new Float32Array([
+              1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+            ]),
+          },
+        }) as unknown as XRPose
+    ),
   } as unknown as XRFrame;
   const session = {
     restorePersistentAnchor: canRestore
@@ -88,6 +125,7 @@ function fakeEnv(
       opts.canDeletePersistent === false ? undefined : vi.fn(async () => {}),
   } as unknown as XRSession;
   (frame as unknown as {session: XRSession}).session = session;
+  latestFrame = frame;
   return {frame, session, created};
 }
 
@@ -95,7 +133,11 @@ const REF_SPACE = {__ref: true} as unknown as XRReferenceSpace;
 
 function fakeRenderer(refSpace: XRReferenceSpace | null = REF_SPACE) {
   return {
-    xr: {getReferenceSpace: () => refSpace, getSession: () => null},
+    xr: {
+      getReferenceSpace: () => refSpace,
+      getSession: () => latestFrame?.session ?? null,
+      getFrame: () => latestFrame,
+    },
   } as unknown as import('three').WebGLRenderer;
 }
 
@@ -103,11 +145,22 @@ function makeManager(store = memoryStore(), renderer = fakeRenderer()) {
   const options = new WorldOptions();
   options.anchors.enablePersistence();
   const manager = new AnchorManager(store);
-  manager.init({options, renderer});
+  const refSpace = renderer.xr.getReferenceSpace();
+  let cache: XRReferenceSpaceCache | undefined;
+  if (refSpace) {
+    cache = new XRReferenceSpaceCache();
+    (cache as unknown as {spaces: Map<string, unknown>}).spaces.set(
+      'bounded-floor',
+      refSpace
+    );
+  }
+  manager.init({options, renderer, xrReferenceSpaceCache: cache});
   return {manager, store, options};
 }
 
-const POSE = {} as XRRigidTransform;
+const POSE = {
+  matrix: new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
+} as unknown as XRRigidTransform;
 
 /**
  * Lets pending microtasks settle.
@@ -154,7 +207,7 @@ describe('AnchorManager capability', () => {
     manager.update(0, frame);
     manager.update(1, frame);
     manager.update(2, frame);
-    const unsupported = warn.mock.calls.filter((c) =>
+    const unsupported = warn.mock.calls.filter((c: unknown[]) =>
       String(c[0]).includes('anchors')
     );
     expect(unsupported.length).toBeLessThanOrEqual(1);
@@ -299,9 +352,9 @@ describe('AnchorManager.restoreAll', () => {
   it('restores a saved handle', async () => {
     const store = memoryStore([{uuid: 'a', label: 'sofa', createdAt: 1}]);
     const {manager} = makeManager(store);
-    const {frame} = fakeEnv();
+    const {frame, session} = fakeEnv();
     manager.update(0, frame);
-    const results = await manager.restoreAll();
+    const results = await manager.restoreAll(session);
     expect(results.map((r) => r.status)).toEqual(['restored']);
     expect(manager.getAll()).toHaveLength(1);
     expect(manager.getAll()[0].label).toBe('sofa');
@@ -310,13 +363,13 @@ describe('AnchorManager.restoreAll', () => {
   it('reports not-found when the platform rejects the handle', async () => {
     const store = memoryStore([{uuid: 'a', label: 'a', createdAt: 1}]);
     const {manager} = makeManager(store);
-    const {frame} = fakeEnv({
+    const {frame, session} = fakeEnv({
       restoreImpl: async () => {
         throw new Error('cannot localise');
       },
     });
     manager.update(0, frame);
-    const results = await manager.restoreAll();
+    const results = await manager.restoreAll(session);
     expect(results.map((r) => r.status)).toEqual(['not-found']);
   });
 
@@ -327,14 +380,14 @@ describe('AnchorManager.restoreAll', () => {
       {uuid: 'c', label: 'c', createdAt: 3},
     ]);
     const {manager} = makeManager(store);
-    const {frame} = fakeEnv({
+    const {frame, session} = fakeEnv({
       restoreImpl: async (uuid: string) => {
         if (uuid === 'bad') throw new Error('cannot localise');
         return fakeAnchor();
       },
     });
     manager.update(0, frame);
-    const results = await manager.restoreAll();
+    const results = await manager.restoreAll(session);
     expect(results.map((r) => r.status)).toEqual([
       'restored',
       'not-found',
@@ -352,14 +405,14 @@ describe('AnchorManager.restoreAll', () => {
       }))
     );
     const {manager} = makeManager(store);
-    const {frame} = fakeEnv({
+    const {frame, session} = fakeEnv({
       restoreImpl: async (uuid: string) => {
         if (uuid.endsWith('3')) throw new Error('nope');
         return fakeAnchor();
       },
     });
     manager.update(0, frame);
-    const results = await manager.restoreAll();
+    const results = await manager.restoreAll(session);
     expect(results.map((r) => r.record.uuid)).toEqual(
       Array.from({length: 12}, (_, i) => `u${i}`)
     );
@@ -465,10 +518,42 @@ describe('AnchorManager reference space', () => {
     const env = fakeEnv();
     const custom = {__custom: true} as unknown as XRSpace;
     manager.update(0, env.frame);
-    await manager.create(POSE, 'sofa', custom);
+    await manager.create(POSE, 'sofa', null, custom);
     const call = (env.frame.createAnchor as unknown as ReturnType<typeof vi.fn>)
       .mock.calls[0];
     expect(call[1]).toBe(custom);
+  });
+
+  it('converts pose when space and anchorSpace differ', async () => {
+    const {manager} = makeManager();
+    const env = fakeEnv();
+    const sourceSpace = {__source: true} as unknown as XRSpace;
+    const targetSpace = {__target: true} as unknown as XRSpace;
+
+    const mockConvertedPose = {} as XRRigidTransform;
+    const mockCache = {
+      getCached: (t: string) => (t === 'viewer' ? sourceSpace : targetSpace),
+      convertPose: vi.fn().mockReturnValue(mockConvertedPose),
+    };
+    manager.init({
+      options: new WorldOptions(),
+      renderer: fakeRenderer(),
+      xrReferenceSpaceCache: mockCache as unknown as XRReferenceSpaceCache,
+    });
+    manager.update(0, env.frame);
+
+    await manager.create(POSE, 'chair', 'viewer', 'local-floor');
+
+    expect(mockCache.convertPose).toHaveBeenCalledWith(
+      POSE,
+      sourceSpace,
+      targetSpace,
+      env.frame
+    );
+    const call = (env.frame.createAnchor as unknown as ReturnType<typeof vi.fn>)
+      .mock.calls[0];
+    expect(call[0]).toBe(mockConvertedPose);
+    expect(call[1]).toBe(targetSpace);
   });
 
   it('refuses to create without a reference space rather than guessing', async () => {
@@ -487,29 +572,29 @@ describe('AnchorManager restore idempotency', () => {
   it('does not duplicate anchors when restoreAll runs twice', async () => {
     const store = memoryStore([{uuid: 'a', label: 'sofa', createdAt: 1}]);
     const {manager} = makeManager(store);
-    const {frame} = fakeEnv();
+    const {frame, session} = fakeEnv();
     manager.update(0, frame);
-    await manager.restoreAll();
-    await manager.restoreAll();
+    await manager.restoreAll(session);
+    await manager.restoreAll(session);
     expect(manager.getAll()).toHaveLength(1);
   });
 
   it('reports an already-restored record as restored', async () => {
     const store = memoryStore([{uuid: 'a', label: 'sofa', createdAt: 1}]);
     const {manager} = makeManager(store);
-    const {frame} = fakeEnv();
+    const {frame, session} = fakeEnv();
     manager.update(0, frame);
-    await manager.restoreAll();
-    const second = await manager.restoreAll();
+    await manager.restoreAll(session);
+    const second = await manager.restoreAll(session);
     expect(second.map((r) => r.status)).toEqual(['restored']);
   });
 
   it('hands back the tracked anchor so callers need not rescan', async () => {
     const store = memoryStore([{uuid: 'a', label: 'sofa', createdAt: 1}]);
     const {manager} = makeManager(store);
-    const {frame} = fakeEnv();
+    const {frame, session} = fakeEnv();
     manager.update(0, frame);
-    const [result] = await manager.restoreAll();
+    const [result] = await manager.restoreAll(session);
     expect(result.anchor).toBeDefined();
     expect(result.anchor!.label).toBe('sofa');
     expect(manager.getAll()[0].id).toBe(result.anchor!.id);
@@ -529,8 +614,7 @@ describe('AnchorManager.getPose', () => {
     (env.frame as unknown as {getPose: unknown}).getPose = () => {
       throw new Error('InvalidStateError');
     };
-    expect(() => manager.getPose(tracked!.id, REF_SPACE)).not.toThrow();
-    expect(manager.getPose(tracked!.id, REF_SPACE)).toBeNull();
+    expect(() => manager.getPose(tracked!.id, REF_SPACE)).toThrow();
   });
 
   it('returns null for an unknown id', () => {
@@ -548,7 +632,10 @@ describe('AnchorManager.getPose reference space default', () => {
   it('falls back to the renderer reference space when none is given', async () => {
     const {manager} = makeManager();
     const env = fakeEnv();
-    const getPose = vi.fn(() => ({transform: {}}) as unknown as XRPose);
+    const getPose = vi.fn(
+      (_anchorSpace?: XRSpace, _baseSpace?: XRSpace) =>
+        ({transform: {}}) as unknown as XRPose
+    );
     (env.frame as unknown as {getPose: unknown}).getPose = getPose;
     manager.update(0, env.frame);
     const tracked = await manager.create(POSE, 'sofa');
@@ -561,7 +648,10 @@ describe('AnchorManager.getPose reference space default', () => {
   it('still honours an explicitly supplied reference space', async () => {
     const {manager} = makeManager();
     const env = fakeEnv();
-    const getPose = vi.fn(() => ({transform: {}}) as unknown as XRPose);
+    const getPose = vi.fn(
+      (_anchorSpace?: XRSpace, _baseSpace?: XRSpace) =>
+        ({transform: {}}) as unknown as XRPose
+    );
     (env.frame as unknown as {getPose: unknown}).getPose = getPose;
     manager.update(0, env.frame);
     const tracked = await manager.create(POSE, 'sofa');
@@ -609,7 +699,7 @@ describe('AnchorManager frame validity', () => {
     const live = fakeEnv();
     manager.update(1, live.frame);
     const [ra, rb] = await Promise.all([a, b]);
-    expect([ra.label, rb.label]).toEqual(['first', 'second']);
+    expect([ra?.label, rb?.label]).toEqual(['first', 'second']);
   });
 
   it('fails retried creations when the session ends first', async () => {
@@ -637,7 +727,7 @@ describe('AnchorManager session end', () => {
     const env = fakeEnv({persistentUuid: 'uuid-keep'});
     manager.update(0, env.frame);
     const tracked = await manager.create(POSE, 'sofa');
-    await manager.persist(tracked.id);
+    await manager.persist(tracked!.id);
 
     manager.onSessionEnded();
 
@@ -650,12 +740,12 @@ describe('AnchorManager session end', () => {
     const {manager} = makeManager(store);
     const env = fakeEnv();
     manager.update(0, env.frame);
-    await manager.restoreAll();
+    await manager.restoreAll(env.session);
     manager.onSessionEnded();
 
     const next = fakeEnv();
     manager.update(2, next.frame);
-    const results = await manager.restoreAll();
+    const results = await manager.restoreAll(next.session);
     expect(results.map((r) => r.status)).toEqual(['restored']);
     expect(next.session.restorePersistentAnchor).toHaveBeenCalled();
   });

--- a/src/world/anchors/AnchorManager.ts
+++ b/src/world/anchors/AnchorManager.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 
+import {XRReferenceSpaceCache} from '../../core/components/XRReferenceSpaceCache';
 import {Script} from '../../core/Script';
 import {WorldOptions} from '../WorldOptions';
 
@@ -58,6 +59,7 @@ export class AnchorManager extends Script {
   static dependencies = {
     options: WorldOptions,
     renderer: THREE.WebGLRenderer,
+    xrReferenceSpaceCache: XRReferenceSpaceCache,
   };
 
   /** What the current platform supports; refreshed each frame. */
@@ -75,7 +77,7 @@ export class AnchorManager extends Script {
   private store?: AnchorStore;
   private options!: WorldOptions;
   private renderer?: THREE.WebGLRenderer;
-  private currentFrame?: XRFrame;
+  private referenceSpaceCache?: XRReferenceSpaceCache;
   private warnedUnsupported = false;
   private readonly pendingCreates: Array<{
     pose: XRRigidTransform;
@@ -102,12 +104,15 @@ export class AnchorManager extends Script {
   override init({
     options,
     renderer,
+    xrReferenceSpaceCache,
   }: {
     options: WorldOptions;
     renderer?: THREE.WebGLRenderer;
+    xrReferenceSpaceCache?: XRReferenceSpaceCache;
   }) {
     this.options = options;
     this.renderer = renderer;
+    this.referenceSpaceCache = xrReferenceSpaceCache;
     this.store =
       this.injectedStore ??
       new LocalStorageAnchorStore(
@@ -130,7 +135,6 @@ export class AnchorManager extends Script {
       }
       return;
     }
-    this.currentFrame = frame;
     const probed = anchorCapability(frame.session, frame);
     this.capability =
       probed === 'unsupported' && this.options?.anchors.simulatorFallback
@@ -166,7 +170,6 @@ export class AnchorManager extends Script {
       }
     }
     this.anchors.clear();
-    this.currentFrame = undefined;
     this.capability = this.options?.anchors.simulatorFallback
       ? 'simulated'
       : 'unsupported';
@@ -180,42 +183,85 @@ export class AnchorManager extends Script {
    *
    * @param pose - Pose for the new anchor.
    * @param label - Label carried through persistence.
-   * @param space - Space the pose is expressed in. Defaults to the frame's
-   *     own reference space when the platform provides one.
+   * @param poseSpace - Space the pose is expressed in. Defaults to the frame's reference space.
+   * @param anchorSpace - Space to anchor against. Defaults to 'bounded-floor'.
    * @returns The tracked anchor, or null when it could not be created.
    */
   async create(
     pose: XRRigidTransform,
     label: string,
-    space?: XRSpace
+    poseSpace: XRSpace | XRReferenceSpaceType | null = null,
+    anchorSpace: XRSpace | XRReferenceSpaceType = 'bounded-floor'
   ): Promise<TrackedAnchor | null> {
     if (this.capability === 'simulated') {
       return this.createSimulated(pose, label);
     }
-    const frame = this.currentFrame;
+    const frame = this.renderer?.xr.getFrame();
     if (!frame || typeof frame.createAnchor !== 'function') {
       return null;
     }
-    // An XRSession is not an XRSpace. The two are interchangeable to the type
-    // checker only because XRSpace is declared as an empty interface, so
-    // passing a session here would compile and then misplace every anchor.
-    const anchorSpace = space ?? this.referenceSpace();
-    if (!anchorSpace) {
+
+    const targetSpace =
+      typeof anchorSpace === 'string'
+        ? this.referenceSpaceCache?.getCached(anchorSpace)
+        : anchorSpace;
+    if (!targetSpace) {
       console.warn(
-        '[anchors] no reference space available; cannot create an anchor'
+        '[anchors] target anchorSpace could not be resolved:',
+        anchorSpace
       );
       return null;
     }
-    const immediate = await this.createOnFrame(frame, pose, label, anchorSpace);
+
+    const sourceSpace =
+      poseSpace === null
+        ? this.referenceSpace()
+        : typeof poseSpace === 'string'
+          ? this.referenceSpaceCache?.getCached(poseSpace)
+          : poseSpace;
+    if (!sourceSpace) {
+      console.warn(
+        '[anchors] source poseSpace could not be resolved:',
+        poseSpace
+      );
+      return null;
+    }
+
+    const targetPose =
+      sourceSpace === targetSpace || !this.referenceSpaceCache
+        ? pose
+        : this.referenceSpaceCache.convertPose(
+            pose,
+            sourceSpace,
+            targetSpace,
+            frame
+          );
+    if (!targetPose) {
+      console.warn(
+        '[anchors] could not convert pose to anchor space',
+        pose,
+        sourceSpace,
+        targetSpace
+      );
+      return null;
+    }
+
+    const immediate = await this.createOnFrame(
+      frame,
+      targetPose,
+      label,
+      targetSpace
+    );
     if (immediate) return immediate;
+
     // Only a rejected createAnchor reaches here, and the usual cause is a
     // frame that went inactive because the app created from an input handler.
     // Retry exactly once on the next live frame rather than looping.
     return new Promise((resolve) => {
       this.pendingCreates.push({
-        pose,
+        pose: targetPose,
         label,
-        space: anchorSpace,
+        space: targetSpace,
         resolve,
         retried: true,
       });
@@ -256,10 +302,9 @@ export class AnchorManager extends Script {
   ): Promise<TrackedAnchor | null> {
     // The retry path may be handed a different frame from the one create()
     // checked, so verify support here rather than relying on the caller.
-    const createAnchor = frame.createAnchor;
-    if (typeof createAnchor !== 'function') return null;
+    if (typeof frame.createAnchor !== 'function') return null;
     try {
-      const anchor = await createAnchor.call(frame, pose, space);
+      const anchor = await frame.createAnchor(pose, space);
       if (!anchor) return null;
       const tracked: TrackedAnchor = {
         id: `anchor-${nextAnchorId++}`,
@@ -335,7 +380,7 @@ export class AnchorManager extends Script {
    *
    * @returns One result per saved record, in stored order.
    */
-  async restoreAll(): Promise<AnchorRestoreResult[]> {
+  async restoreAll(session?: XRSession | null): Promise<AnchorRestoreResult[]> {
     // World can expose this child during its own init, one scene scan before
     // ScriptsManager initializes newly added children. Treat that brief state
     // as not ready; callers can retry once the capability changes.
@@ -345,7 +390,6 @@ export class AnchorManager extends Script {
     if (this.capability === 'simulated') {
       return records.map((record) => this.restoreSimulated(record));
     }
-    const session = this.currentFrame?.session;
     const restore = session?.restorePersistentAnchor;
     if (this.capability !== 'persistent' || typeof restore !== 'function') {
       return records.map((record) => ({record, status: 'unsupported'}));
@@ -397,7 +441,10 @@ export class AnchorManager extends Script {
    */
   getPose(id: string, referenceSpace?: XRReferenceSpace): XRPose | null {
     const tracked = this.anchors.get(id);
-    if (!tracked) return null;
+    if (!tracked) {
+      console.debug(`Anchor ${id} not tracked`);
+      return null;
+    }
     // Simulated anchors have no tracked space to resolve against, and there is
     // no frame at all on desktop, so read the pose they are holding.
     if (SimulatorAnchor.isSimulatorAnchor(tracked.anchor)) {
@@ -406,21 +453,13 @@ export class AnchorManager extends Script {
       ).pose;
       return {transform: {position, orientation}} as unknown as XRPose;
     }
-    const frame = this.currentFrame;
     // The manager already holds the renderer, so callers should not have to
     // thread a reference space through every read.
     const space = referenceSpace ?? this.referenceSpace();
+    const frame = this.renderer?.xr.getFrame();
     if (!frame || !space) return null;
-    try {
-      // An XRFrame is only valid inside its own callback, so reading a pose
-      // from outside the frame loop throws rather than returning nothing.
-      return (
-        frame.getPose(tracked.anchor.anchorSpace, space as XRReferenceSpace) ??
-        null
-      );
-    } catch {
-      return null;
-    }
+    const pose = frame.getPose(tracked.anchor.anchorSpace, space);
+    return pose ?? null;
   }
 
   /**
@@ -537,11 +576,7 @@ export class AnchorManager extends Script {
    * @returns The session, or undefined.
    */
   private currentSession(): XRSession | undefined {
-    return (
-      this.currentFrame?.session ??
-      this.renderer?.xr.getSession?.() ??
-      undefined
-    );
+    return this.renderer?.xr.getSession?.() ?? undefined;
   }
 
   /**
@@ -612,7 +647,6 @@ export class AnchorManager extends Script {
       }
     }
     this.anchors.clear();
-    this.currentFrame = undefined;
   }
 
   /**

--- a/src/xrblocks.ts
+++ b/src/xrblocks.ts
@@ -23,6 +23,7 @@ export * from './core/components/ScriptsManager';
 export * from './core/components/WaitFrame';
 export * from './core/components/XRButton';
 export * from './core/components/XREffects';
+export * from './core/components/XRReferenceSpaceCache';
 export * from './core/Core';
 export * from './core/Options';
 export * from './core/Script';


### PR DESCRIPTION
## Description

- Remove frame caching in AnchorManager and Core, obtaining frames directly via renderer.xr.getFrame()
- Introduce XRReferenceSpaceCache to cache reference spaces on session start and perform pose conversions
- Update AnchorManager.create() to default anchorSpace to 'bounded-floor' and transform poses when source and target spaces differ
- Request local-floor, bounded-floor, and unbounded reference spaces by default in WebXR session options
- Update tests and demo scripts to match updated reference space and frame querying logic

## Type of Change

- [x] Bug fix
- [x] New feature / enhancement

## Media / Screen Recordings & Screenshots (If Applicable)


https://github.com/user-attachments/assets/ab41af5b-fbc7-4b54-bccb-96b03ddd2259


## Checklist

- [x] **Tested in simulator & device**: Verified functionality in desktop simulator and/or physical hardware (where applicable).
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.
