### PR TITLE
fixed raycasting on sprites

### DIFF
--- a/src/interaction/HitRegistry.ts
+++ b/src/interaction/HitRegistry.ts
@@ -18,6 +18,10 @@ export class HitRegistry {
     RegisteredHitSurface
   >();
 
+  constructor(camera?: THREE.Camera) {
+    if (camera) this.raycaster.camera = camera;
+  }
+
   register(physical: THREE.Object3D, logical: THREE.Object3D): () => void {
     const entry = {physical, logical};
     this.mappings.set(physical, entry);

--- a/src/interaction/Interaction.ts
+++ b/src/interaction/Interaction.ts
@@ -81,7 +81,7 @@ export class Interaction {
   private readonly reticle;
   private readonly reticleOptions;
   private readonly scene?: THREE.Scene;
-  private readonly registry = new HitRegistry();
+  private readonly registry: HitRegistry;
   private readonly resolver;
   private readonly directTouch;
   private longSelectDuration;
@@ -107,6 +107,7 @@ export class Interaction {
   private nextFrameSources = new Set<Controller>();
 
   constructor(dependencies: InteractionDependencies) {
+    this.registry = new HitRegistry(dependencies.camera);
     this.callbacks = dependencies.callbacks;
     this.scene = dependencies.scene;
     this.manipulation = new ManipulationManager(


### PR DESCRIPTION
# Raycasting on sprites

## Description

Raycasting on sprites needs a camera for the raycaster to know where the sprite is facing.

## Type of Change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

- **Simulator Recording**: <!-- Attach video/GIF running in desktop simulator -->
- **Device Recording**: <!-- Attach video/GIF running on physical hardware -->

## Checklist

- [x] **Tested in simulator & device**: Verified functionality in desktop simulator and/or physical hardware (where applicable).
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.
