### PR TITLE
Migrate legacy UIBlocks usages in demos to v0.20.0 UI system

### DIFF
--- a/demos/context/main.js
+++ b/demos/context/main.js
@@ -183,16 +183,16 @@ class ContextBugtestScene extends xb.Script {
     const actionButton = new xb.UIButton({
       label: 'Ping',
       onClick: () => {
-        console.log('UIBlocks debug action clicked');
+        console.log('XRBlocks debug action clicked');
       },
       style: {width: 260},
     });
-    actionButton.name = 'UIBlocks Action Button';
+    actionButton.name = 'XRBlocks Action Button';
     actionButton.userData.semantic = {
       role: 'button',
       name: 'Ping Button',
       text: 'Ping',
-      source: 'uiblocks',
+      source: 'xrblocks',
       traits: ['selectable'],
     };
 
@@ -210,7 +210,7 @@ class ContextBugtestScene extends xb.Script {
       },
       children: [
         new xb.UIText({
-          text: 'UIBlocks Card',
+          text: 'XRBlocks Card',
           style: {fontSize: 44, fontWeight: 'bold'},
         }),
         new xb.UIText({
@@ -220,7 +220,7 @@ class ContextBugtestScene extends xb.Script {
         actionButton,
       ],
     });
-    card.name = 'UIBlocks Debug Card';
+    card.name = 'XRBlocks Debug Card';
     card.position.set(0, xb.user.height + 0.05, -1.32);
     this.add(card);
 

--- a/demos/dietHelper/index.html
+++ b/demos/dietHelper/index.html
@@ -286,7 +286,10 @@
       <button
         class="diet-helper-btn"
         id="dietHelperCaptureBtn"
-        onclick="window.dietHelperCaptureAndAnalyze && window.dietHelperCaptureAndAnalyze()"
+        onclick="
+          window.dietHelperCaptureAndAnalyze &&
+            window.dietHelperCaptureAndAnalyze()
+        "
       >
         Capture &amp; Analyze
       </button>

--- a/demos/objects_3d/index.html
+++ b/demos/objects_3d/index.html
@@ -30,7 +30,6 @@
           "@pmndrs/msdfonts": "https://cdn.jsdelivr.net/npm/@pmndrs/msdfonts@1.0.64/dist/index.min.js",
           "@preact/signals-core": "https://cdn.jsdelivr.net/npm/@preact/signals-core@1.12.1/dist/signals-core.mjs",
           "yoga-layout/load": "https://cdn.jsdelivr.net/npm/yoga-layout@3.2.1/dist/src/load.js",
-          "uiblocks": "../../build/addons/uiblocks/src/index.js",
           "xrblocks": "../../build/xrblocks.js",
           "xrblocks/addons/": "../../build/addons/",
           "@mediapipe/tasks-vision": "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.34/vision_bundle.mjs",
@@ -246,13 +245,6 @@
     <script type="module">
       import * as THREE from 'three';
       import * as xb from 'xrblocks';
-      import {
-        ManipulationBehavior,
-        UICore,
-        UIIcon,
-        UIPanel,
-        UIText,
-      } from 'uiblocks';
       import {
         FilesetResolver,
         InteractiveSegmenter,
@@ -1687,10 +1679,7 @@
       function setStatus(s) {
         const el = document.getElementById('status');
         if (el) el.textContent = s;
-        // The MSDF font uiblocks uses doesn't include the Unicode ellipsis
-        // glyph (U+2026), so swap it for three ASCII dots before handing
-        // the string to UIText, otherwise it renders as '?'.
-        if (xrStatusText) xrStatusText.setText(s.replace(/…/g, '...'));
+        if (xrStatusText) xrStatusText.text = s.replace(/…/g, '...');
       }
 
       function clearBoxes() {
@@ -2144,7 +2133,6 @@
       }
 
       const options = new xb.Options();
-      options.enableUI();
       options.enableAI();
       options.enableCamera();
       options.enableDepth();
@@ -2190,68 +2178,75 @@
         window.location.search = '?' + p.toString();
       }
 
-      // Spatial control panel for immersive XR. Built as an xb.Script so
-      // UICore + HeadLeashBehavior get the lifecycle hooks they need. The
-      // panel mirrors the DOM controls (detect / clear + detector / mask
-      // pickers) and shows live status. Uses uiblocks (preferred over the
-      // older xb.SpatialPanel per ruofei's guidance on PR #274).
+      // Spatial control panel for immersive XR. Built as an xb.Script.
+      // The panel mirrors the DOM controls (detect / clear + detector / mask
+      // pickers) and shows live status.
       class Objects3dControlPanel extends xb.Script {
         init() {
-          this.uiCore = new UICore(this);
-          const card = this.uiCore.createCard({
-            name: 'Objects3dControlCard',
-            position: new THREE.Vector3(0, 1.4, -1.0),
-            sizeX: 0.62,
-            sizeY: 0.42,
-          });
-          const panel = new UIPanel({
-            width: '100%',
-            height: '100%',
-            fillColor: 'rgba(15, 18, 25, 0.9)',
-            innerShadowColor: 'rgba(100, 180, 255, 0.12)',
-            innerShadowBlur: 60,
-            strokeWidth: 3,
-            strokeColor: {
-              gradientType: 'linear',
-              rotation: 45,
-              stops: [
-                {position: 0, color: '#4796e3'},
-                {position: 1, color: '#9b5de5'},
-              ],
+          const card = new xb.UICard({
+            size: {width: 0.62, height: 0.42},
+            manipulation: {actions: {translate: {faceCamera: true}}},
+            edge: true,
+            style: {
+              width: '100%',
+              height: '100%',
+              backgroundColor: 'rgba(15, 18, 25, 0.9)',
+              borderWidth: 3,
+              borderColor: {
+                gradientType: 'linear',
+                rotation: 45,
+                stops: [
+                  {position: 0, color: '#4796e3'},
+                  {position: 1, color: '#9b5de5'},
+                ],
+              },
+              borderRadius: 22,
+              padding: 18,
+              flexDirection: 'column',
+              gap: 10,
+              alignItems: 'stretch',
+              justifyContent: 'flex-start',
             },
-            cornerRadius: 22,
-            padding: 18,
-            flexDirection: 'column',
-            gap: 10,
-            alignItems: 'stretch',
-            justifyContent: 'flex-start',
           });
-          const titleText = new UIText('3D OBJECT BOXES', {
-            fontSize: 22,
-            fontWeight: 'bold',
-            color: '#00f0ff',
-            textAlign: 'center',
-            width: '100%',
+          card.name = 'Objects3dControlCard';
+          card.position.set(0, 1.4, -1.0);
+
+          const titleText = new xb.UIText({
+            text: '3D OBJECT BOXES',
+            style: {
+              fontSize: 22,
+              fontWeight: 'bold',
+              color: '#00f0ff',
+              textAlign: 'center',
+              width: '100%',
+            },
           });
-          xrStatusText = new UIText('idle', {
-            fontSize: 14,
-            color: '#a0aec0',
-            textAlign: 'center',
-            width: '100%',
-            paddingBottom: 4,
+          xrStatusText = new xb.UIText({
+            text: 'idle',
+            style: {
+              fontSize: 14,
+              color: '#a0aec0',
+              textAlign: 'center',
+              width: '100%',
+              paddingBottom: 4,
+            },
           });
-          const separator = new UIPanel({
-            width: '100%',
-            height: 2,
-            fillColor: 'rgba(255, 255, 255, 0.12)',
-            marginBottom: 4,
+          const separator = new xb.UIPanel({
+            style: {
+              width: '100%',
+              height: 2,
+              backgroundColor: 'rgba(255, 255, 255, 0.12)',
+              marginBottom: 4,
+            },
           });
-          const buttonRow = new UIPanel({
-            width: '100%',
-            flexDirection: 'row',
-            gap: 14,
-            justifyContent: 'center',
-            alignItems: 'center',
+          const buttonRow = new xb.UIPanel({
+            style: {
+              width: '100%',
+              flexDirection: 'row',
+              gap: 14,
+              justifyContent: 'center',
+              alignItems: 'center',
+            },
           });
           buttonRow.add(this.makeXrLabeledButton('search', 'detect', detect));
           buttonRow.add(
@@ -2260,13 +2255,15 @@
               setStatus('cleared');
             })
           );
-          const pickerRow = new UIPanel({
-            width: '100%',
-            flexDirection: 'row',
-            gap: 10,
-            justifyContent: 'center',
-            alignItems: 'center',
-            marginTop: 4,
+          const pickerRow = new xb.UIPanel({
+            style: {
+              width: '100%',
+              flexDirection: 'row',
+              gap: 10,
+              justifyContent: 'center',
+              alignItems: 'center',
+              marginTop: 4,
+            },
           });
           pickerRow.add(
             this.makeXrCycleButton(
@@ -2284,87 +2281,58 @@
               (next) => cycleQueryParam('mask', next)
             )
           );
-          panel.add(titleText);
-          panel.add(xrStatusText);
-          panel.add(separator);
-          panel.add(buttonRow);
-          panel.add(pickerRow);
-          card.add(panel);
-          card.addBehavior(
-            new ManipulationBehavior({draggable: true, faceCamera: true})
-          );
+          card.add(titleText);
+          card.add(xrStatusText);
+          card.add(separator);
+          card.add(buttonRow);
+          card.add(pickerRow);
+          this.add(card);
         }
 
         // Detect / clear: icon + caption stacked so XR users get the same
         // affordance as the DOM "Detect 3D objects" / "Clear" buttons.
         makeXrLabeledButton(iconName, label, onClick) {
-          const idle = '#2a2a2a';
-          const hover = '#3a3a3a';
-          const btn = new UIPanel({
-            paddingTop: 8,
-            paddingBottom: 8,
-            paddingLeft: 16,
-            paddingRight: 16,
-            cornerRadius: 12,
-            fillColor: idle,
-            strokeWidth: 1,
-            strokeColor: '#444444',
-            flexDirection: 'row',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: 8,
-            renderOrder: 10,
-            onHoverEnter: () => btn.setFillColor(hover),
-            onHoverExit: () => btn.setFillColor(idle),
+          const btn = new xb.UIButton({
+            ariaLabel: label,
             onClick: () => {
-              btn.setFillColor('#4796e3');
-              setTimeout(() => btn.setFillColor(idle), 180);
+              btn.style.backgroundColor = '#4796e3';
+              setTimeout(() => {
+                btn.style.backgroundColor = '#2a2a2a';
+              }, 180);
               onClick();
             },
-          });
-          btn.add(
-            new UIIcon(iconName, {
-              color: 'white',
-              width: 22,
-              height: 22,
-              renderOrder: 12,
-            })
-          );
-          btn.add(
-            new UIText(label, {
-              fontSize: 14,
-              color: '#ffffff',
-              fontWeight: 'bold',
-              depthTest: false,
-              renderOrder: 100,
-            })
-          );
-          return btn;
-        }
-
-        makeXrIconButton(iconName, onClick) {
-          const idle = '#2a2a2a';
-          const hover = '#3a3a3a';
-          const btn = new UIPanel({
-            width: 56,
-            height: 56,
-            cornerRadius: 12,
-            fillColor: idle,
-            strokeWidth: 1,
-            strokeColor: '#444444',
-            justifyContent: 'center',
-            alignItems: 'center',
-            onHoverEnter: () => btn.setFillColor(hover),
-            onHoverExit: () => btn.setFillColor(idle),
-            onClick: () => {
-              btn.setFillColor('#4796e3');
-              setTimeout(() => btn.setFillColor(idle), 180);
-              onClick();
+            style: {
+              paddingTop: 8,
+              paddingBottom: 8,
+              paddingLeft: 16,
+              paddingRight: 16,
+              borderRadius: 12,
+              backgroundColor: '#2a2a2a',
+              borderWidth: 1,
+              borderColor: '#444444',
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 8,
+              ':hover': {backgroundColor: '#3a3a3a'},
+              ':active': {backgroundColor: '#4796e3'},
             },
+            children: [
+              new xb.UIIcon({
+                icon: iconName,
+                ariaLabel: iconName,
+                style: {color: '#ffffff', width: 22, height: 22},
+              }),
+              new xb.UIText({
+                text: label,
+                style: {
+                  fontSize: 14,
+                  color: '#ffffff',
+                  fontWeight: 'bold',
+                },
+              }),
+            ],
           });
-          btn.add(
-            new UIIcon(iconName, {color: 'white', width: 32, height: 32})
-          );
           return btn;
         }
 
@@ -2372,49 +2340,60 @@
         // in the list and reloads the page so the backend gets re-initialised
         // (mirrors the DOM <select> behaviour, which also reloads on change).
         makeXrCycleButton(label, current, options, onChange) {
-          const idle = '#2a2a2a';
-          const hover = '#3a3a3a';
-          const btn = new UIPanel({
-            paddingTop: 6,
-            paddingBottom: 6,
-            paddingLeft: 12,
-            paddingRight: 12,
-            cornerRadius: 10,
-            fillColor: idle,
-            strokeWidth: 1,
-            strokeColor: '#444444',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: 2,
-            renderOrder: 10,
-            onHoverEnter: () => btn.setFillColor(hover),
-            onHoverExit: () => btn.setFillColor(idle),
+          const labelColumn = new xb.UIPanel({
+            style: {
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 2,
+            },
+          });
+          labelColumn.add(
+            new xb.UIText({
+              text: label,
+              style: {
+                fontSize: 10,
+                color: '#888888',
+                textAlign: 'center',
+              },
+            })
+          );
+          const valueText = new xb.UIText({
+            text: current,
+            style: {
+              fontSize: 14,
+              color: '#ffffff',
+              fontWeight: 'bold',
+              textAlign: 'center',
+            },
+          });
+          labelColumn.add(valueText);
+
+          const btn = new xb.UIButton({
+            ariaLabel: `${label}: ${current}`,
             onClick: () => {
               const idx = options.indexOf(current);
               const next = options[(idx + 1) % options.length];
               onChange(next);
             },
+            style: {
+              paddingTop: 6,
+              paddingBottom: 6,
+              paddingLeft: 12,
+              paddingRight: 12,
+              borderRadius: 10,
+              backgroundColor: '#2a2a2a',
+              borderWidth: 1,
+              borderColor: '#444444',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 2,
+              ':hover': {backgroundColor: '#3a3a3a'},
+              ':active': {backgroundColor: '#4796e3'},
+            },
+            children: [labelColumn],
           });
-          btn.add(
-            new UIText(label, {
-              fontSize: 10,
-              color: '#888888',
-              textAlign: 'center',
-              depthTest: false,
-              renderOrder: 100,
-            })
-          );
-          btn.add(
-            new UIText(current, {
-              fontSize: 14,
-              color: '#ffffff',
-              fontWeight: 'bold',
-              textAlign: 'center',
-              depthTest: false,
-              renderOrder: 100,
-            })
-          );
           return btn;
         }
       }

--- a/demos/skybox_agent/GeminiSkyboxGenerator.js
+++ b/demos/skybox_agent/GeminiSkyboxGenerator.js
@@ -250,7 +250,6 @@ async function start() {
     await requestAudioPermission();
 
     const options = new xb.Options();
-    options.enableUI();
     options.enableHands();
     options.enableAI();
     options.setAppTitle('Generating Skybox with Gemini');

--- a/demos/world_companion/index.html
+++ b/demos/world_companion/index.html
@@ -29,7 +29,6 @@
           "@pmndrs/msdfonts": "https://cdn.jsdelivr.net/npm/@pmndrs/msdfonts@1.0.64/dist/index.min.js",
           "@preact/signals-core": "https://cdn.jsdelivr.net/npm/@preact/signals-core@1.12.1/dist/signals-core.mjs",
           "yoga-layout/load": "https://cdn.jsdelivr.net/npm/yoga-layout@3.2.1/dist/src/load.js",
-          "uiblocks": "../../build/addons/uiblocks/src/index.js",
           "xrblocks": "../../build/xrblocks.js",
           "xrblocks/addons/": "../../build/addons/",
           "@google/genai": "https://cdn.jsdelivr.net/npm/@google/genai/+esm",
@@ -267,13 +266,6 @@
       import * as THREE from 'three';
       import * as xb from 'xrblocks';
       import {GeminiManager} from 'xrblocks/addons/ai/GeminiManager.js';
-      import {
-        ManipulationBehavior,
-        UICore,
-        UIIcon,
-        UIPanel,
-        UIText,
-      } from 'uiblocks';
       import {Text} from 'troika-three-text';
       import {marked} from 'marked';
       import DOMPurify from 'dompurify';
@@ -371,7 +363,7 @@
 
       function setStatus(s) {
         statusEl.textContent = s;
-        if (xrStatusText) xrStatusText.setText(s.replace(/…/g, '...'));
+        if (xrStatusText) xrStatusText.text = s.replace(/…/g, '...');
       }
       function renderTranscript() {
         transcriptEl.innerHTML = DOMPurify.sanitize(
@@ -620,7 +612,7 @@
             if (xrStatusText) {
               const want = list.map((it) => it.text).join(', ');
               const got = detected.map((d) => d.label).join(', ') || '(none)';
-              xrStatusText.setText(`want: ${want} | got: ${got}`);
+              xrStatusText.text = `want: ${want} | got: ${got}`;
             }
 
             const expand = (s) => {
@@ -971,7 +963,6 @@
       clearBtn.addEventListener('click', clearLabels);
 
       const options = new xb.Options();
-      options.enableUI();
       options.enableAI();
       options.enableCamera();
       options.enableDepth();
@@ -1006,117 +997,120 @@
       });
       xb.add(geminiManager);
 
-      // Immersive control panel built with uiblocks (preferred over the older
-      // xb.SpatialPanel). Mirrors the DOM controls and shows live status. An
-      // xb.Script so UICore gets its lifecycle hooks; draggable so users can
-      // place it anywhere.
+      // Immersive control panel for XR. Mirrors the DOM controls and shows live status.
       class WorldCompanionPanel extends xb.Script {
         init() {
-          this.uiCore = new UICore(this);
-          const card = this.uiCore.createCard({
-            name: 'WorldCompanionControlCard',
-            position: new THREE.Vector3(0, 1.3, -0.8),
-            sizeX: 0.56,
-            sizeY: 0.2,
+          const card = new xb.UICard({
+            size: {width: 0.56, height: 0.22},
+            manipulation: {actions: {translate: {faceCamera: true}}},
+            edge: true,
+            style: {
+              width: '100%',
+              height: '100%',
+              backgroundColor: 'rgba(10, 12, 16, 0.94)',
+              borderWidth: 2,
+              borderColor: 'rgba(126, 231, 135, 0.45)',
+              borderRadius: 18,
+              padding: 14,
+              flexDirection: 'column',
+              gap: 8,
+              alignItems: 'stretch',
+              justifyContent: 'center',
+            },
           });
-          const panel = new UIPanel({
-            width: '100%',
-            height: '100%',
-            fillColor: 'rgba(10, 12, 16, 0.94)',
-            strokeWidth: 2,
-            strokeColor: 'rgba(126, 231, 135, 0.45)',
-            cornerRadius: 18,
-            padding: 14,
-            flexDirection: 'column',
-            gap: 8,
-            alignItems: 'stretch',
-            justifyContent: 'center',
+          card.name = 'WorldCompanionControlCard';
+          card.position.set(0, 1.3, -0.8);
+
+          const titleText = new xb.UIText({
+            text: 'WORLD COMPANION',
+            style: {
+              fontSize: 18,
+              fontWeight: 'bold',
+              color: '#7ee787',
+              textAlign: 'center',
+              width: '100%',
+            },
           });
-          const titleText = new UIText('WORLD COMPANION', {
-            fontSize: 18,
-            fontWeight: 'bold',
-            color: '#7ee787',
-            textAlign: 'center',
-            width: '100%',
+          xrStatusText = new xb.UIText({
+            text: 'idle',
+            style: {
+              fontSize: 12,
+              color: '#8b97a7',
+              textAlign: 'center',
+              width: '100%',
+            },
           });
-          xrStatusText = new UIText('idle', {
-            fontSize: 12,
-            color: '#8b97a7',
-            textAlign: 'center',
-            width: '100%',
+          const separator = new xb.UIPanel({
+            style: {
+              width: '100%',
+              height: 1,
+              backgroundColor: 'rgba(255, 255, 255, 0.10)',
+            },
           });
-          const separator = new UIPanel({
-            width: '100%',
-            height: 1,
-            fillColor: 'rgba(255, 255, 255, 0.10)',
-          });
-          const buttonRow = new UIPanel({
-            width: '100%',
-            flexDirection: 'row',
-            gap: 10,
-            justifyContent: 'center',
-            alignItems: 'center',
+          const buttonRow = new xb.UIPanel({
+            style: {
+              width: '100%',
+              flexDirection: 'row',
+              gap: 10,
+              justifyContent: 'center',
+              alignItems: 'center',
+            },
           });
           buttonRow.add(this.makeXrButton('mic', 'talk', start));
           buttonRow.add(this.makeXrButton('stop', 'stop', stop));
           buttonRow.add(
             this.makeXrButton('delete_sweep', 'clear', clearLabels)
           );
-          panel.add(titleText);
-          panel.add(xrStatusText);
-          panel.add(separator);
-          panel.add(buttonRow);
-          card.add(panel);
-          card.addBehavior(
-            new ManipulationBehavior({draggable: true, faceCamera: true})
-          );
+          card.add(titleText);
+          card.add(xrStatusText);
+          card.add(separator);
+          card.add(buttonRow);
+          this.add(card);
         }
 
-        // Icon + caption button mirroring a DOM control. renderOrder/depthTest
-        // pin the label and icon on top of the fill so they read from every
-        // angle (the uiblocks button fill otherwise draws over nested text).
+        // Icon + caption button mirroring a DOM control.
         makeXrButton(iconName, label, onClick) {
-          const idle = '#2a2a2a';
-          const hover = '#3a3a3a';
-          const btn = new UIPanel({
-            paddingTop: 8,
-            paddingBottom: 8,
-            paddingLeft: 16,
-            paddingRight: 16,
-            cornerRadius: 12,
-            fillColor: idle,
-            strokeWidth: 1,
-            strokeColor: '#444444',
-            flexDirection: 'row',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: 8,
-            renderOrder: 10,
-            onHoverEnter: () => btn.setFillColor(hover),
-            onHoverExit: () => btn.setFillColor(idle),
+          const btn = new xb.UIButton({
+            ariaLabel: label,
             onClick: () => {
-              btn.setFillColor('#4796e3');
-              setTimeout(() => btn.setFillColor(idle), 180);
+              btn.style.backgroundColor = '#4796e3';
+              setTimeout(() => {
+                btn.style.backgroundColor = '#2a2a2a';
+              }, 180);
               onClick();
             },
+            style: {
+              paddingTop: 8,
+              paddingBottom: 8,
+              paddingLeft: 16,
+              paddingRight: 16,
+              borderRadius: 12,
+              backgroundColor: '#2a2a2a',
+              borderWidth: 1,
+              borderColor: '#444444',
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 8,
+              ':hover': {backgroundColor: '#3a3a3a'},
+              ':active': {backgroundColor: '#4796e3'},
+            },
+            children: [
+              new xb.UIIcon({
+                icon: iconName,
+                ariaLabel: iconName,
+                style: {color: 'white', width: 22, height: 22},
+              }),
+              new xb.UIText({
+                text: label,
+                style: {
+                  fontSize: 14,
+                  color: '#ffffff',
+                  fontWeight: 'bold',
+                },
+              }),
+            ],
           });
-          btn.add(
-            new UIIcon(iconName, {
-              color: 'white',
-              width: 22,
-              height: 22,
-              renderOrder: 12,
-            })
-          );
-          btn.add(
-            new UIText(label, {
-              fontSize: 14,
-              color: '#ffffff',
-              fontWeight: 'bold',
-              depthTest: false,
-              renderOrder: 100,
-            })
-          );
           return btn;
         }
       }


### PR DESCRIPTION
## Description

Removed remaining usage and imports of UI Blocks. Note that UI Blocks has been removed so these samples were already broken.

## Type of Change

- [x] Bug fix

## Checklist

- [x] **Tested in simulator & device**: Briefly checked `demos/objects_3d/`, `demos/world_companion/`, and `demos/context/` are working in the simulator.
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.