### PR TITLE
changed spatial placement to a raycast place on mesh demo

### DIFF
--- a/templates/03_spatial_placement/README.md
+++ b/templates/03_spatial_placement/README.md
@@ -1,6 +1,6 @@
 # Spatial Placement
 
-Use depth and detected planes to place an object on a horizontal surface.
+Move a sphere to the point where the active ray hits the depth mesh.
 
 ## Run
 
@@ -9,5 +9,6 @@ XR.
 
 ## Controls
 
-No input is required. Look around the room while the template searches for a
-surface for up to 15 seconds.
+Point a hand, controller, or mouse ray at the environment. The transparent blue
+sphere follows the current depth hit. Select to place one opaque blue sphere.
+Each new selection moves the placed sphere to the new point.

--- a/templates/03_spatial_placement/main.js
+++ b/templates/03_spatial_placement/main.js
@@ -2,29 +2,65 @@ import * as THREE from 'three';
 import * as xb from 'xrblocks';
 
 class SpatialPlacement extends xb.Script {
-  init() {
+  static dependencies = {
+    depth: xb.Depth,
+    user: xb.User,
+  };
+
+  init({depth, user}) {
+    this.depth = depth;
+    this.user = user;
     this.add(new THREE.HemisphereLight(0xffffff, 0x3c4043, 3));
-    this.object = new THREE.Mesh(
-      new THREE.CylinderGeometry(0.09, 0.12, 0.22, 32),
-      new THREE.MeshStandardMaterial({color: 0x4285f4, roughness: 0.35})
-    );
-    this.object.name = 'Placed object';
-    this.object.position.set(0, -10, 0);
-    this.add(this.object);
-    void xb.world
-      .placeOnHorizontalSurface(this.object)
-      .then((placed) => (this.object.visible = placed));
+    this.geometry = new THREE.SphereGeometry(0.08, 32, 16);
+    this.previewMaterial = new THREE.MeshStandardMaterial({
+      color: 0x4285f4,
+      transparent: true,
+      opacity: 0.35,
+      depthWrite: false,
+      roughness: 0.35,
+    });
+    this.placedMaterial = new THREE.MeshStandardMaterial({
+      color: 0x4285f4,
+      roughness: 0.35,
+    });
+    this.sphere = new THREE.Mesh(this.geometry, this.previewMaterial);
+    this.sphere.name = 'Depth hit';
+    this.sphere.visible = false;
+    this.sphere.xb = {pointerEvents: 'none'};
+    this.add(this.sphere);
+
+    this.placedSphere = new THREE.Mesh(this.geometry, this.placedMaterial);
+    this.placedSphere.name = 'Placed depth hit';
+    this.placedSphere.visible = false;
+    this.placedSphere.xb = {pointerEvents: 'none'};
+    this.add(this.placedSphere);
+  }
+
+  update() {
+    const hit = this.depth.depthMesh
+      ? this.user.getIntersectionAt(this.depth.depthMesh)
+      : null;
+    this.sphere.visible = Boolean(hit);
+    if (hit) this.sphere.position.copy(hit.point);
+  }
+
+  onSelectStart(event) {
+    if (event.surface !== this.depth.depthMesh || !event.intersection) return;
+
+    this.placedSphere.position.copy(event.intersection.point);
+    this.placedSphere.visible = true;
   }
 
   dispose() {
-    this.object.geometry.dispose();
-    this.object.material.dispose();
+    this.geometry.dispose();
+    this.previewMaterial.dispose();
+    this.placedMaterial.dispose();
   }
 }
 
 const options = new xb.Options();
 options.enableDepth();
-options.enablePlaneDetection();
+options.reticles.projectOnDepthMesh = true;
 
 xb.add(new SpatialPlacement());
 xb.init(options);

--- a/templates/README.md
+++ b/templates/README.md
@@ -24,7 +24,7 @@ For example, open `http://127.0.0.1:8080/templates/00_basic/`.
 
 - [`02_object_interaction`](02_object_interaction): Select, touch, grab, move, and
   release an object.
-- [`03_spatial_placement`](03_spatial_placement): Find a suitable room surface and
+- [`03_spatial_placement`](03_spatial_placement): Follow a live depth raycast and
   place content.
 - [`12_hand_gestures`](12_hand_gestures): Inspect built-in heuristic gestures
   for both hands.


### PR DESCRIPTION
# New spatial placement template

## Description

Changed spatial placement template to a place on mesh demo over horizontal placement as requested by @ruofeidu 

## Type of Change

- [ ] Bug fix
- [ ] New feature / enhancement
- [x] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

https://github.com/user-attachments/assets/4a186046-9c39-46ef-a79c-e22c12083076



## Checklist

- [x] **Tested in simulator & device**: Verified functionality in desktop simulator and/or physical hardware (where applicable).
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.
