### PR TITLE
fix(anchors): restore anchor creation and persistence 

### DIFF
--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -564,8 +564,8 @@ export class Core {
       this.context.setDeviceCamera(this.deviceCamera);
     }
 
-    const webXRRequiredFeatures: string[] = [...options.webxrRequiredFeatures];
-    const webXROptionalFeatures: string[] = [...options.webxrOptionalFeatures];
+    const webXRRequiredFeatures: string[] = options.webxrRequiredFeatures;
+    const webXROptionalFeatures: string[] = options.webxrOptionalFeatures;
     // The space the scene is drawn in has to be granted, and an app that sets
     // webxrOptionalFeatures itself would otherwise drop it and fail to start.
     if (!webXROptionalFeatures.includes(options.referenceSpaceType)) {

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -564,8 +564,13 @@ export class Core {
       this.context.setDeviceCamera(this.deviceCamera);
     }
 
-    const webXRRequiredFeatures: string[] = options.webxrRequiredFeatures;
-    const webXROptionalFeatures: string[] = options.webxrOptionalFeatures;
+    const webXRRequiredFeatures: string[] = [...options.webxrRequiredFeatures];
+    const webXROptionalFeatures: string[] = [...options.webxrOptionalFeatures];
+    // The space the scene is drawn in has to be granted, and an app that sets
+    // webxrOptionalFeatures itself would otherwise drop it and fail to start.
+    if (!webXROptionalFeatures.includes(options.referenceSpaceType)) {
+      webXROptionalFeatures.push(options.referenceSpaceType);
+    }
     // Use camera-access when the browser supports it.
     if (options.deviceCamera?.enabled) {
       webXROptionalFeatures.push('camera-access');

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -174,7 +174,7 @@ export class Core {
   gestureRecognition?: GestureRecognition;
   transition?: XRTransition;
   get currentFrame() {
-    return this.renderer.xr.getFrame();
+    return this._renderer?.xr.getFrame();
   }
   scriptsManager = new ScriptsManager(async (script: Script) => {
     await callInitWithDependencyInjection(script, this.registry, this);

--- a/src/core/components/XRReferenceSpaceCache.test.ts
+++ b/src/core/components/XRReferenceSpaceCache.test.ts
@@ -130,3 +130,32 @@ describe('XRReferenceSpaceCache', () => {
     expect(result).toBeNull();
   });
 });
+
+describe('XRReferenceSpaceCache session hygiene', () => {
+  it('ignores a reference space that resolves after the session ended', async () => {
+    // requestReferenceSpace settles asynchronously, so a slow one can land
+    // after the session is gone and leave a dead space for the next session.
+    const cache = new XRReferenceSpaceCache();
+    let resolveLate: (space: XRReferenceSpace) => void = () => {};
+    const listeners: Record<string, () => void> = {};
+    const session = {
+      requestReferenceSpace: (type: string) =>
+        type === 'local'
+          ? new Promise<XRReferenceSpace>((r) => {
+              resolveLate = r;
+            })
+          : Promise.reject(new Error('unavailable')),
+      addEventListener: (event: string, fn: () => void) => {
+        listeners[event] = fn;
+      },
+      removeEventListener: vi.fn(),
+    } as unknown as XRSession;
+
+    cache.onXRSessionStart(session);
+    listeners['end']?.();
+    resolveLate({__late: true} as unknown as XRReferenceSpace);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(cache.getCached('local')).toBeUndefined();
+  });
+});

--- a/src/core/components/XRReferenceSpaceCache.ts
+++ b/src/core/components/XRReferenceSpaceCache.ts
@@ -19,6 +19,7 @@ const tempScale = new THREE.Vector3(1, 1, 1);
  */
 export class XRReferenceSpaceCache {
   private spaces = new Map<XRReferenceSpaceType, XRReferenceSpace>();
+  private session: XRSession | null = null;
 
   /**
    * Called when an XR session starts to reset the cache and request all reference spaces.
@@ -26,12 +27,24 @@ export class XRReferenceSpaceCache {
    */
   onXRSessionStart(session: XRSession): void {
     this.spaces.clear();
-    session.addEventListener('end', () => this.spaces.clear(), {once: true});
+    this.session = session;
+    session.addEventListener(
+      'end',
+      () => {
+        if (this.session === session) this.session = null;
+        this.spaces.clear();
+      },
+      {once: true}
+    );
 
     for (const type of REFERENCE_SPACE_TYPES) {
       session
         .requestReferenceSpace(type)
         .then((space) => {
+          // These settle after the session may already have ended, and a late
+          // write would leave a dead session's space in the cache for the next
+          // one to pick up.
+          if (this.session !== session) return;
           this.spaces.set(type, space);
           console.debug(
             `[XRReferenceSpaceCache] Cached reference space "${type}"`

--- a/src/world/anchors/AnchorManager.test.ts
+++ b/src/world/anchors/AnchorManager.test.ts
@@ -1075,3 +1075,102 @@ describe('AnchorManager releaseAllPlatformHandles', () => {
     expect(await manager.releaseAllPlatformHandles()).toBe(0);
   });
 });
+
+/**
+ * Renderer double that models three.js honestly: a frame exists only while an
+ * animation callback is running. The shared double above keeps one alive at
+ * all times, which is what let the no-live-frame path regress unnoticed.
+ */
+function strictEnv(opts: {cached?: XRReferenceSpaceType[]} = {}) {
+  const session = {
+    restorePersistentAnchor: vi.fn(async () => fakeAnchor('uuid-a')),
+    deletePersistentAnchor: vi.fn(async () => {}),
+  } as unknown as XRSession;
+  const frame = {
+    createAnchor: vi.fn(async () => fakeAnchor('uuid-a')),
+    getPose: vi.fn(() => ({
+      transform: {
+        matrix: new Float32Array([
+          1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+        ]),
+      },
+    })),
+    session,
+  } as unknown as XRFrame;
+
+  const sceneSpace = {__scene: true} as unknown as XRReferenceSpace;
+  const cache = new XRReferenceSpaceCache();
+  for (const type of opts.cached ?? ['bounded-floor']) {
+    (cache as unknown as {spaces: Map<string, unknown>}).spaces.set(type, {
+      __named: type,
+    });
+  }
+
+  let live: XRFrame | null = null;
+  const renderer = {
+    xr: {
+      getReferenceSpace: () => sceneSpace,
+      getSession: () => session,
+      getFrame: () => live,
+    },
+  } as unknown as import('three').WebGLRenderer;
+
+  return {
+    session,
+    frame,
+    cache,
+    renderer,
+    make(store = memoryStore()) {
+      const options = new WorldOptions();
+      options.anchors.enablePersistence();
+      const manager = new AnchorManager(store);
+      manager.init({options, renderer, xrReferenceSpaceCache: cache});
+      return manager;
+    },
+    /** Runs one animation frame, during which a frame is live. */
+    tick(manager: AnchorManager) {
+      live = frame;
+      manager.update(0, frame);
+      live = null;
+    },
+  };
+}
+
+describe('AnchorManager without a live frame', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  it('creates from a click handler once the next frame arrives', async () => {
+    // three.js clears its frame at the end of the animation callback, so an
+    // app dropping an anchor from a button has no live frame at that moment.
+    const env = strictEnv();
+    const manager = env.make();
+    env.tick(manager);
+
+    const promise = manager.create(POSE, 'sofa');
+    env.tick(manager);
+
+    expect(await promise).not.toBeNull();
+    expect(env.frame.createAnchor).toHaveBeenCalled();
+  });
+
+  it('resolves queued creates as null when the session ends first', async () => {
+    const env = strictEnv();
+    const manager = env.make();
+    env.tick(manager);
+
+    const promise = manager.create(POSE, 'sofa');
+    manager.onSessionEnded();
+
+    await expect(promise).resolves.toBeNull();
+  });
+
+  it('does not queue forever when the platform has no anchors', async () => {
+    const env = strictEnv();
+    const manager = env.make();
+    // No tick, so capability is still the initial unsupported.
+    await expect(manager.create(POSE, 'sofa')).resolves.toBeNull();
+  });
+});

--- a/src/world/anchors/AnchorManager.test.ts
+++ b/src/world/anchors/AnchorManager.test.ts
@@ -1221,3 +1221,20 @@ describe('AnchorManager anchor space fallback', () => {
     await expect(promise).resolves.toBeNull();
   });
 });
+
+describe('AnchorManager.restoreAll without an explicit session', () => {
+  it('falls back to the session the renderer holds', async () => {
+    // AnchoredObjects and both anchor demos call restoreAll() with no
+    // arguments, which is the shape this has to keep working for.
+    const env = strictEnv();
+    const manager = env.make(
+      memoryStore([{uuid: 'uuid-a', label: 'sofa', createdAt: 1}])
+    );
+    env.tick(manager);
+
+    const results = await manager.restoreAll();
+
+    expect(results.map((r) => r.status)).toEqual(['restored']);
+    expect(env.session.restorePersistentAnchor).toHaveBeenCalled();
+  });
+});

--- a/src/world/anchors/AnchorManager.test.ts
+++ b/src/world/anchors/AnchorManager.test.ts
@@ -1174,3 +1174,50 @@ describe('AnchorManager without a live frame', () => {
     await expect(manager.create(POSE, 'sofa')).resolves.toBeNull();
   });
 });
+
+describe('AnchorManager anchor space fallback', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  it('still anchors when bounded-floor is not granted', async () => {
+    // bounded-floor needs a configured play space and is absent on plenty of
+    // hardware. Refusing there would be worse than the behaviour it replaced.
+    const env = strictEnv({cached: ['local-floor']});
+    const manager = env.make();
+    env.tick(manager);
+
+    const promise = manager.create(POSE, 'sofa');
+    env.tick(manager);
+
+    await expect(promise).resolves.not.toBeNull();
+    expect(env.frame.createAnchor).toHaveBeenCalled();
+  });
+
+  it('anchors against the scene space when no cache was injected', async () => {
+    const env = strictEnv();
+    const options = new WorldOptions();
+    const manager = new AnchorManager(memoryStore());
+    manager.init({options, renderer: env.renderer});
+    env.tick(manager);
+
+    const promise = manager.create(POSE, 'sofa');
+    env.tick(manager);
+
+    await expect(promise).resolves.not.toBeNull();
+  });
+
+  it('refuses rather than guessing when a named poseSpace is missing', async () => {
+    // The caller is asserting what the pose means, so substituting another
+    // space would put the anchor somewhere else entirely.
+    const env = strictEnv();
+    const manager = env.make();
+    env.tick(manager);
+
+    const promise = manager.create(POSE, 'sofa', 'unbounded');
+    env.tick(manager);
+
+    await expect(promise).resolves.toBeNull();
+  });
+});

--- a/src/world/anchors/AnchorManager.test.ts
+++ b/src/world/anchors/AnchorManager.test.ts
@@ -606,15 +606,19 @@ describe('AnchorManager.getPose', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
-  it('returns null instead of throwing on a stale frame', async () => {
+  it('returns null instead of throwing when the space is from another session', async () => {
     const {manager} = makeManager();
     const env = fakeEnv();
     manager.update(0, env.frame);
     const tracked = await manager.create(POSE, 'sofa');
+    // getPose throws InvalidStateError when the anchor and the reference
+    // space belong to different sessions, which a caller holding a space
+    // across a session boundary can still reach.
     (env.frame as unknown as {getPose: unknown}).getPose = () => {
       throw new Error('InvalidStateError');
     };
-    expect(() => manager.getPose(tracked!.id, REF_SPACE)).toThrow();
+    expect(manager.getPose(tracked!.id, REF_SPACE)).toBeNull();
+    expect(manager.lastError).toBeInstanceOf(Error);
   });
 
   it('returns null for an unknown id', () => {

--- a/src/world/anchors/AnchorManager.ts
+++ b/src/world/anchors/AnchorManager.ts
@@ -82,7 +82,8 @@ export class AnchorManager extends Script {
   private readonly pendingCreates: Array<{
     pose: XRRigidTransform;
     label: string;
-    space?: XRSpace;
+    poseSpace: XRSpace | XRReferenceSpaceType | null;
+    anchorSpace: XRSpace | XRReferenceSpaceType;
     resolve: (value: TrackedAnchor | null) => void;
     retried: boolean;
   }> = [];
@@ -196,11 +197,77 @@ export class AnchorManager extends Script {
     if (this.capability === 'simulated') {
       return this.createSimulated(pose, label);
     }
+    // Queueing on a platform that cannot make anchors would leave the caller
+    // awaiting a promise that never settles, since update() bails before the
+    // flush when support is missing.
+    if (this.capability === 'unsupported') return null;
     const frame = this.renderer?.xr.getFrame();
-    if (!frame || typeof frame.createAnchor !== 'function') {
-      return null;
+    // three.js clears its frame at the end of the animation callback, so there
+    // is no live frame during a click handler, which is where apps actually
+    // drop anchors from. Queue rather than refuse, and let the next frame do
+    // the work.
+    if (!frame) {
+      return this.queueCreate(pose, label, poseSpace, anchorSpace, false);
     }
+    if (typeof frame.createAnchor !== 'function') return null;
+    return this.createResolved(
+      frame,
+      pose,
+      label,
+      poseSpace,
+      anchorSpace,
+      false
+    );
+  }
 
+  /**
+   * Holds a creation request until a frame is live.
+   *
+   * @param pose - Pose for the new anchor.
+   * @param label - Label carried through persistence.
+   * @param poseSpace - Space the pose is expressed in.
+   * @param anchorSpace - Space to anchor against.
+   * @param retried - Whether this request has already been requeued once.
+   * @returns The tracked anchor once a frame arrives, or null.
+   */
+  private queueCreate(
+    pose: XRRigidTransform,
+    label: string,
+    poseSpace: XRSpace | XRReferenceSpaceType | null,
+    anchorSpace: XRSpace | XRReferenceSpaceType,
+    retried: boolean
+  ): Promise<TrackedAnchor | null> {
+    return new Promise((resolve) => {
+      this.pendingCreates.push({
+        pose,
+        label,
+        poseSpace,
+        anchorSpace,
+        resolve,
+        retried,
+      });
+    });
+  }
+
+  /**
+   * Resolves spaces against a live frame and creates the anchor.
+   *
+   * @param frame - A frame known to be active.
+   * @param pose - Pose for the new anchor.
+   * @param label - Label carried through persistence.
+   * @param poseSpace - Space the pose is expressed in.
+   * @param anchorSpace - Space to anchor against.
+   * @param retried - Whether this request has already been requeued once.
+   * @returns The tracked anchor, or null when it could not be created.
+   */
+  private async createResolved(
+    frame: XRFrame,
+    pose: XRRigidTransform,
+    label: string,
+    poseSpace: XRSpace | XRReferenceSpaceType | null,
+    anchorSpace: XRSpace | XRReferenceSpaceType,
+    retried: boolean
+  ): Promise<TrackedAnchor | null> {
     const targetSpace =
       typeof anchorSpace === 'string'
         ? this.referenceSpaceCache?.getCached(anchorSpace)
@@ -252,20 +319,12 @@ export class AnchorManager extends Script {
       label,
       targetSpace
     );
-    if (immediate) return immediate;
+    if (immediate || retried) return immediate;
 
     // Only a rejected createAnchor reaches here, and the usual cause is a
-    // frame that went inactive because the app created from an input handler.
-    // Retry exactly once on the next live frame rather than looping.
-    return new Promise((resolve) => {
-      this.pendingCreates.push({
-        pose: targetPose,
-        label,
-        space: targetSpace,
-        resolve,
-        retried: true,
-      });
-    });
+    // frame that went inactive mid-call. Retry exactly once on the next live
+    // frame rather than looping.
+    return this.queueCreate(targetPose, label, targetSpace, targetSpace, true);
   }
 
   /**
@@ -274,13 +333,23 @@ export class AnchorManager extends Script {
    */
   private async flushPendingCreates(frame: XRFrame): Promise<void> {
     if (this.pendingCreates.length === 0) return;
+    if (typeof frame.createAnchor !== 'function') {
+      // The platform cannot make anchors at all, so waiting for a better frame
+      // would leave every caller hanging on a promise that never settles.
+      for (const pending of this.pendingCreates.splice(0)) {
+        pending.resolve(null);
+      }
+      return;
+    }
     for (const pending of this.pendingCreates.splice(0)) {
       pending.resolve(
-        await this.createOnFrame(
+        await this.createResolved(
           frame,
           pending.pose,
           pending.label,
-          pending.space!
+          pending.poseSpace,
+          pending.anchorSpace,
+          pending.retried
         )
       );
     }

--- a/src/world/anchors/AnchorManager.ts
+++ b/src/world/anchors/AnchorManager.ts
@@ -495,12 +495,13 @@ export class AnchorManager extends Script {
     if (this.capability === 'simulated') {
       return records.map((record) => this.restoreSimulated(record));
     }
-    const restore = session?.restorePersistentAnchor;
+    const activeSession = session ?? this.currentSession();
+    const restore = activeSession?.restorePersistentAnchor;
     if (this.capability !== 'persistent' || typeof restore !== 'function') {
       return records.map((record) => ({record, status: 'unsupported'}));
     }
     return Promise.all(
-      records.map((record) => this.restoreOne(record, session!))
+      records.map((record) => this.restoreOne(record, activeSession!))
     );
   }
 

--- a/src/world/anchors/AnchorManager.ts
+++ b/src/world/anchors/AnchorManager.ts
@@ -79,6 +79,7 @@ export class AnchorManager extends Script {
   private renderer?: THREE.WebGLRenderer;
   private referenceSpaceCache?: XRReferenceSpaceCache;
   private warnedUnsupported = false;
+  private warnedSpaceDowngrade = false;
   private readonly pendingCreates: Array<{
     pose: XRRigidTransform;
     label: string;
@@ -174,6 +175,7 @@ export class AnchorManager extends Script {
     this.capability = this.options?.anchors.simulatorFallback
       ? 'simulated'
       : 'unsupported';
+    this.warnedSpaceDowngrade = false;
     for (const pending of this.pendingCreates.splice(0)) {
       pending.resolve(null);
     }
@@ -268,24 +270,24 @@ export class AnchorManager extends Script {
     anchorSpace: XRSpace | XRReferenceSpaceType,
     retried: boolean
   ): Promise<TrackedAnchor | null> {
-    const targetSpace =
-      typeof anchorSpace === 'string'
-        ? this.referenceSpaceCache?.getCached(anchorSpace)
-        : anchorSpace;
+    // Anchoring against a space the platform did not grant is not a reason to
+    // refuse. bounded-floor needs a configured play space and is absent on
+    // plenty of hardware, so fall back to the space the scene is drawn in and
+    // say so once, rather than placing nothing at all.
+    let targetSpace = this.resolveSpace(anchorSpace);
     if (!targetSpace) {
-      console.warn(
-        '[anchors] target anchorSpace could not be resolved:',
-        anchorSpace
-      );
+      targetSpace = this.referenceSpace();
+      this.warnSpaceDowngrade(anchorSpace);
+    }
+    if (!targetSpace) {
+      console.warn('[anchors] no reference space available; cannot anchor');
       return null;
     }
 
-    const sourceSpace =
-      poseSpace === null
-        ? this.referenceSpace()
-        : typeof poseSpace === 'string'
-          ? this.referenceSpaceCache?.getCached(poseSpace)
-          : poseSpace;
+    // A named pose space is different: the caller is asserting what the pose
+    // means, so guessing another one would put the anchor somewhere else
+    // entirely. Only the unspecified default falls back.
+    const sourceSpace = this.resolveSpace(poseSpace);
     if (!sourceSpace) {
       console.warn(
         '[anchors] source poseSpace could not be resolved:',
@@ -294,15 +296,20 @@ export class AnchorManager extends Script {
       return null;
     }
 
-    const targetPose =
-      sourceSpace === targetSpace || !this.referenceSpaceCache
-        ? pose
-        : this.referenceSpaceCache.convertPose(
-            pose,
-            sourceSpace,
-            targetSpace,
-            frame
-          );
+    let targetPose: XRRigidTransform | null = pose;
+    if (sourceSpace !== targetSpace) {
+      if (!this.referenceSpaceCache) {
+        // Using the pose unconverted here would silently misplace the anchor.
+        console.warn('[anchors] no reference space cache; cannot convert pose');
+        return null;
+      }
+      targetPose = this.referenceSpaceCache.convertPose(
+        pose,
+        sourceSpace,
+        targetSpace,
+        frame
+      );
+    }
     if (!targetPose) {
       console.warn(
         '[anchors] could not convert pose to anchor space',
@@ -325,6 +332,35 @@ export class AnchorManager extends Script {
     // frame that went inactive mid-call. Retry exactly once on the next live
     // frame rather than looping.
     return this.queueCreate(targetPose, label, targetSpace, targetSpace, true);
+  }
+
+  /**
+   * Resolves a space request to a live XRSpace.
+   *
+   * @param request - A space, a reference space name, or null for the space
+   *     the scene is currently drawn in.
+   * @returns The space, or undefined when the platform has no such space.
+   */
+  private resolveSpace(
+    request: XRSpace | XRReferenceSpaceType | null
+  ): XRSpace | undefined {
+    if (request === null) return this.referenceSpace();
+    if (typeof request !== 'string') return request;
+    return this.referenceSpaceCache?.getCached(request);
+  }
+
+  /**
+   * Says once per session that a requested anchor space was unavailable.
+   *
+   * @param requested - The space that could not be resolved.
+   */
+  private warnSpaceDowngrade(requested: XRSpace | XRReferenceSpaceType): void {
+    if (this.warnedSpaceDowngrade) return;
+    this.warnedSpaceDowngrade = true;
+    console.warn(
+      `[anchors] ${String(requested)} is unavailable; anchoring against the ` +
+        'scene reference space instead'
+    );
   }
 
   /**

--- a/src/world/anchors/AnchorManager.ts
+++ b/src/world/anchors/AnchorManager.ts
@@ -564,8 +564,17 @@ export class AnchorManager extends Script {
     const space = referenceSpace ?? this.referenceSpace();
     const frame = this.renderer?.xr.getFrame();
     if (!frame || !space) return null;
-    const pose = frame.getPose(tracked.anchor.anchorSpace, space);
-    return pose ?? null;
+    try {
+      return frame.getPose(tracked.anchor.anchorSpace, space) ?? null;
+    } catch (error) {
+      // Throws InvalidStateError when the anchor and the reference space
+      // belong to different sessions, which a caller holding a space across a
+      // session boundary can still reach. Recorded rather than swallowed, so
+      // it does not look like an untracked anchor.
+      this.lastError = error;
+      console.debug('[anchors] could not read pose for', id, error);
+      return null;
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

Follow-up to #523, adjusting a few paths for the move away from a cached `XRFrame`.

| Fix | Why |
| --- | --- |
| `create()` queues when there is no live frame | `getFrame()` is null outside the animation callback, so nothing was placed when called from a click handler |
| `restoreAll()` falls back to the renderer's session | Keeps the existing no-argument callers working |
| Anchor space falls back when `bounded-floor` isn't granted, warns once | Hardware without a configured play space could not anchor |
| A named `poseSpace` that can't be resolved fails rather than guessing | Substituting a space would misplace the anchor |
| Reference spaces resolving after their session ended are ignored | A late promise could repopulate a cleared cache |
| `getPose()` guards again and records `lastError` | Can throw across sessions, and it's called every frame |
| `Core.currentFrame` no longer throws before the renderer exists | Reading it early gave a TypeError rather than undefined |
| `Core` keeps `referenceSpaceType` in the optional features | An app setting `webxrOptionalFeatures` itself dropped `local-floor` |

`bounded-floor` stays the default, it just falls back now rather than declining to anchor. Placement is unaffected either way, as the pose is converted into whichever space is used.

## Type of Change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

Checked on a Quest 3 with this branch and `main` served side by side, same demo, only the SDK bundle differing.

## Checklist

- [x] **Tested in simulator & device**: Quest 3, compared against `main`. 619 unit tests pass. The one full-suite failure (`Core.test.ts` simulator lifecycle) also reproduces on `main` and is unrelated.
- [x] **Large Assets ($\ge$ 1MB)**: None.
- [x] **SDK Dynamic Dependencies**: None added.
- [x] **Security**: No keys or secrets.
