### PR TITLE
Auto height for better UI generation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,8 +57,9 @@ await xb.init(options);
 
 ## Spatial and UI units
 
-- World positions, model dimensions, placement offsets, and `UICard.size` use
-  meters.
+- World positions, model dimensions, placement offsets, and fixed
+  `UICard.size` values use meters. Use `size.height: 'auto'` for a card that
+  fits its child layout while keeping a fixed width.
 - Descendant UI layout numbers use UIKit layout units. Percent strings and
   `auto` are accepted where the property type permits them.
 - Numeric `lineHeight` is a multiplier of `fontSize`. Use a `px` or percentage

--- a/docs/docs/manual/UI.mdx
+++ b/docs/docs/manual/UI.mdx
@@ -34,7 +34,7 @@ viewport.
 import * as xb from 'xrblocks';
 
 const card = new xb.UICard({
-  size: {width: 0.6, height: 0.35},
+  size: {width: 0.6, height: 'auto'},
   manipulation: true,
   edge: true,
   style: {
@@ -67,6 +67,11 @@ behavior. `edge: true` adds the outer translation hit band and requires
 translation to be enabled. Two-source scale uses the card's scale action; the
 edge does not enable a missing action.
 
+Use `height: 'auto'` when the card should fit its children, gaps, and padding.
+Keep the width fixed so text wrapping and percentage-width children have a
+stable horizontal constraint. Use a numeric height when the surface must stay
+at a fixed physical size.
+
 ## View-space overlays
 
 An overlay's world transform does not control its rendered position. Layout it
@@ -97,7 +102,8 @@ UI values have two separate unit systems:
 
 | Property                                                              | Meaning                                                 |
 | --------------------------------------------------------------------- | ------------------------------------------------------- |
-| `UICard.size` and world transforms                                    | Meters                                                  |
+| Fixed `UICard.size` values and world transforms                       | Meters                                                  |
+| `UICard.size.height: 'auto'`                                          | Height calculated from child layout                     |
 | Descendant numeric width, height, gap, padding, margin, and font size | UIKit layout units                                      |
 | Percentage strings                                                    | Percentage of the applicable parent layout size         |
 | `auto`                                                                | Content or flex layout chooses the size where supported |

--- a/samples/avatar_lab/gnm/GNMSpatialUI.js
+++ b/samples/avatar_lab/gnm/GNMSpatialUI.js
@@ -39,7 +39,7 @@ export class GNMSpatialUI {
     if (this.statusText) this.statusText.text = text || ' ';
   }
 
-  card(name, sizeX, sizeY, x, y, z, rotationY) {
+  card(name, sizeX, sizeY = 'auto', x, y, z, rotationY) {
     const card = new xb.UICard({
       size: {width: sizeX, height: sizeY},
       manipulation: {
@@ -124,7 +124,7 @@ export class GNMSpatialUI {
   }
 
   buildSampleCard() {
-    const card = this.card('GNMSample', 0.6, 0.8, -0.62, 1.32, -0.46, 0.6);
+    const card = this.card('GNMSample', 0.6, 'auto', -0.62, 1.32, -0.46, 0.6);
     this.header(card, 'face', 'GNM Sample');
     this.sectionLabel(card, 'IDENTITY');
 
@@ -230,7 +230,7 @@ export class GNMSpatialUI {
   }
 
   buildMotionCard() {
-    const card = this.card('GNMMotion', 0.52, 0.46, 0.62, 1.52, -0.46, -0.6);
+    const card = this.card('GNMMotion', 0.52, 'auto', 0.62, 1.52, -0.46, -0.6);
     this.header(card, 'animation', 'Motion');
 
     const scene = this.scene;
@@ -287,7 +287,7 @@ export class GNMSpatialUI {
   }
 
   buildViewCard() {
-    const card = this.card('GNMView', 0.52, 0.4, 0.64, 1.08, -0.46, -0.6);
+    const card = this.card('GNMView', 0.52, 'auto', 0.64, 1.08, -0.46, -0.6);
     this.header(card, 'visibility', 'View');
 
     const scene = this.scene;

--- a/samples/avatar_lab/vrm/main.js
+++ b/samples/avatar_lab/vrm/main.js
@@ -22,7 +22,7 @@ class VRMLabUI extends xb.Script {
     });
 
     const card = new xb.UICard({
-      size: {width: 0.54, height: 0.34},
+      size: {width: 0.54, height: 'auto'},
       manipulation: true,
       edge: {scale: true},
       children: [

--- a/samples/spatial_ui/ui/index.html
+++ b/samples/spatial_ui/ui/index.html
@@ -35,7 +35,7 @@
       import * as THREE from 'three';
       import * as xb from 'xrblocks';
 
-      const CARD_SIZE = {width: 0.56, height: 0.58};
+      const CARD_SIZE = {width: 0.56, height: 'auto'};
 
       function createHeader(icon, title, subtitle) {
         return new xb.UIPanel({
@@ -48,7 +48,7 @@
           children: [
             new xb.UIIcon({
               icon,
-              style: {width: 44, height: 44},
+              style: {width: 44, height: 44, color: '#ffffff'},
             }),
             new xb.UIPanel({
               style: {
@@ -84,7 +84,10 @@
             borderRadius: 18,
           },
           children: [
-            new xb.UIIcon({icon, style: {width: 34, height: 34}}),
+            new xb.UIIcon({
+              icon,
+              style: {width: 34, height: 34, color: '#ffffff'},
+            }),
             new xb.UIPanel({
               style: {
                 flexGrow: 1,

--- a/samples/xr_interaction/hand_gestures/HandGestureDemo.js
+++ b/samples/xr_interaction/hand_gestures/HandGestureDemo.js
@@ -228,7 +228,7 @@ export class HandGestureDemo extends xb.Script {
     });
 
     this.card = new xb.UICard({
-      size: {width: 1.0, height: 0.68},
+      size: {width: 1.0, height: 'auto'},
       manipulation: true,
       edge: {scale: true},
       children: [

--- a/samples/xr_interaction/rock_paper_scissors/GameRps.js
+++ b/samples/xr_interaction/rock_paper_scissors/GameRps.js
@@ -93,7 +93,7 @@ export class GameRps extends xb.Script {
     });
 
     this.card = new xb.UICard({
-      size: {width: 0.92, height: 0.72},
+      size: {width: 0.92, height: 'auto'},
       manipulation: true,
       edge: {scale: true},
       style: {

--- a/skills/xb-add-spatial-ui/SKILL.md
+++ b/skills/xb-add-spatial-ui/SKILL.md
@@ -44,6 +44,10 @@ Treat `UICard.size` and world transforms as meters. Treat descendant numeric
 layout values as UIKit layout units. Treat numeric `lineHeight` as a font-size
 multiplier; use `px` or `%` strings for explicit units.
 
+Use `size: {width, height: 'auto'}` for content-driven cards. Keep the width
+fixed so text and percentage-width children have a stable wrapping constraint.
+Use a numeric height only when the surface must have a fixed physical size.
+
 Complete this step when all content fits at the intended physical size and each
 state-changing control has hover or active feedback plus an observable result.
 

--- a/src/context/shared/SemanticObjectUtils.ts
+++ b/src/context/shared/SemanticObjectUtils.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 
 import {XRSystems} from '../../core/components/XRSystems';
 import {DepthMesh} from '../../depth/DepthMesh';
+import {UICard, getResolvedUICardSize} from '../../ui/components/UICard';
 
 type BoundsObject = THREE.Object3D & {
   isUI?: boolean;
@@ -102,17 +103,20 @@ function getUIObjectBounds(
   target?: THREE.Box3
 ): THREE.Box3 | null {
   const uiObject = object as BoundsObject;
+  const resolvedCardSize =
+    object instanceof UICard ? getResolvedUICardSize(object) : undefined;
+  const size = resolvedCardSize ?? uiObject.size;
   if (
     uiObject.isUI !== true ||
-    typeof uiObject.size?.width !== 'number' ||
-    typeof uiObject.size?.height !== 'number'
+    typeof size?.width !== 'number' ||
+    typeof size.height !== 'number'
   ) {
     return null;
   }
 
   object.updateMatrixWorld(true);
-  const halfWidth = uiObject.size.width / 2;
-  const halfHeight = uiObject.size.height / 2;
+  const halfWidth = size.width / 2;
+  const halfHeight = size.height / 2;
   boundsBox.makeEmpty();
 
   for (const x of [-halfWidth, halfWidth]) {

--- a/src/ui/components/UICard.ts
+++ b/src/ui/components/UICard.ts
@@ -7,6 +7,11 @@ import {UIElement, type UIElementOptions} from '../UIElement';
 
 export interface UISize {
   width: number;
+  height: number | 'auto';
+}
+
+export interface UIResolvedSize {
+  width: number;
   height: number;
 }
 
@@ -67,15 +72,17 @@ export class UICard<
     this.sizeTarget = {...size};
     this.sizeProxy = new Proxy(this.sizeTarget, {
       set: (target, property, value) => {
-        if (
-          (property !== 'width' && property !== 'height') ||
-          typeof value !== 'number' ||
-          !Number.isFinite(value) ||
-          value < 0
-        ) {
-          throw new Error('UICard size values must be finite and nonnegative.');
+        if (property === 'width') {
+          validateFixedSize(value);
+        } else if (property === 'height') {
+          validateHeight(value);
+        } else {
+          throw new Error(
+            `Unknown UICard size property "${String(property)}".`
+          );
         }
         Reflect.set(target, property, value);
+        resolvedSizes.delete(this);
         this.markUIDirty();
         return true;
       },
@@ -161,6 +168,27 @@ export function getUICardEdgeOptions(
   return card.edge || undefined;
 }
 
+const resolvedSizes = new WeakMap<UICard, UIResolvedSize>();
+
+/** Returns the current physical card size after layout resolves. */
+export function getResolvedUICardSize(
+  card: UICard
+): Readonly<UIResolvedSize> | undefined {
+  if (card.size.height !== 'auto') {
+    return {width: card.size.width, height: card.size.height};
+  }
+  return resolvedSizes.get(card);
+}
+
+/** Stores a backend-calculated physical size for an automatic-height card. */
+export function setResolvedUICardSize(
+  card: UICard,
+  size: UIResolvedSize
+): void {
+  if (card.size.height !== 'auto') return;
+  resolvedSizes.set(card, size);
+}
+
 function normalizeCardManipulation(
   value: boolean | ManipulationOptions | undefined
 ): boolean | ManipulationOptions | undefined {
@@ -213,15 +241,20 @@ function normalizeCardManipulation(
 }
 
 function validateSize(size: UISize): void {
-  if (
-    !size ||
-    !Number.isFinite(size.width) ||
-    !Number.isFinite(size.height) ||
-    size.width < 0 ||
-    size.height < 0
-  ) {
-    throw new Error('UICard size values must be finite and nonnegative.');
+  if (!size) throw new Error('UICard requires a size.');
+  validateFixedSize(size.width);
+  validateHeight(size.height);
+}
+
+function validateFixedSize(value: unknown): asserts value is number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new Error('UICard fixed size values must be finite and nonnegative.');
   }
+}
+
+function validateHeight(value: unknown): asserts value is number | 'auto' {
+  if (value === 'auto') return;
+  validateFixedSize(value);
 }
 
 function validatePixelSize(pixelSize: number): void {

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -5,6 +5,7 @@ export type {
   UICardAnchorY,
   UICardEdgeOptions,
   UICardOptions,
+  UIResolvedSize,
   UISize,
 } from './components/UICard';
 export {UIOverlay} from './components/UIOverlay';

--- a/src/ui/internal/UIKitBackend.ts
+++ b/src/ui/internal/UIKitBackend.ts
@@ -819,7 +819,7 @@ function panelDefaults(
   };
   if (kind === 'card' || kind === 'overlay') {
     defaults.flexDirection = style.flexDirection ?? 'column';
-    defaults.justifyContent = style.justifyContent ?? 'flex-start';
+    defaults.justifyContent = style.justifyContent ?? 'center';
     defaults.alignItems = style.alignItems ?? 'stretch';
   }
   if (kind === 'panel') {

--- a/src/ui/internal/UIKitBackend.ts
+++ b/src/ui/internal/UIKitBackend.ts
@@ -11,7 +11,11 @@ import * as THREE from 'three';
 
 import {getSemanticControl} from '../../interaction/SemanticControl';
 import {UIButton} from '../components/UIButton';
-import {UICard, getUICardEdgeOptions} from '../components/UICard';
+import {
+  UICard,
+  getUICardEdgeOptions,
+  setResolvedUICardSize,
+} from '../components/UICard';
 import {UIIcon} from '../components/UIIcon';
 import {UIImage} from '../components/UIImage';
 import {UIOverlay} from '../components/UIOverlay';
@@ -120,6 +124,13 @@ class UIKitMount implements UIMount {
 
   update(deltaSeconds: number): void {
     this.rendered?.update(deltaSeconds * 1000);
+    if (!(this.root instanceof UICard) || !this.binding) return;
+    const size = this.binding.node.size.peek();
+    if (!validPair(size)) return;
+    setResolvedUICardSize(this.root, {
+      width: size[0] * this.root.pixelSize,
+      height: size[1] * this.root.pixelSize,
+    });
   }
 
   validate(): readonly UIValidationIssue[] {
@@ -808,17 +819,22 @@ function panelDefaults(
   };
   if (kind === 'card' || kind === 'overlay') {
     defaults.flexDirection = style.flexDirection ?? 'column';
-    defaults.justifyContent = style.justifyContent ?? 'center';
+    defaults.justifyContent = style.justifyContent ?? 'flex-start';
     defaults.alignItems = style.alignItems ?? 'stretch';
+  }
+  if (kind === 'panel') {
+    defaults.flexShrink = style.flexShrink ?? 1;
   }
   if (kind === 'card') {
     const card = element as UICard;
     defaults.backfaceColor = defaults.fillColor;
     defaults.pixelSize = card.pixelSize;
     defaults.sizeX = card.size.width;
-    defaults.sizeY = card.size.height;
     defaults.width = card.size.width / card.pixelSize;
-    defaults.height = card.size.height / card.pixelSize;
+    if (card.size.height !== 'auto') {
+      defaults.sizeY = card.size.height;
+      defaults.height = card.size.height / card.pixelSize;
+    }
     defaults.anchorX = card.anchorX;
     defaults.anchorY = card.anchorY;
   } else if (kind === 'overlay') {

--- a/templates/01_spatial_ui/main.js
+++ b/templates/01_spatial_ui/main.js
@@ -51,7 +51,7 @@ class SpatialUiScene extends xb.Script {
     });
 
     const card = new xb.UICard({
-      size: {width: 0.62, height: 0.6},
+      size: {width: 0.62, height: 'auto'},
       manipulation: true,
       edge: true,
       style: {flexDirection: 'column', gap: 16, padding: 20},


### PR DESCRIPTION
# Added auto for height of UI cards to avoid having to set size

## Description

before ui cards were fixed sized leaving that padding since we do flex-center alignment on content. Added an "auto" param to height to cover this. Direct fix to https://github.com/google/xrblocks/issues/536

## Type of Change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

Before 
<img width="836" height="882" alt="image" src="https://github.com/user-attachments/assets/952dcfd7-cfeb-4709-8bdf-e7037eee410f" />

After
<img width="410" height="297" alt="image" src="https://github.com/user-attachments/assets/1479cc44-3e1d-4037-b859-1e66836e80ed" />



## Checklist

- [x] **Tested in simulator & device**: Verified functionality in desktop simulator and/or physical hardware (where applicable).
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.
