### PR TITLE
Bump to 0.21.0

### DIFF
--- a/demos/vrm-avatar/README.md
+++ b/demos/vrm-avatar/README.md
@@ -63,8 +63,8 @@ On device, `onSelectEnd` uses the callback's `event.surface` and `event.intersec
 | ------------------ | --------- | ----------- |
 | `three`            | `0.184.0` | CDN         |
 | `@pixiv/three-vrm` | `^3`      | CDN         |
-| `xrblocks`         | `0.20.0`  | Local build |
-| `xrblocks/addons/` | `0.20.0`  | Local build |
+| `xrblocks`         | `0.21.0`  | Local build |
+| `xrblocks/addons/` | `0.21.0`  | Local build |
 
 All other dependencies (rapier3d, lit) are CDN — see the import map in `index.html`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xrblocks",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xrblocks",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "Apache-2.0",
       "bin": {
         "xrblocks-mcp": "src/addons/mcp/server/bin.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xrblocks",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "XR Blocks SDK",
   "main": "build/xrblocks.js",
   "types": "build/xrblocks.d.ts",

--- a/templates/13_typescript_vite/package.json
+++ b/templates/13_typescript_vite/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "three": "^0.184.0",
-    "xrblocks": "0.20.0"
+    "xrblocks": "0.21.0"
   },
   "devDependencies": {
     "@types/three": "^0.184.0",


### PR DESCRIPTION
## Description

Bump repository and template package versions to `0.21.0`.

## Type of Change

- [x] Version bump

## Checklist

- [x] **Tested in simulator & device**: All 87 test suites (633 tests) pass and linter/formatter are clean.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.