### PR TITLE
getWorldPosition on ui actually gets physical location

### DIFF
--- a/docs/docs/manual/EmbodiedControl.mdx
+++ b/docs/docs/manual/EmbodiedControl.mdx
@@ -110,11 +110,11 @@ gesture sequence is complete.
   Options: `velocity` in radians/second; if omitted, snaps instantly in 1
   frame.
 - **`pointTo(handIndex, target, options)`**: Rotates the controller locally in
-  camera space to point directly at the target. Options: `velocity` in
-  radians/second; if omitted, snaps instantly in 1 frame.
+  camera space to point at a nearby rendered surface of an object target.
+  Options: `velocity` in radians/second; if omitted, snaps instantly in 1 frame.
 - **`reachTo(handIndex, target, options)`**: Moves the controller so its index
-  fingertip reaches the target. Options: `velocity` in meters/second; if
-  omitted, moves instantly.
+  fingertip reaches a nearby rendered surface of an object target. Options:
+  `velocity` in meters/second; if omitted, moves instantly.
 - **`click(handIndex, options)`**: Simulates click gesture press and release.
   Options: `durationMs` (default 200ms).
 

--- a/docs/docs/manual/EmbodiedControl.mdx
+++ b/docs/docs/manual/EmbodiedControl.mdx
@@ -112,9 +112,9 @@ gesture sequence is complete.
 - **`pointTo(handIndex, target, options)`**: Rotates the controller locally in
   camera space to point directly at the target. Options: `velocity` in
   radians/second; if omitted, snaps instantly in 1 frame.
-- **`reachTo(handIndex, target, options)`**: Moves the controller position
-  toward the target. Options: `velocity` in meters/second; if omitted, moves
-  instantly.
+- **`reachTo(handIndex, target, options)`**: Moves the controller so its index
+  fingertip reaches the target. Options: `velocity` in meters/second; if
+  omitted, moves instantly.
 - **`click(handIndex, options)`**: Simulates click gesture press and release.
   Options: `durationMs` (default 200ms).
 

--- a/src/addons/embodied-control/EmbodiedControlExecutor.ts
+++ b/src/addons/embodied-control/EmbodiedControlExecutor.ts
@@ -487,6 +487,12 @@ export class EmbodiedControlExecutor {
       const {camera, simulator, core} = this.dependencies;
       const targetWorldPos = new THREE.Vector3();
       this.getTargetWorldPosition(target, targetWorldPos);
+      offsetTargetByIndexFingertip(
+        handIndex,
+        targetWorldPos,
+        simulator,
+        core.input.hands
+      );
 
       const targetCamSpace = targetWorldPos
         .clone()
@@ -556,4 +562,24 @@ export class EmbodiedControlExecutor {
       simulator.hands.lerpSpeed = originalLerpSpeed;
     }
   }
+}
+
+function offsetTargetByIndexFingertip(
+  handIndex: number,
+  targetWorldPosition: THREE.Vector3,
+  simulator: Simulator,
+  hands: THREE.XRHandSpace[]
+): void {
+  const controller =
+    handIndex === 0
+      ? simulator.hands.leftController
+      : simulator.hands.rightController;
+  const fingertip = hands[handIndex]?.joints?.['index-finger-tip'];
+  if (!controller || !fingertip) return;
+
+  const controllerPosition = new THREE.Vector3();
+  const fingertipPosition = new THREE.Vector3();
+  controller.getWorldPosition(controllerPosition);
+  fingertip.getWorldPosition(fingertipPosition);
+  targetWorldPosition.sub(fingertipPosition.sub(controllerPosition));
 }

--- a/src/addons/embodied-control/EmbodiedControlExecutor.ts
+++ b/src/addons/embodied-control/EmbodiedControlExecutor.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import {
   Core,
+  getObjectTargetPoint,
   type Simulator,
   type SimulatorHandPose,
   type SimulatorHandPoseRotations,
@@ -310,14 +311,16 @@ export class EmbodiedControlExecutor {
 
   private getTargetWorldPosition(
     target: THREE.Object3D | THREE.Vector3 | [number, number, number],
-    out: THREE.Vector3
+    out: THREE.Vector3,
+    from?: THREE.Vector3
   ) {
     if (target instanceof THREE.Vector3) {
       out.copy(target);
     } else if (Array.isArray(target)) {
       out.fromArray(target);
     } else if (target instanceof THREE.Object3D) {
-      target.getWorldPosition(out);
+      if (from) getObjectTargetPoint(target, from, out, 'closest');
+      else target.getWorldPosition(out);
     }
   }
 
@@ -430,14 +433,16 @@ export class EmbodiedControlExecutor {
     return this.executeAction(async () => {
       const {velocity} = options;
       const {camera, simulator, core} = this.dependencies;
+      const controllerPos =
+        simulator.simulatorControllerState.localControllerPositions[handIndex];
+      const controllerWorldPos = controllerPos
+        .clone()
+        .applyMatrix4(camera.matrixWorld);
       const targetWorldPos = new THREE.Vector3();
-      this.getTargetWorldPosition(target, targetWorldPos);
-
+      this.getTargetWorldPosition(target, targetWorldPos, controllerWorldPos);
       const targetCamSpace = targetWorldPos
         .clone()
         .applyMatrix4(camera.matrixWorldInverse);
-      const controllerPos =
-        simulator.simulatorControllerState.localControllerPositions[handIndex];
       const up = new THREE.Vector3(0, 1, 0);
       const matrix = new THREE.Matrix4().lookAt(
         controllerPos,
@@ -486,7 +491,15 @@ export class EmbodiedControlExecutor {
       const {velocity} = options;
       const {camera, simulator, core} = this.dependencies;
       const targetWorldPos = new THREE.Vector3();
-      this.getTargetWorldPosition(target, targetWorldPos);
+      const fingertip =
+        core.input.hands[handIndex]?.joints?.['index-finger-tip'];
+      const controller =
+        handIndex === 0
+          ? simulator.hands.leftController
+          : simulator.hands.rightController;
+      const targetSource = new THREE.Vector3();
+      (fingertip ?? controller).getWorldPosition(targetSource);
+      this.getTargetWorldPosition(target, targetWorldPos, targetSource);
       offsetTargetByIndexFingertip(
         handIndex,
         targetWorldPos,

--- a/src/addons/embodied-control/README.md
+++ b/src/addons/embodied-control/README.md
@@ -156,11 +156,11 @@ gesture sequence is complete.
   Options: `velocity` in radians/second; if omitted, snaps instantly in 1
   frame.
 - **`pointTo(handIndex, target, options)`**: Rotates the controller locally in
-  camera space to point directly at the target. Options: `velocity` in
-  radians/second; if omitted, snaps instantly in 1 frame.
+  camera space to point at a nearby rendered surface of an object target.
+  Options: `velocity` in radians/second; if omitted, snaps instantly in 1 frame.
 - **`reachTo(handIndex, target, options)`**: Moves the controller so its index
-  fingertip reaches the target. Options: `velocity` in meters/second; if
-  omitted, moves instantly.
+  fingertip reaches a nearby rendered surface of an object target. Options:
+  `velocity` in meters/second; if omitted, moves instantly.
 - **`click(handIndex, options)`**: Simulates click gesture press and release.
   Options: `durationMs` (default 200ms).
 

--- a/src/addons/embodied-control/README.md
+++ b/src/addons/embodied-control/README.md
@@ -158,9 +158,9 @@ gesture sequence is complete.
 - **`pointTo(handIndex, target, options)`**: Rotates the controller locally in
   camera space to point directly at the target. Options: `velocity` in
   radians/second; if omitted, snaps instantly in 1 frame.
-- **`reachTo(handIndex, target, options)`**: Moves the controller position
-  toward the target. Options: `velocity` in meters/second; if omitted, moves
-  instantly.
+- **`reachTo(handIndex, target, options)`**: Moves the controller so its index
+  fingertip reaches the target. Options: `velocity` in meters/second; if
+  omitted, moves instantly.
 - **`click(handIndex, options)`**: Simulates click gesture press and release.
   Options: `durationMs` (default 200ms).
 

--- a/src/context/shared/SemanticObjectUtils.ts
+++ b/src/context/shared/SemanticObjectUtils.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 
 import {XRSystems} from '../../core/components/XRSystems';
 import {DepthMesh} from '../../depth/DepthMesh';
+import {getUIPresentationObject} from '../../ui/UIElement';
 
 type BoundsObject = THREE.Object3D & {
   isUI?: boolean;
@@ -72,11 +73,26 @@ export function getObjectBounds(
   object: THREE.Object3D,
   target?: THREE.Box3
 ): THREE.Box3 | null {
+  const presentation = getUIPresentationObject(object);
+  if (presentation) {
+    const presentationBounds = getThreeObjectBounds(presentation, target);
+    if (presentationBounds) {
+      return presentationBounds;
+    }
+  }
+
   const uiBounds = getUIObjectBounds(object, target);
   if (uiBounds) {
     return uiBounds;
   }
 
+  return getThreeObjectBounds(object, target);
+}
+
+function getThreeObjectBounds(
+  object: THREE.Object3D,
+  target?: THREE.Box3
+): THREE.Box3 | null {
   try {
     boundsBox.setFromObject(object);
   } catch (_error) {

--- a/src/ui/UIElement.ts
+++ b/src/ui/UIElement.ts
@@ -281,6 +281,7 @@ const ENUM_VALUES: Partial<Record<keyof UIStyle, readonly unknown[]>> = {
 };
 
 const states = new WeakMap<UIElement, UIElementState>();
+const presentationObjects = new WeakMap<UIElement, THREE.Object3D>();
 const rootReferences = new Set<WeakRef<UIElement>>();
 
 export abstract class UIElement<
@@ -327,6 +328,13 @@ export abstract class UIElement<
   override attach(object: THREE.Object3D): this {
     validateUIChild(this, object);
     return super.attach(object);
+  }
+
+  override getWorldPosition(target: THREE.Vector3): THREE.Vector3 {
+    const presentation = presentationObjects.get(this);
+    return presentation
+      ? presentation.getWorldPosition(target)
+      : super.getWorldPosition(target);
   }
 
   get style(): UIStyle {
@@ -388,6 +396,26 @@ export function isUIElement(object: THREE.Object3D): object is UIElement {
 
 export function getUIElementKind(element: UIElement): UIElementKind {
   return states.get(element)!.kind;
+}
+
+/** Returns the rendered object that owns an element's calculated layout. */
+export function getUIPresentationObject(
+  element: THREE.Object3D
+): THREE.Object3D | undefined {
+  return presentationObjects.get(element as UIElement);
+}
+
+/** Registers one rendered object for world-space UI queries. */
+export function registerUIPresentationObject(
+  element: UIElement,
+  presentation: THREE.Object3D
+): () => void {
+  presentationObjects.set(element, presentation);
+  return () => {
+    if (presentationObjects.get(element) === presentation) {
+      presentationObjects.delete(element);
+    }
+  };
 }
 
 export function getUIRevision(element: UIElement): number {

--- a/src/ui/internal/UIKitBackend.ts
+++ b/src/ui/internal/UIKitBackend.ts
@@ -23,6 +23,7 @@ import {
   getUIRevision,
   getUIStructureRevision,
   isUIElement,
+  registerUIPresentationObject,
   type UIElement,
   type UIStyle,
 } from '../UIElement';
@@ -256,6 +257,7 @@ type UIKitNode =
 /** A retained physical node and the small private subtree it owns. */
 class UIKitNodeBinding {
   readonly node: UIKitNode;
+  private readonly unregisterPresentationObject: () => void;
   private readonly children = new Map<UIElement, UIKitNodeBinding>();
   private readonly childOrder: UIElement[] = [];
   private readonly cursorPoints = [
@@ -310,6 +312,10 @@ class UIKitNodeBinding {
     } else {
       this.node = new GradientPanel(properties);
     }
+    this.unregisterPresentationObject = registerUIPresentationObject(
+      this.element,
+      this.node
+    );
     this.baseProperties = properties;
     this.presentedProperties = properties;
     this.theme = context.theme;
@@ -438,6 +444,7 @@ class UIKitNodeBinding {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    this.unregisterPresentationObject();
     for (const child of this.children.values()) child.dispose();
     this.children.clear();
     this.childOrder.length = 0;

--- a/src/utils/SceneGraphUtils.ts
+++ b/src/utils/SceneGraphUtils.ts
@@ -63,3 +63,58 @@ export function traverseUtil(
   }
   return false;
 }
+
+/**
+ * Gets a world-space point on an object's rendered geometry near a reference
+ * position. Falls back to the object's world position when it has no mesh
+ * triangles. `closest` measures from `from`; `center` measures from the
+ * object's world bounding-box center.
+ */
+export function getObjectTargetPoint(
+  object: THREE.Object3D,
+  from: THREE.Vector3,
+  out: THREE.Vector3,
+  mode: 'closest' | 'center' = 'closest'
+): THREE.Vector3 {
+  object.updateWorldMatrix(true, true);
+  const reference =
+    mode === 'center'
+      ? new THREE.Box3()
+          .setFromObject(object, true)
+          .getCenter(new THREE.Vector3())
+      : from;
+  let closestDistanceSquared = Infinity;
+  const a = new THREE.Vector3();
+  const b = new THREE.Vector3();
+  const c = new THREE.Vector3();
+  const centroid = new THREE.Vector3();
+
+  object.traverse((child) => {
+    if (!(child instanceof THREE.Mesh) || !child.visible) return;
+    const position = child.geometry.getAttribute('position');
+    if (!position) return;
+    const index = child.geometry.index;
+    const vertexCount = index?.count ?? position.count;
+
+    for (let offset = 0; offset + 2 < vertexCount; offset += 3) {
+      child.getVertexPosition(index?.getX(offset) ?? offset, a);
+      child.getVertexPosition(index?.getX(offset + 1) ?? offset + 1, b);
+      child.getVertexPosition(index?.getX(offset + 2) ?? offset + 2, c);
+      a.applyMatrix4(child.matrixWorld);
+      b.applyMatrix4(child.matrixWorld);
+      c.applyMatrix4(child.matrixWorld);
+      centroid
+        .copy(a)
+        .add(b)
+        .add(c)
+        .multiplyScalar(1 / 3);
+      const distanceSquared = centroid.distanceToSquared(reference);
+      if (distanceSquared < closestDistanceSquared) {
+        closestDistanceSquared = distanceSquared;
+        out.copy(centroid);
+      }
+    }
+  });
+
+  return closestDistanceSquared < Infinity ? out : object.getWorldPosition(out);
+}


### PR DESCRIPTION
# getWorldPosition on ui actually gets physical location

## Description

Before getWorldPosition would get the center of the UICard due to the way the private rendering worked so then all ui on a card would have the same value. Fixed by mapping to actual physical location

- Smaller fixes to reach to in embodied controller now reaching by fingertip (https://github.com/google/xrblocks/issues/535)
- A new helper to ensure raycasts are on geometry for the embodiedControl to have more accurate raycasts

## Type of Change

- [x] Bug fix
- [x] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

- **Simulator Recording**: <!-- Attach video/GIF running in desktop simulator -->
- **Device Recording**: <!-- Attach video/GIF running on physical hardware -->

## Checklist

- [x] **Tested in simulator & device**: Verified functionality in desktop simulator and/or physical hardware (where applicable).
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.
