### PR TITLE
Add TEventMap generic parameter to UIElement and UI components

### DIFF
--- a/src/addons/virtualkeyboard/Keyboard.ts
+++ b/src/addons/virtualkeyboard/Keyboard.ts
@@ -1,3 +1,4 @@
+import type * as THREE from 'three';
 import * as xb from 'xrblocks';
 
 type CharacterKey = {
@@ -99,7 +100,9 @@ const CHARACTER_KEYS = new Map(
  * The parent card owns world placement and lifecycle. The keyboard owns text
  * input state, modifier state, layout, and key interaction feedback.
  */
-export class Keyboard extends xb.UIPanel {
+export class Keyboard<
+  TEventMap extends THREE.Object3DEventMap = THREE.Object3DEventMap,
+> extends xb.UIPanel<TEventMap> {
   public onValueChange?: (value: string) => void;
   public onSubmit?: (value: string) => void;
 

--- a/src/ui/UIElement.test.ts
+++ b/src/ui/UIElement.test.ts
@@ -1,0 +1,109 @@
+import {describe, expect, it, vi} from 'vitest';
+import type * as THREE from 'three';
+
+import {
+  UIElement,
+  UICard,
+  UIOverlay,
+  UIPanel,
+  UIButton,
+  UISlider,
+  UIText,
+  UIImage,
+  UIIcon,
+} from './index';
+
+interface CustomUIEventMap extends THREE.Object3DEventMap {
+  customEvent: {value: number};
+  stateChange: {active: boolean};
+}
+
+class TestCustomUIElement extends UIElement<CustomUIEventMap> {
+  constructor() {
+    super('panel');
+  }
+
+  triggerCustomEvent(value: number) {
+    this.dispatchEvent({type: 'customEvent', value});
+  }
+}
+
+describe('UIElement TEventMap generic', () => {
+  it('supports typed custom event maps on custom UIElement subclasses', () => {
+    const element = new TestCustomUIElement();
+    const handler = vi.fn();
+
+    element.addEventListener('customEvent', (event) => {
+      handler(event.value);
+    });
+
+    element.triggerCustomEvent(42);
+    expect(handler).toHaveBeenCalledWith(42);
+  });
+
+  it('supports typed custom event maps on UICard', () => {
+    interface CardEvents extends THREE.Object3DEventMap {
+      cardResized: {width: number; height: number};
+    }
+
+    const card = new UICard<CardEvents>({size: {width: 1, height: 1}});
+    const handler = vi.fn();
+
+    card.addEventListener('cardResized', (event) => {
+      handler(event.width, event.height);
+    });
+
+    card.dispatchEvent({type: 'cardResized', width: 2, height: 3});
+    expect(handler).toHaveBeenCalledWith(2, 3);
+  });
+
+  it('supports typed custom event maps on UIButton', () => {
+    interface ButtonEvents extends THREE.Object3DEventMap {
+      pressed: {timestamp: number};
+    }
+
+    const button = new UIButton<ButtonEvents>({label: 'Click'});
+    const handler = vi.fn();
+
+    button.addEventListener('pressed', (event) => {
+      handler(event.timestamp);
+    });
+
+    button.dispatchEvent({type: 'pressed', timestamp: 1000});
+    expect(handler).toHaveBeenCalledWith(1000);
+  });
+
+  it('supports typed custom event maps on UISlider, UIPanel, UIOverlay, UIText, UIImage, UIIcon', () => {
+    interface ExtendedEvents extends THREE.Object3DEventMap {
+      valueUpdated: {newValue: number};
+    }
+
+    const slider = new UISlider<ExtendedEvents>({ariaLabel: 'Volume'});
+    const panel = new UIPanel<ExtendedEvents>();
+    const overlay = new UIOverlay<ExtendedEvents>();
+    const text = new UIText<ExtendedEvents>({text: 'Hello'});
+    const image = new UIImage<ExtendedEvents>({src: 'test.png'});
+    const icon = new UIIcon<ExtendedEvents>({icon: 'home'});
+
+    const sliderHandler = vi.fn();
+    slider.addEventListener('valueUpdated', (e) => sliderHandler(e.newValue));
+    slider.dispatchEvent({type: 'valueUpdated', newValue: 0.5});
+    expect(sliderHandler).toHaveBeenCalledWith(0.5);
+
+    expect(panel.isUI).toBe(true);
+    expect(overlay.isUI).toBe(true);
+    expect(text.text).toBe('Hello');
+    expect(image.src).toBe('test.png');
+    expect(icon.icon).toBe('home');
+  });
+
+  it('maintains default THREE.Object3DEventMap behavior when untyped', () => {
+    const card = new UICard({size: {width: 1, height: 1}});
+    const addedHandler = vi.fn();
+
+    card.addEventListener('added', addedHandler);
+    card.dispatchEvent({type: 'added'});
+
+    expect(addedHandler).toHaveBeenCalled();
+  });
+});

--- a/src/ui/UIElement.ts
+++ b/src/ui/UIElement.ts
@@ -283,7 +283,9 @@ const ENUM_VALUES: Partial<Record<keyof UIStyle, readonly unknown[]>> = {
 const states = new WeakMap<UIElement, UIElementState>();
 const rootReferences = new Set<WeakRef<UIElement>>();
 
-export abstract class UIElement extends Script {
+export abstract class UIElement<
+  TEventMap extends THREE.Object3DEventMap = THREE.Object3DEventMap,
+> extends Script<TEventMap> {
   readonly isUI = true;
   private readonly styleTarget: UIStyle = {};
   private readonly styleProxy: UIStyle;

--- a/src/ui/components/UIButton.ts
+++ b/src/ui/components/UIButton.ts
@@ -13,7 +13,9 @@ export interface UIButtonOptions extends UIElementOptions {
 }
 
 /** A semantic button that activates after a valid captured press and release. */
-export class UIButton extends UIElement {
+export class UIButton<
+  TEventMap extends THREE.Object3DEventMap = THREE.Object3DEventMap,
+> extends UIElement<TEventMap> {
   name = 'UIButton';
   onClick?: () => void;
   private _label?: string;

--- a/src/ui/components/UICard.ts
+++ b/src/ui/components/UICard.ts
@@ -1,3 +1,5 @@
+import type * as THREE from 'three';
+
 import type {ManipulationOptions} from '../../interaction/manipulation/ManipulationTypes';
 import {normalizeManipulationConfig} from '../../interaction/manipulation/ManipulationConfig';
 import {type UIAppearance, validateUIAppearance} from '../UIAppearance';
@@ -26,7 +28,9 @@ export interface UICardOptions extends UIElementOptions {
 }
 
 /** The only world-transform root in a spatial UI tree. */
-export class UICard extends UIElement {
+export class UICard<
+  TEventMap extends THREE.Object3DEventMap = THREE.Object3DEventMap,
+> extends UIElement<TEventMap> {
   name = 'UICard';
   readonly pixelSize: number;
   readonly anchorX: UICardAnchorX;

--- a/src/ui/components/UIIcon.ts
+++ b/src/ui/components/UIIcon.ts
@@ -1,3 +1,5 @@
+import type * as THREE from 'three';
+
 import {UIElement, type UIElementOptions} from '../UIElement';
 
 export type UIIconVariant = 'outlined' | 'rounded' | 'sharp';
@@ -12,7 +14,9 @@ export interface UIIconOptions extends UIElementOptions {
 }
 
 /** One Material Symbol icon. */
-export class UIIcon extends UIElement {
+export class UIIcon<
+  TEventMap extends THREE.Object3DEventMap = THREE.Object3DEventMap,
+> extends UIElement<TEventMap> {
   name = 'UIIcon';
   readonly ariaLabel?: string;
   private _icon: string;

--- a/src/ui/components/UIImage.ts
+++ b/src/ui/components/UIImage.ts
@@ -8,7 +8,9 @@ export interface UIImageOptions extends UIElementOptions {
 }
 
 /** URL-backed or caller-texture-backed image content. */
-export class UIImage extends UIElement {
+export class UIImage<
+  TEventMap extends THREE.Object3DEventMap = THREE.Object3DEventMap,
+> extends UIElement<TEventMap> {
   name = 'UIImage';
   readonly ariaLabel?: string;
   private _src: string | THREE.Texture;

--- a/src/ui/components/UIOverlay.ts
+++ b/src/ui/components/UIOverlay.ts
@@ -1,3 +1,5 @@
+import type * as THREE from 'three';
+
 import {type UIAppearance, validateUIAppearance} from '../UIAppearance';
 import {UIElement, type UIElementOptions} from '../UIElement';
 
@@ -6,7 +8,9 @@ export interface UIOverlayOptions extends UIElementOptions {
 }
 
 /** A view-space UI root. World transforms have no rendering effect. */
-export class UIOverlay extends UIElement {
+export class UIOverlay<
+  TEventMap extends THREE.Object3DEventMap = THREE.Object3DEventMap,
+> extends UIElement<TEventMap> {
   name = 'UIOverlay';
   readonly appearance: UIAppearance;
 

--- a/src/ui/components/UIPanel.ts
+++ b/src/ui/components/UIPanel.ts
@@ -1,9 +1,13 @@
+import type * as THREE from 'three';
+
 import {UIElement, type UIElementOptions} from '../UIElement';
 
 export type UIPanelOptions = UIElementOptions;
 
 /** A passive flex-layout and visual grouping element. */
-export class UIPanel extends UIElement {
+export class UIPanel<
+  TEventMap extends THREE.Object3DEventMap = THREE.Object3DEventMap,
+> extends UIElement<TEventMap> {
   name = 'UIPanel';
 
   constructor(options: UIPanelOptions = {}) {

--- a/src/ui/components/UISlider.ts
+++ b/src/ui/components/UISlider.ts
@@ -1,3 +1,5 @@
+import type * as THREE from 'three';
+
 import type {SelectEvent} from '../../core/Script';
 import {
   registerSemanticControl,
@@ -18,7 +20,9 @@ export interface UISliderOptions extends UIElementOptions {
 }
 
 /** A horizontal slider with one exclusive captured interaction. */
-export class UISlider extends UIElement {
+export class UISlider<
+  TEventMap extends THREE.Object3DEventMap = THREE.Object3DEventMap,
+> extends UIElement<TEventMap> {
   name = 'UISlider';
   readonly ariaLabel: string;
   onInput?: (value: number) => void;

--- a/src/ui/components/UIText.ts
+++ b/src/ui/components/UIText.ts
@@ -1,3 +1,5 @@
+import type * as THREE from 'three';
+
 import {UIElement, type UIElementOptions} from '../UIElement';
 
 export interface UITextOptions extends UIElementOptions {
@@ -5,7 +7,9 @@ export interface UITextOptions extends UIElementOptions {
 }
 
 /** Text content in a card or overlay layout. */
-export class UIText extends UIElement {
+export class UIText<
+  TEventMap extends THREE.Object3DEventMap = THREE.Object3DEventMap,
+> extends UIElement<TEventMap> {
   name = 'UIText';
   private _text: string;
 

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -32,6 +32,7 @@ export type {
   ModelViewerOrigin,
   PlayModelAnimationOptions,
 } from './model/ModelViewer';
+export {UIElement} from './UIElement';
 export type {
   UIColor,
   UIElementOptions,


### PR DESCRIPTION
## Summary
Adds generic parameter `TEventMap extends THREE.Object3DEventMap = THREE.Object3DEventMap` to `UIElement` and all spatial UI element subclasses (`UICard`, `UIOverlay`, `UIPanel`, `UIButton`, `UISlider`, `UIText`, `UIImage`, `UIIcon`, `Keyboard`).

- Enables strongly-typed custom event listener and dispatch capabilities.
- Maintains complete backward compatibility for untyped usages.
- Re-exports `UIElement` class in `src/ui/index.ts`.
- Adds unit tests in `src/ui/UIElement.test.ts`.