### PR TITLE
Replace gemini 3.6 flash with 3.7 flash.

### DIFF
--- a/demos/dietHelper/index.html
+++ b/demos/dietHelper/index.html
@@ -269,7 +269,7 @@
         id="dietHelperModelSelect"
         title="Choose which multimodal Gemini model analyzes the captured image."
       >
-        <option value="gemini-3.6-flash">Gemini 3.6 Flash</option>
+        <option value="gemini-3.7-flash">Gemini 3.7 Flash</option>
         <option value="gemini-3-flash-preview">Gemini 3 Flash (preview)</option>
         <option value="gemini-3.1-pro-preview">Gemini 3.1 Pro (preview)</option>
         <option value="gemini-2.5-flash">Gemini 2.5 Flash</option>

--- a/docs/docs/manual/AI.mdx
+++ b/docs/docs/manual/AI.mdx
@@ -20,7 +20,7 @@ Gemini is the default provider:
 const options = new xb.Options();
 options.enableAI();
 options.ai.model = 'gemini';
-options.ai.gemini.model = 'gemini-3.6-flash';
+options.ai.gemini.model = 'gemini-3.7-flash';
 options.ai.promptForApiKey = true; // optional local prototype prompt
 
 await xb.init(options);

--- a/src/ai/AIOptions.ts
+++ b/src/ai/AIOptions.ts
@@ -1,6 +1,6 @@
 import type * as GoogleGenAITypes from '@google/genai';
 
-export const GEMINI_DEFAULT_FLASH_MODEL = 'gemini-3.6-flash';
+export const GEMINI_DEFAULT_FLASH_MODEL = 'gemini-3.7-flash';
 export const GEMINI_DEFAULT_LIVE_MODEL = 'gemini-3.1-flash-live-preview';
 export const GEMINI_DEFAULT_IMAGE_MODEL = 'gemini-3.1-flash-image';
 

--- a/src/world/objects/backends/GeminiDetectorBackend.test.ts
+++ b/src/world/objects/backends/GeminiDetectorBackend.test.ts
@@ -27,7 +27,7 @@ describe('GeminiDetectorBackend', () => {
     ).buildGeminiConfig();
 
     expect(config.thinkingConfig).toEqual({
-      thinkingLevel: 'MINIMAL',
+      thinkingLevel: 'LOW',
     });
     expect(config.thinkingConfig).not.toHaveProperty('thinkingBudget');
   });

--- a/src/world/objects/backends/GeminiDetectorBackend.ts
+++ b/src/world/objects/backends/GeminiDetectorBackend.ts
@@ -29,11 +29,9 @@ export class GeminiDetectorBackend<T> extends BaseDetectorBackend<T> {
     const geminiOptions = this.context.options.objects.backendConfig.gemini;
     return {
       // Keep detection fast by asking for as little reasoning as possible.
-      // gemini-3.6-flash rejects a zero thinking budget, which 3.5 accepted,
-      // so use the minimal thinking level instead. Both resolve to no thought
-      // tokens and it is accepted by 3.5 and 3.6 alike.
+      // gemini-3.7-flash doesn't support MINIMAL, only LOW.
       thinkingConfig: {
-        thinkingLevel: 'MINIMAL' as ThinkingLevel,
+        thinkingLevel: 'LOW' as ThinkingLevel,
       },
       responseMimeType: 'application/json',
       responseSchema: geminiOptions.responseSchema,


### PR DESCRIPTION
## Description

Update Gemini to 3.7 flash: https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash
Note that 3.7 flash doesn't support MINIMAL thinking, only LOW, MEDIUM, HIGH.

## Type of Change

- [x] New feature / enhancement

## Media / Screen Recordings & Screenshots (If Applicable)

## Checklist

- [x] **Tested in simulator & device**: Checked gemini-xrobject in the simulator
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.
