### PR TITLE
Fixed Rendering on Emoji Text

### DIFF
--- a/samples/spatial_ui/ui/index.html
+++ b/samples/spatial_ui/ui/index.html
@@ -154,6 +154,14 @@
                 text: 'Build spatial interfaces from familiar flex layouts.',
                 style: {fontSize: 18, lineHeight: 1.35},
               }),
+              new xb.UIText({
+                text: 'Emojis 🚀✨',
+                style: {fontSize: 18, lineHeight: 1.35},
+              }),
+              new xb.UIText({
+                text: '你好！',
+                style: {fontSize: 18, lineHeight: 1.35},
+              }),
               new xb.UIPanel({
                 style: {width: '100%', flexDirection: 'row', gap: 12},
                 children: [

--- a/src/ui/internal/AdaptiveText.ts
+++ b/src/ui/internal/AdaptiveText.ts
@@ -6,6 +6,7 @@ import {
 } from '@pmndrs/uikit';
 import type * as THREE from 'three';
 
+import {canRenderEmojiText, EmojiText} from './EmojiText';
 import {UnicodeText, type UnicodeTextProperties} from './UnicodeText';
 
 export interface AdaptiveTextProperties extends Record<string, unknown> {
@@ -22,8 +23,9 @@ export interface AdaptiveTextProperties extends Record<string, unknown> {
 /** Stable layout node that selects native or canvas glyph rendering internally. */
 export class AdaptiveText extends Container {
   private nativeText?: Text;
+  private emojiText?: EmojiText;
   private unicodeText?: UnicodeText;
-  private activeText?: Text | UnicodeText;
+  private activeText?: Text | EmojiText | UnicodeText;
 
   constructor(properties: AdaptiveTextProperties) {
     super(containerProperties(properties));
@@ -33,9 +35,11 @@ export class AdaptiveText extends Container {
 
   updateTextProperties(properties: AdaptiveTextProperties): void {
     this.resetProperties(containerProperties(properties));
-    const next = requiresUnicodeTextRenderer(properties.text)
-      ? this.updateUnicodeText(properties)
-      : this.updateNativeText(properties);
+    const next = canRenderEmojiText(properties.text)
+      ? this.updateEmojiText(properties)
+      : requiresUnicodeTextRenderer(properties.text)
+        ? this.updateUnicodeText(properties)
+        : this.updateNativeText(properties);
     if (next === this.activeText) return;
     this.activeText?.removeFromParent();
     this.add(next);
@@ -44,10 +48,13 @@ export class AdaptiveText extends Container {
 
   override dispose(): void {
     this.nativeText?.removeFromParent();
+    this.emojiText?.removeFromParent();
     this.unicodeText?.removeFromParent();
     this.nativeText?.dispose();
+    this.emojiText?.dispose();
     this.unicodeText?.dispose();
     this.nativeText = undefined;
+    this.emojiText = undefined;
     this.unicodeText = undefined;
     this.activeText = undefined;
     super.dispose();
@@ -58,6 +65,12 @@ export class AdaptiveText extends Container {
     if (!this.nativeText) this.nativeText = new Text(textProperties);
     else this.nativeText.resetProperties(textProperties);
     return this.nativeText;
+  }
+
+  private updateEmojiText(properties: AdaptiveTextProperties): EmojiText {
+    if (!this.emojiText) this.emojiText = new EmojiText(properties);
+    else this.emojiText.updateTextProperties(properties);
+    return this.emojiText;
   }
 
   private updateUnicodeText(properties: AdaptiveTextProperties): UnicodeText {

--- a/src/ui/internal/EmojiText.ts
+++ b/src/ui/internal/EmojiText.ts
@@ -1,0 +1,153 @@
+import {Container, type ContainerProperties, Image, Text} from '@pmndrs/uikit';
+
+import type {AdaptiveTextProperties} from './AdaptiveText';
+
+const EMOJI_SEQUENCE_SOURCE = String.raw`(?:\p{Regional_Indicator}{2}|[#*0-9]\uFE0F?\u20E3|(?:\p{Emoji_Presentation}|\p{Emoji}\uFE0F)(?:\p{Emoji_Modifier})?(?:\u200D(?:\p{Emoji_Presentation}|\p{Emoji}\uFE0F)(?:\p{Emoji_Modifier})?)*)`;
+const EMOJI_SEQUENCE_REGEX = new RegExp(EMOJI_SEQUENCE_SOURCE, 'u');
+const EMOJI_SEQUENCE_GLOBAL_REGEX = new RegExp(EMOJI_SEQUENCE_SOURCE, 'gu');
+const TEXT_SEGMENT_REGEX = new RegExp(
+  `${EMOJI_SEQUENCE_SOURCE}|\\n|[ \\t\\r]+|[a-zA-Z0-9]+|[^a-zA-Z0-9\\s]`,
+  'gu'
+);
+
+type Segment = {
+  type: 'space' | 'newline' | 'emoji' | 'word';
+  text: string;
+  blankLine?: boolean;
+  trailingSpaceWidth?: number;
+};
+
+/** Renders ASCII text as sharp UIKit glyphs and emoji as inline images. */
+export class EmojiText extends Container {
+  constructor(properties: AdaptiveTextProperties) {
+    super(emojiContainerProperties(properties));
+    this.name = 'EmojiText';
+    this.updateTextProperties(properties);
+  }
+
+  updateTextProperties(properties: AdaptiveTextProperties): void {
+    this.resetProperties(emojiContainerProperties(properties));
+    for (const child of [...this.children]) {
+      if (
+        child instanceof Container ||
+        child instanceof Image ||
+        child instanceof Text
+      ) {
+        child.dispose();
+      }
+    }
+
+    const fontSize = properties.fontSize ?? 16;
+    const emojiSize = fontSize * 1.05;
+    for (const segment of parseSegments(properties.text, fontSize)) {
+      if (segment.type === 'space') {
+        this.add(
+          new Container({
+            width: fontSize * 0.26 * segment.text.length,
+            height: fontSize,
+          })
+        );
+      } else if (segment.type === 'newline') {
+        this.add(
+          new Container({
+            width: '100%',
+            height: segment.blankLine ? fontSize : 0,
+          })
+        );
+      } else if (segment.type === 'emoji') {
+        this.add(
+          new Image({
+            src: emojiUrl(segment.text),
+            width: emojiSize,
+            height: emojiSize,
+            keepAspectRatio: true,
+            transformTranslateY: -emojiSize * 0.08,
+            marginRight: segment.trailingSpaceWidth,
+            pointerEvents: 'none',
+          })
+        );
+      } else {
+        this.add(
+          new Text({
+            text: segment.text,
+            fontSize,
+            lineHeight: properties.lineHeight,
+            color: properties.color,
+            fontWeight: properties.fontWeight,
+            whiteSpace: 'pre',
+            marginRight: segment.trailingSpaceWidth,
+            pointerEvents: 'none',
+          })
+        );
+      }
+    }
+  }
+}
+
+export function canRenderEmojiText(value: string): boolean {
+  if (!EMOJI_SEQUENCE_REGEX.test(value)) return false;
+  const textWithoutEmoji = value.replace(EMOJI_SEQUENCE_GLOBAL_REGEX, '');
+  return !/[^\u0020-\u007e\n\r\t]/u.test(textWithoutEmoji);
+}
+
+function emojiContainerProperties(
+  properties: AdaptiveTextProperties
+): ContainerProperties {
+  return {
+    flexDirection: 'row',
+    flexWrap: properties.whiteSpace === 'nowrap' ? 'nowrap' : 'wrap',
+    alignItems: 'center',
+    justifyContent:
+      properties.textAlign === 'center'
+        ? 'center'
+        : properties.textAlign === 'right'
+          ? 'flex-end'
+          : 'flex-start',
+    color: properties.color,
+    fontSize: properties.fontSize,
+    fontWeight: properties.fontWeight,
+    lineHeight: properties.lineHeight,
+    flexShrink: 0,
+    pointerEvents: 'none',
+  } as ContainerProperties;
+}
+
+function parseSegments(text: string, fontSize: number): Segment[] {
+  const rawSegments =
+    text.replace(/\r\n/gu, '\n').match(TEXT_SEGMENT_REGEX) ?? [];
+  const segments: Segment[] = [];
+
+  for (let index = 0; index < rawSegments.length; index++) {
+    const value = rawSegments[index];
+    if (value === '\n') {
+      segments.push({
+        type: 'newline',
+        text: value,
+        blankLine: index === 0 || rawSegments[index - 1] === '\n',
+      });
+    } else if (/^[ \t\r]+$/u.test(value)) {
+      const previous = segments[segments.length - 1];
+      if (previous?.type === 'word' || previous?.type === 'emoji') {
+        previous.trailingSpaceWidth = fontSize * 0.26 * value.length;
+      } else {
+        segments.push({type: 'space', text: value});
+      }
+    } else if (EMOJI_SEQUENCE_REGEX.test(value)) {
+      segments.push({type: 'emoji', text: value});
+    } else {
+      segments.push({type: 'word', text: value.replace(/\uFE0F/gu, '')});
+    }
+  }
+
+  return segments;
+}
+
+function emojiUrl(emoji: string): string {
+  let hex = Array.from(emoji)
+    .map((character) => character.codePointAt(0)!.toString(16))
+    .join('-');
+  if (!hex.includes('200d') && hex.endsWith('-fe0f')) {
+    hex = hex.slice(0, -5);
+  }
+  return `https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72/${hex}.png`;
+}

--- a/src/ui/internal/UnicodeText.ts
+++ b/src/ui/internal/UnicodeText.ts
@@ -30,6 +30,7 @@ interface TextLayout {
 }
 
 const MAX_CANVAS_DIMENSION = 4096;
+const CANVAS_SUPERSAMPLING = 2;
 const MEASURE_MODE_UNDEFINED = 0;
 const MEASURE_MODE_EXACTLY = 1;
 const SYSTEM_FONT =
@@ -119,7 +120,7 @@ export class UnicodeText extends Image {
     const scale = Math.max(
       Number.EPSILON,
       Math.min(
-        window.devicePixelRatio || 1,
+        (window.devicePixelRatio || 1) * CANVAS_SUPERSAMPLING,
         MAX_CANVAS_DIMENSION / width,
         MAX_CANVAS_DIMENSION / height
       )


### PR DESCRIPTION
# Fixed Rendering on Emoji Text

## Description

Emoji text used to render all the text + emoji on a canvas-> bitmap. Took the old UIWithEmojis approach from Glasses Blocks and renders text as MSDF and only emojis as sprites

Upped the rendering scale of the canvas to make unicode characters a bit clearer too. Unfortunately no way around the lack of MSDF antialiasing for that but its atleast clearer.

## Type of Change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

<img width="453" height="370" alt="image" src="https://github.com/user-attachments/assets/cb634be9-a454-4372-93b6-80955f3f8796" />


## Checklist

- [x] **Tested in simulator & device**: Verified functionality in desktop simulator and/or physical hardware (where applicable).
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.
