### PR TITLE
Changed Default Drag to Capsule Face Camera

### DIFF
--- a/docs/docs/manual/Interaction.md
+++ b/docs/docs/manual/Interaction.md
@@ -188,6 +188,11 @@ translate as the surface action. `UICard` makes translation face the camera and
 can display an edge. `ModelViewer` enables move, Y-axis rotate, and scale with
 its own private interaction proxies.
 
+Face-camera translation uses `mode: 'capsule'` by default. It keeps an object
+upright within `0.25` meters above or below the camera, then tilts it toward the
+viewer. Set `capsuleHalfHeight` to change that region, or select `cylindrical`
+or `spherical` mode explicitly.
+
 Use a handle when one surface must select a specific action:
 
 ```js

--- a/docs/docs/manual/Placement.md
+++ b/docs/docs/manual/Placement.md
@@ -165,19 +165,22 @@ model.add(
 ```js
 card.add(
   new xb.FaceCamera({
-    mode: 'cylindrical',
+    mode: 'capsule',
+    capsuleHalfHeight: 0.25,
     smoothing: 0.1,
   })
 );
 ```
 
-| Mode          | Behavior                                            | Typical use                               |
-| ------------- | --------------------------------------------------- | ----------------------------------------- |
-| `cylindrical` | Turns around the vertical axis and stays upright    | Panels and signs at about eye height      |
-| `spherical`   | Turns vertically and horizontally toward the camera | Labels above, below, or around the viewer |
+| Mode          | Behavior                                                    | Typical use                               |
+| ------------- | ----------------------------------------------------------- | ----------------------------------------- |
+| `capsule`     | Stays upright near eye height, then tilts toward the viewer | Panels that can move vertically           |
+| `cylindrical` | Turns around the vertical axis and always stays upright     | Panels and signs at about eye height      |
+| `spherical`   | Turns vertically and horizontally toward the camera         | Labels above, below, or around the viewer |
 
-The default mode is `cylindrical`. A higher `smoothing` value responds faster.
-The default is `0.1`.
+The default mode is `capsule`. Its upright region extends `capsuleHalfHeight`
+above and below the camera. The default half-height is `0.25` meters. A higher
+`smoothing` value responds faster. The default is `0.1`.
 
 `UICard` can accept a `TransformScript` as a direct child. Nested UI elements
 such as `UIPanel` accept UI children, not placement scripts. Attach the script

--- a/src/interaction/manipulation/ManipulationTypes.ts
+++ b/src/interaction/manipulation/ManipulationTypes.ts
@@ -20,6 +20,8 @@ export interface TranslateOptions {
   faceCamera?: boolean;
   /** Camera-facing rotation mode used while translating. */
   mode?: FaceCameraMode;
+  /** Half-height of the upright region used by capsule mode, in meters. */
+  capsuleHalfHeight?: number;
   /** Camera-facing rotation smoothing, matching `FaceCamera`. */
   smoothing?: number;
 }

--- a/src/interaction/manipulation/drivers/TranslateDriver.ts
+++ b/src/interaction/manipulation/drivers/TranslateDriver.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 
 import {
+  DEFAULT_FACE_CAMERA_CAPSULE_HALF_HEIGHT,
   DEFAULT_FACE_CAMERA_SMOOTHING,
   faceCameraSlerpAlpha,
 } from '../../../utils/FaceCameraMath';
@@ -32,8 +33,12 @@ export class TranslateDriver implements ManipulationDriver<TranslateBaseline> {
     if (
       options.faceCamera &&
       ((options.mode !== undefined &&
+        options.mode !== 'capsule' &&
         options.mode !== 'cylindrical' &&
         options.mode !== 'spherical') ||
+        (options.capsuleHalfHeight !== undefined &&
+          (!Number.isFinite(options.capsuleHalfHeight) ||
+            options.capsuleHalfHeight < 0)) ||
         (options.smoothing !== undefined &&
           (!Number.isFinite(options.smoothing) || options.smoothing < 0)))
     ) {
@@ -82,7 +87,9 @@ export class TranslateDriver implements ManipulationDriver<TranslateBaseline> {
           worldPosition,
           this.camera?.getWorldPosition(new THREE.Vector3()),
           parent?.getWorldQuaternion(new THREE.Quaternion()),
-          baseline.options.mode
+          baseline.options.mode,
+          baseline.options.capsuleHalfHeight ??
+            DEFAULT_FACE_CAMERA_CAPSULE_HALF_HEIGHT
         )
       : undefined;
     const rotationAlpha = this.timer

--- a/src/placement/FaceCamera.ts
+++ b/src/placement/FaceCamera.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 
 import {
+  DEFAULT_FACE_CAMERA_CAPSULE_HALF_HEIGHT,
   DEFAULT_FACE_CAMERA_SMOOTHING,
   faceCameraQuaternion,
   faceCameraSlerpAlpha,
@@ -12,6 +13,8 @@ export type {FaceCameraMode} from '../utils/FaceCameraMath';
 
 export interface FaceCameraOptions {
   mode?: FaceCameraMode;
+  /** Half-height of the upright region used by capsule mode, in meters. */
+  capsuleHalfHeight?: number;
   smoothing?: number;
 }
 
@@ -22,6 +25,7 @@ export class FaceCamera extends TransformScript {
   private camera?: THREE.Camera;
   private timer?: THREE.Timer;
   private readonly mode: FaceCameraMode;
+  private readonly capsuleHalfHeight: number;
   private readonly smoothing: number;
   private readonly worldPosition = new THREE.Vector3();
   private readonly cameraPosition = new THREE.Vector3();
@@ -35,7 +39,9 @@ export class FaceCamera extends TransformScript {
 
   constructor(options: FaceCameraOptions = {}) {
     super();
-    this.mode = options.mode ?? 'cylindrical';
+    this.mode = options.mode ?? 'capsule';
+    this.capsuleHalfHeight =
+      options.capsuleHalfHeight ?? DEFAULT_FACE_CAMERA_CAPSULE_HALF_HEIGHT;
     this.smoothing = options.smoothing ?? DEFAULT_FACE_CAMERA_SMOOTHING;
   }
 
@@ -58,6 +64,7 @@ export class FaceCamera extends TransformScript {
       this.cameraPosition,
       parentWorldQuaternion,
       this.mode,
+      this.capsuleHalfHeight,
       this.targetQuaternion,
       this.faceCameraScratch
     );

--- a/src/utils/FaceCameraMath.ts
+++ b/src/utils/FaceCameraMath.ts
@@ -2,9 +2,10 @@ import * as THREE from 'three';
 
 import {UP} from './HelperConstants';
 
-export type FaceCameraMode = 'cylindrical' | 'spherical';
+export type FaceCameraMode = 'capsule' | 'cylindrical' | 'spherical';
 
 export const DEFAULT_FACE_CAMERA_SMOOTHING = 0.1;
+export const DEFAULT_FACE_CAMERA_CAPSULE_HALF_HEIGHT = 0.25;
 
 type FaceCameraScratch = {
   target: THREE.Vector3;
@@ -24,13 +25,21 @@ export function faceCameraQuaternion(
   worldPosition: THREE.Vector3,
   cameraPosition?: THREE.Vector3,
   parentWorldQuaternion?: THREE.Quaternion,
-  mode: FaceCameraMode = 'cylindrical',
+  mode: FaceCameraMode = 'capsule',
+  capsuleHalfHeight = DEFAULT_FACE_CAMERA_CAPSULE_HALF_HEIGHT,
   result = new THREE.Quaternion(),
   scratch?: FaceCameraScratch
 ): THREE.Quaternion | undefined {
   if (!cameraPosition) return undefined;
   const target = scratch?.target.copy(cameraPosition) ?? cameraPosition.clone();
   if (mode === 'cylindrical') target.y = worldPosition.y;
+  if (mode === 'capsule') {
+    target.y = THREE.MathUtils.clamp(
+      worldPosition.y,
+      cameraPosition.y - capsuleHalfHeight,
+      cameraPosition.y + capsuleHalfHeight
+    );
+  }
   if (target.distanceToSquared(worldPosition) < 1e-8) return undefined;
 
   const worldQuaternion = scratch?.worldQuaternion ?? new THREE.Quaternion();


### PR DESCRIPTION
# Capsule Face Camera

## Description

Dragging now maintains that the objects will stay cylindrical to the user until too far which will angle like a capsule. New default.

## Type of Change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

- **Simulator Recording**: <!-- Attach video/GIF running in desktop simulator -->
- **Device Recording**: <!-- Attach video/GIF running on physical hardware -->

## Checklist

- [x] **Tested in simulator & device**: Verified functionality in desktop simulator and/or physical hardware (where applicable).
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.
