### PR TITLE
feat: added unofficial uv mapping to GNM demo and a mona lisa texture

### DIFF
--- a/samples/avatar_lab/gnm/GNMControls.js
+++ b/samples/avatar_lab/gnm/GNMControls.js
@@ -25,6 +25,7 @@ const MATERIAL_MODES = [
   ['clay', 'Clay'],
   ['normals', 'Normals'],
   ['regions', 'Regions'],
+  ['texture', 'Mona Lisa'],
 ];
 
 const INITIAL_SLIDERS_PER_GROUP = 10;
@@ -962,7 +963,29 @@ export class GNMControls {
     return fragment;
   }
 
-  setMaterialMode(mode) {
+  async setMaterialMode(mode) {
+    // The UV sidecar and the texture are a few megabytes between them, so they
+    // are fetched the first time someone asks for the mode, not at startup.
+    if (mode === 'texture' && !this.scene.canShowTexture()) {
+      const button = this._materialButtons?.find(
+        (candidate) => candidate.dataset.mode === 'texture'
+      );
+      const label = button?.textContent;
+      if (button) {
+        button.textContent = 'Loading…';
+        button.classList.add('busy');
+      }
+      this.setStatus('Loading the Mona Lisa texture…');
+      const loaded = await this.scene.loadTexture(
+        this.scene.skinTextureUrls,
+        'Mona Lisa'
+      );
+      if (button) {
+        button.textContent = label;
+        button.classList.remove('busy');
+      }
+      if (!loaded) return;
+    }
     this.scene.setMaterialMode(mode);
     this._materialButtons?.forEach((button) =>
       button.classList.toggle('active', button.dataset.mode === mode)
@@ -1251,14 +1274,6 @@ export class GNMControls {
           break;
         case 't':
           this.scene.setExpressionTour(!this.scene.tour);
-          break;
-        case 'w':
-          if (this._wireToggle) {
-            this._wireToggle.checked = !this._wireToggle.checked;
-          }
-          this.scene.setWireframeVisible(
-            this._wireToggle?.checked ?? !this.scene.wireframe.visible
-          );
           break;
         case 'g':
           this.scene.turntable = !this.scene.turntable;

--- a/samples/avatar_lab/gnm/GNMModel.js
+++ b/samples/avatar_lab/gnm/GNMModel.js
@@ -147,6 +147,18 @@ export class GNMHeadModel {
     this.componentId = sections.component_id;
     this.materialId = sections.material_id;
     this.regionId = sections.region_id;
+
+    // UV sections are optional: containers exported before texturing existed
+    // (including the ones on the CDN) simply have no texture coordinates, and
+    // the viewer falls back to per-vertex colors. Seam vertices are duplicated
+    // at export, so the render mesh can be larger than the model; the first
+    // numVertices render vertices are the model's, in order.
+    this.vertexUvs = null;
+    this.uvSource = null;
+    this.uvTriangles = null;
+    this.hasUvs = false;
+    this.numRenderVertices = this.numVertices;
+    this.attachUvs(sections);
     this.landmarkIndices = sections.landmark_indices;
     this.landmarkWeights = sections.landmark_weights;
 
@@ -180,6 +192,37 @@ export class GNMHeadModel {
     const buffer = await fetchWithProgress(url, onProgress);
     const {meta, sections} = parseContainer(buffer);
     return new GNMHeadModel(meta, sections);
+  }
+
+  /**
+   * Installs UV sections, from the model container or from a sidecar fetched
+   * later. Returns whether the model now has usable texture coordinates.
+   */
+  attachUvs(sections) {
+    const uvs = sections.vertex_uvs;
+    const source = sections.uv_source;
+    const triangles = sections.uv_triangles;
+    if (!uvs || !source || !triangles) return this.hasUvs;
+    // A sidecar built from a different GNM version would silently mismap.
+    if (triangles.length !== this.triangles.length) {
+      throw new Error(
+        `UV data has ${triangles.length / 3} triangles, model has ` +
+          `${this.triangles.length / 3}.`
+      );
+    }
+    this.vertexUvs = uvs;
+    this.uvSource = source;
+    this.uvTriangles = triangles;
+    this.numRenderVertices = source.length;
+    this.hasUvs = true;
+    return true;
+  }
+
+  /** Fetches a UV sidecar written by tools/export_gnm_web.py. */
+  async loadUvs(url) {
+    const buffer = await fetchWithProgress(url);
+    const {sections} = parseContainer(buffer);
+    return this.attachUvs(sections);
   }
 
   // ---------------------------------------------------------------- params --
@@ -518,7 +561,52 @@ export class GNMHeadModel {
       out[v * 3 + 1] = oy;
       out[v * 3 + 2] = oz;
     }
+    if (this.hasUvs && out.length >= this.numRenderVertices * 3) {
+      // Seam duplicates ride along with the vertex they were split from.
+      const source = this.uvSource;
+      for (let v = V; v < this.numRenderVertices; ++v) {
+        const src = source[v] * 3;
+        out[v * 3] = out[src];
+        out[v * 3 + 1] = out[src + 1];
+        out[v * 3 + 2] = out[src + 2];
+      }
+    }
     this.dirty = false;
+  }
+
+  /**
+   * Welds vertex normals back together across the UV seams.
+   *
+   * Seam vertices are duplicated so each copy can carry its island's texture
+   * coordinate, but three.js then averages face normals per *render* vertex,
+   * so each copy only sees the faces on its own side of the seam. The shared
+   * edge ends up with two different normals and shades as a hard crease - a
+   * black line down the middle of the back of the head. Summing the copies and
+   * handing every one of them the same normal restores the smooth surface.
+   */
+  weldSeamNormals(normals) {
+    if (!this.hasUvs) return;
+    const source = this.uvSource;
+    for (let v = this.numVertices; v < this.numRenderVertices; ++v) {
+      const dst = source[v] * 3;
+      normals[dst] += normals[v * 3];
+      normals[dst + 1] += normals[v * 3 + 1];
+      normals[dst + 2] += normals[v * 3 + 2];
+    }
+    for (let v = this.numVertices; v < this.numRenderVertices; ++v) {
+      const src = source[v] * 3;
+      const x = normals[src];
+      const y = normals[src + 1];
+      const z = normals[src + 2];
+      // Idempotent: duplicates sharing a source just renormalize a unit vector.
+      const length = Math.hypot(x, y, z) || 1;
+      normals[src] = x / length;
+      normals[src + 1] = y / length;
+      normals[src + 2] = z / length;
+      normals[v * 3] = normals[src];
+      normals[v * 3 + 1] = normals[src + 1];
+      normals[v * 3 + 2] = normals[src + 2];
+    }
   }
 
   /** Barycentric landmark extraction (68 × 3 vertices/weights). */

--- a/samples/avatar_lab/gnm/GNMScene.js
+++ b/samples/avatar_lab/gnm/GNMScene.js
@@ -1,6 +1,8 @@
 import * as THREE from 'three';
 import * as xb from 'xrblocks';
 
+import {SAMPLE_IMAGE} from './GNMFaceFitter.js';
+
 /**
  * GNMScene — renders the GNM parametric head and animates it.
  *
@@ -98,10 +100,11 @@ export class GNMScene extends xb.Script {
     });
     this.add(this.modelViewer);
 
-    // GNM geometry.
+    // GNM geometry. With UVs the mesh carries a few hundred extra vertices,
+    // split off at the texture seams; without them it is the model 1:1.
     const geometry = new THREE.BufferGeometry();
     this.positionAttribute = new THREE.BufferAttribute(
-      new Float32Array(model.numVertices * 3),
+      new Float32Array(model.numRenderVertices * 3),
       3
     );
     this.positionAttribute.setUsage(THREE.DynamicDrawUsage);
@@ -110,10 +113,20 @@ export class GNMScene extends xb.Script {
       'color',
       new THREE.BufferAttribute(this._buildMaterialColors(), 3)
     );
+    if (model.hasUvs) {
+      geometry.setAttribute(
+        'uv',
+        new THREE.BufferAttribute(model.vertexUvs, 2)
+      );
+    }
     this._regionColors = null; // built lazily for the regions mode
-    this.fullIndex = new THREE.BufferAttribute(model.triangles, 1);
+    // Skin triangles come first so the textured mode can draw them as their
+    // own group; the eyes, teeth and tongue have their own UV squares and are
+    // not in the skin texture.
+    this.fullIndex = new THREE.BufferAttribute(this._buildIndex(), 1);
     geometry.setIndex(this.fullIndex);
     this.geometry = geometry;
+    this._applyGroups(this._skinIndexCount, this.fullIndex.count);
 
     this.materials = {
       studio: new THREE.MeshStandardMaterial({
@@ -146,6 +159,19 @@ export class GNMScene extends xb.Script {
         polygonOffsetUnits: 1,
       }),
     };
+
+    // Textured mode. The map only covers the skin, so the mesh is drawn as two
+    // groups: skin with the texture, everything else with the studio palette.
+    // Registered only once a texture actually loads.
+    this.textureMaterial = new THREE.MeshStandardMaterial({
+      roughness: 0.62,
+      metalness: 0.0,
+      polygonOffset: true,
+      polygonOffsetFactor: 1,
+      polygonOffsetUnits: 1,
+    });
+    this.textureUrl = null;
+    this.textureLabel = 'Texture';
     this.mesh = new THREE.Mesh(geometry, this.materials.studio);
     this.mesh.frustumCulled = false;
     this.mesh.name = 'GNM Head';
@@ -246,12 +272,46 @@ export class GNMScene extends xb.Script {
     this._modelViewerHomeY = viewer.position.y;
   }
 
+  /** Maps a render vertex back to the model vertex it was split from. */
+  _sourceVertex(v) {
+    return this.model.hasUvs ? this.model.uvSource[v] : v;
+  }
+
+  /**
+   * Index buffer with every skin triangle first, then everything else, so the
+   * two can be drawn as separate groups. Sets _skinIndexCount to the split.
+   */
+  _buildIndex() {
+    const model = this.model;
+    const triangles = model.hasUvs ? model.uvTriangles : model.triangles;
+    const skin = [];
+    const rest = [];
+    for (let t = 0; t < triangles.length; t += 3) {
+      const target = model.materialId[this._sourceVertex(triangles[t])]
+        ? rest
+        : skin;
+      target.push(triangles[t], triangles[t + 1], triangles[t + 2]);
+    }
+    this._skinIndexCount = skin.length;
+    return Uint16Array.from(skin.concat(rest));
+  }
+
+  /** Declares the skin / non-skin draw groups for the textured mode. */
+  _applyGroups(skinCount, totalCount) {
+    this.geometry.clearGroups();
+    if (skinCount > 0) this.geometry.addGroup(0, skinCount, 0);
+    if (totalCount > skinCount) {
+      this.geometry.addGroup(skinCount, totalCount - skinCount, 1);
+    }
+  }
+
   _buildMaterialColors() {
     const model = this.model;
     const palette = MATERIAL_COLORS.map((c) => new THREE.Color(c));
-    const colors = new Float32Array(model.numVertices * 3);
-    for (let v = 0; v < model.numVertices; ++v) {
-      const color = palette[model.materialId[v]] ?? palette[0];
+    const colors = new Float32Array(model.numRenderVertices * 3);
+    for (let v = 0; v < model.numRenderVertices; ++v) {
+      const color =
+        palette[model.materialId[this._sourceVertex(v)]] ?? palette[0];
       colors[v * 3] = color.r;
       colors[v * 3 + 1] = color.g;
       colors[v * 3 + 2] = color.b;
@@ -267,9 +327,9 @@ export class GNMScene extends xb.Script {
       palette.push(new THREE.Color().setHSL((i * 0.61803) % 1, 0.62, 0.55));
     }
     const neutral = new THREE.Color('#6d6d70');
-    const colors = new Float32Array(model.numVertices * 3);
-    for (let v = 0; v < model.numVertices; ++v) {
-      const id = model.regionId[v];
+    const colors = new Float32Array(model.numRenderVertices * 3);
+    for (let v = 0; v < model.numRenderVertices; ++v) {
+      const id = model.regionId[this._sourceVertex(v)];
       const color = id === 255 ? neutral : palette[id];
       colors[v * 3] = color.r;
       colors[v * 3 + 1] = color.g;
@@ -302,6 +362,183 @@ export class GNMScene extends xb.Script {
     this.spatialUI?.setStatus(text);
   }
 
+  /** True once the model carries UVs and a texture has finished loading. */
+  canShowTexture() {
+    return this.model.hasUvs && !!this.textureMaterial.map;
+  }
+
+  /**
+   * Rebuilds the render buffers after UVs arrive from a sidecar.
+   *
+   * The seam splits make the mesh a few hundred vertices longer, so the
+   * position buffer is reallocated and the index, groups and vertex colors are
+   * rebuilt around it. The wireframe shares the position attribute and has to
+   * be repointed at the new one.
+   */
+  _rebuildForUvs() {
+    const model = this.model;
+    this.positionAttribute = new THREE.BufferAttribute(
+      new Float32Array(model.numRenderVertices * 3),
+      3
+    );
+    this.positionAttribute.setUsage(THREE.DynamicDrawUsage);
+    this.geometry.setAttribute('position', this.positionAttribute);
+    this.wireframe.geometry.setAttribute('position', this.positionAttribute);
+    this.geometry.setAttribute(
+      'uv',
+      new THREE.BufferAttribute(model.vertexUvs, 2)
+    );
+    // computeVertexNormals() reuses an existing normal attribute rather than
+    // growing it, so the one sized for the pre-seam mesh would leave the new
+    // duplicate vertices with no normal at all - a black line down every seam.
+    this.geometry.deleteAttribute('normal');
+    this.geometry.setAttribute(
+      'color',
+      new THREE.BufferAttribute(this._buildMaterialColors(), 3)
+    );
+    this._regionColors = null;
+    this.fullIndex = new THREE.BufferAttribute(this._buildIndex(), 1);
+    this.geometry.setIndex(this.fullIndex);
+    this._applyGroups(this._skinIndexCount, this.fullIndex.count);
+    // Reapply whatever component filtering was in effect.
+    const hidden = this.visibleComponents.findIndex((visible) => !visible);
+    if (hidden >= 0) this.setComponentVisible(hidden, false);
+    if (this.materialMode === 'regions') this.setMaterialMode('regions');
+    this.model.dirty = true;
+    this._refreshGeometry();
+  }
+
+  /**
+   * Makes sure the model has UVs, fetching the sidecar if the loaded container
+   * predates them. Returns false with a status message if it cannot.
+   */
+  async ensureUvs() {
+    if (this.model.hasUvs) return true;
+    const urls = this.uvSidecarUrls ?? [];
+    for (const url of urls) {
+      try {
+        if (await this.model.loadUvs(url)) {
+          this._rebuildForUvs();
+          return true;
+        }
+      } catch (error) {
+        console.warn(`No GNM UV data at ${url}:`, error.message);
+      }
+    }
+    this._emitStatus(
+      'No UV data for this head. Run tools/export_gnm_web.py to write ' +
+        'gnm_head_uvs.bin next to the demo assets.'
+    );
+    return false;
+  }
+
+  /**
+   * Gives the head her face as well as her skin.
+   *
+   * The sample portrait the face fitter already ships with is the same C2RMF
+   * scan the texture was painted from, so fitting to it lands her proportions
+   * and her expression under the matching texture. That needs the landmark
+   * tracker, which is a sizeable download and wants a face to be detectable,
+   * so the precomputed eye pose stays as the fallback.
+   *
+   * @return {!Promise<string>} 'fitted', 'posed', or 'none'.
+   */
+  async _applySkinLikeness() {
+    if (this.faceFitter) {
+      try {
+        this._emitStatus(`Fitting the head to ${SAMPLE_IMAGE.name}...`);
+        await this.faceFitter.fitImage(SAMPLE_IMAGE.url, SAMPLE_IMAGE.name);
+        return 'fitted';
+      } catch (error) {
+        console.warn(`Could not fit ${SAMPLE_IMAGE.name}:`, error.message);
+      }
+    }
+    return (await this._applySkinPose()) ? 'posed' : 'none';
+  }
+
+  /**
+   * Applies the expression that ships with the texture, if there is one.
+   *
+   * The painted likeness can only go so far: GNM's neutral eyes are round and
+   * wide, and the skin texture cannot cover the eyeballs, which are their own
+   * mesh. So the texture tool solves for a small expression that hoods the
+   * lids into almonds and writes it alongside the image. Identity and pose are
+   * left alone - this only touches the expression sliders, and Neutral undoes
+   * it.
+   */
+  async _applySkinPose() {
+    for (const url of this.skinPoseUrls ?? []) {
+      try {
+        const response = await fetch(url);
+        if (!response.ok) throw new Error(`${response.status}`);
+        const pose = await response.json();
+        const values = pose.expression;
+        if (!Array.isArray(values)) throw new Error('no expression vector');
+        if (values.length !== this.model.expressionDim) {
+          throw new Error(
+            `expression dim ${values.length} != ${this.model.expressionDim}`
+          );
+        }
+        this.model.setExpressionVector(values);
+        this.onModelChanged?.();
+        return true;
+      } catch (error) {
+        console.warn(`No GNM skin pose at ${url}:`, error.message);
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Loads the skin texture and registers the 'texture' material mode.
+   *
+   * Takes one URL or a list to try in order, and resolves to false with a
+   * status message rather than throwing, so the caller can just stay put.
+   */
+  async loadTexture(urls, label) {
+    if (!(await this.ensureUvs())) return false;
+    if (this.textureUrl && this.textureMaterial.map) return true;
+    const candidates = (Array.isArray(urls) ? urls : [urls]).filter(Boolean);
+    let lastError = null;
+    for (const url of candidates) {
+      try {
+        const texture = await new THREE.TextureLoader().loadAsync(url);
+        texture.colorSpace = THREE.SRGBColorSpace;
+        texture.flipY = true;
+        texture.anisotropy = 8;
+        // The atlas wraps horizontally: u=0 and u=1 are the same line down the
+        // back of the head. Repeating in s means a filter tap that falls off
+        // one edge fetches the texel that really does sit next to it on the
+        // head, instead of clamping and smearing the edge along the seam. v
+        // does not wrap - that would fold the neck onto the scalp.
+        texture.wrapS = THREE.RepeatWrapping;
+        texture.wrapT = THREE.ClampToEdgeWrapping;
+        this.textureMaterial.map?.dispose();
+        this.textureMaterial.map = texture;
+        this.textureMaterial.needsUpdate = true;
+        this.textureUrl = url;
+        if (label) this.textureLabel = label;
+        this.materials.texture = this.textureMaterial;
+        const likeness = await this._applySkinLikeness();
+        const suffix = {
+          fitted: ', fitted to the painting',
+          posed: ', with her eye shape',
+          none: '',
+        }[likeness];
+        this._emitStatus(`Loaded ${label ?? 'texture'}${suffix}.`);
+        return true;
+      } catch (error) {
+        lastError = error;
+        console.warn(`No GNM skin texture at ${url}:`, error.message);
+      }
+    }
+    this._emitStatus(
+      `Could not load ${label ?? 'the texture'}` +
+        `${lastError ? `: ${lastError.message}` : '.'}`
+    );
+    return false;
+  }
+
   setMaterialMode(mode) {
     if (!this.materials[mode]) return;
     this.materialMode = mode;
@@ -313,13 +550,19 @@ export class GNMScene extends xb.Script {
     }
     if (mode === 'regions') {
       this.geometry.setAttribute('color', this._regionColors);
-    } else if (mode === 'studio') {
+    } else if (mode === 'studio' || mode === 'texture') {
       this.geometry.setAttribute(
         'color',
         new THREE.BufferAttribute(this._buildMaterialColors(), 3)
       );
     }
-    this.mesh.material = this.materials[mode];
+    // An array material makes three honour the draw groups, so only the skin
+    // group samples the texture; a single material ignores them and covers the
+    // whole mesh, which is what every other mode wants.
+    this.mesh.material =
+      mode === 'texture'
+        ? [this.textureMaterial, this.materials.studio]
+        : this.materials[mode];
   }
 
   setWireframeVisible(visible) {
@@ -341,18 +584,25 @@ export class GNMScene extends xb.Script {
     const allVisible = this.visibleComponents.every(Boolean);
     if (allVisible) {
       this.geometry.setIndex(this.fullIndex);
+      this._applyGroups(this._skinIndexCount, this.fullIndex.count);
       return;
     }
-    const {triangles, componentId} = this.model;
-    const filtered = [];
-    for (let t = 0; t < triangles.length; t += 3) {
-      if (this.visibleComponents[componentId[triangles[t]]]) {
-        filtered.push(triangles[t], triangles[t + 1], triangles[t + 2]);
-      }
+    // Filter the ordered index in place, keeping skin ahead of the rest so the
+    // draw groups stay valid.
+    const index = this.fullIndex.array;
+    const {componentId, materialId} = this.model;
+    const skin = [];
+    const rest = [];
+    for (let t = 0; t < index.length; t += 3) {
+      const source = this._sourceVertex(index[t]);
+      if (!this.visibleComponents[componentId[source]]) continue;
+      const target = materialId[source] ? rest : skin;
+      target.push(index[t], index[t + 1], index[t + 2]);
     }
     this.geometry.setIndex(
-      new THREE.BufferAttribute(Uint16Array.from(filtered), 1)
+      new THREE.BufferAttribute(Uint16Array.from(skin.concat(rest)), 1)
     );
+    this._applyGroups(skin.length, skin.length + rest.length);
   }
 
   // ------------------------------------------------------------- sampling --
@@ -761,7 +1011,17 @@ export class GNMScene extends xb.Script {
     const start = performance.now();
     this.model.computeVertices(this.positionAttribute.array);
     this.positionAttribute.needsUpdate = true;
+    // Guard the same trap as above: a normal attribute left over from a
+    // smaller mesh is silently kept by computeVertexNormals, and the vertices
+    // past its end render black.
+    const stale = this.geometry.getAttribute('normal');
+    if (stale && stale.count !== this.positionAttribute.count) {
+      this.geometry.deleteAttribute('normal');
+    }
     this.geometry.computeVertexNormals();
+    const normals = this.geometry.getAttribute('normal');
+    this.model.weldSeamNormals(normals.array);
+    normals.needsUpdate = true;
     this.geometry.boundingSphere = null;
     if (this.landmarkMesh.visible) this._updateLandmarks();
     if (this.skeletonGroup.visible) this._updateSkeleton();

--- a/samples/avatar_lab/gnm/GNMSpatialUI.js
+++ b/samples/avatar_lab/gnm/GNMSpatialUI.js
@@ -311,14 +311,25 @@ export class GNMSpatialUI {
 
     const scene = this.scene;
     const modeRow = this.row(card, {gap: 8});
-    for (const [mode, label] of [
+    const modes = [
       ['studio', 'Studio'],
       ['clay', 'Clay'],
       ['normals', 'Normals'],
       ['regions', 'Regions'],
-    ]) {
+    ];
+    modes.push(['texture', 'Mona Lisa']);
+    for (const [mode, label] of modes) {
       const button = this.button(modeRow, label, {
-        onClick: () => {
+        onClick: async () => {
+          if (mode === 'texture' && !scene.canShowTexture()) {
+            button.setLabel('Loading…');
+            const loaded = await scene.loadTexture(
+              scene.skinTextureUrls,
+              'Mona Lisa'
+            );
+            button.setLabel(label);
+            if (!loaded) return;
+          }
           scene.setMaterialMode(mode);
           this.update();
         },

--- a/samples/avatar_lab/gnm/README.md
+++ b/samples/avatar_lab/gnm/README.md
@@ -8,5 +8,30 @@ Introduces a purely browser-based demonstration for the Generative aNthropometri
 - Core WebGL/JS components: GNMModel, GNMControls, GNMScene, and SemanticSampler to handle model logic, rendering, and interactions.
 - Demo web application structure: index.html, main.js, and CSS files.
 - Python export utility (tools/export_gnm_web.py) to convert GNM weights into web-optimized binary formats.
+- Python texture utility (tools/gnm_texture_from_photo.py) to paint a GNM skin texture from a reference photo with Nano Banana 2, conditioned on UV guides baked out of the GNM mesh. Skin and hair are generated as separate passes and composited through a scalp mask taken from the mesh, so the hairline lands where the geometry says rather than where the image model would put it. Reads the Gemini key from `keys.json` at the repository root.
+
+## Textured heads
+
+View → Material has a **Mona Lisa** button that paints her skin onto the head and fits the head to her, in the browser and in XR. It also fits the geometry: the portrait the face fitter already ships with is the same C2RMF scan the texture was painted from, so pressing the button runs a fit against it and the head arrives with her proportions, expression and head turn under the matching texture. Nothing is downloaded until it is pressed.
+
+The texture, the UV sidecar and the pose file all come from the same CDN as the model, so it works on the plain URL. `?localAssets=1` switches every asset to the sample's `assets/` folder, which is how to try a texture you have just generated:
+
+```bash
+python demos/gnm/tools/export_gnm_web.py --out_dir=samples/avatar_lab/gnm/assets
+```
+
+```bash
+python demos/gnm/tools/gnm_texture_from_photo.py --out=samples/avatar_lab/gnm/assets/gnm_skin_mona_lisa.png
+```
+
+If an asset is missing the button says so in the status line rather than doing nothing. If the landmark tracker cannot load or finds no face, the fit is skipped and the precomputed eye pose is applied instead, so the eyes still read as hers.
+
+The exporter writes UVs into `gnm_head_web.bin` and also, separately, into a 0.4 MB `gnm_head_uvs.bin`. The sidecar exists because the published model container predates UVs: the viewer keeps using the 35 MB container and pulls the sidecar in on demand, so texturing can ship without re-uploading the model.
+
+The tool also solves for a small expression that hoods the eyes into almonds and writes it beside the texture as `_pose.json`, which the demo applies when the texture loads (`--eye_narrow`, default 8%). The painted likeness cannot do this on its own: GNM's neutral eyes are round and wide, and the skin texture can't cover the eyeballs because they are a separate mesh with their own UV square. GNM's expression basis is per-region PCA rather than named blendshapes, so there is no lid slider either — but the eye aperture is linear in the coefficients, so its gradient over the eye-region components is the cheapest direction that closes the lid. Only the expression is touched; identity and pose are left alone, and Neutral undoes it.
+
+Two things the image model will not do reliably, so the tool does them itself. It puts the hairline wherever a portrait would put it, ignoring the layout, which renders as a bald head — so hair is generated as its own square and composited through a scalp mask taken from the mesh (`--hairline`, `--temple_drop`; higher hairline and lower temple drop mean more forehead). And it drifts toward a neutral, pinker complexion than the reference — so the reference's lit skin is measured, quoted into the prompt as hex targets, and the painted result is then pulled onto it per channel (`--tone`). It also paints a lit face, bright down the middle and falling away at the temples, which doubles up with the renderer's own shading and turns the sides of the head muddy; `--deshade` divides that low-frequency luminance back out and leaves the pores and craquelure alone.
+
+GNM gives every mesh component its own 0..1 UV square, so the texture covers the `skin` component only; the eyes, teeth and tongue keep their per-vertex colors, drawn as a second geometry group. Vertices on a UV seam carry more than one texture coordinate, so the exporter splits them into extra render vertices (616 of them for the v3.0 head) that copy their position from the vertex they came from — the model itself, its skinning, the landmarks and the wireframe are all untouched.
 
 The webcam tracking part is ported from [GNM Webcam Puppet](https://github.com/edualvarado/gnm-webcam-puppet) by Eduardo Alvarado.

--- a/samples/avatar_lab/gnm/gnm.css
+++ b/samples/avatar_lab/gnm/gnm.css
@@ -153,8 +153,19 @@
   text-transform: none;
 }
 
-.gnm-btn:hover {
+.gnm-btn:hover:not(:disabled) {
   background: rgba(79, 140, 224, 0.34);
+}
+
+/* A button that cannot act has to look like it. */
+.gnm-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.gnm-btn.busy {
+  opacity: 0.7;
+  cursor: progress;
 }
 
 .gnm-btn.active {

--- a/samples/avatar_lab/gnm/main.js
+++ b/samples/avatar_lab/gnm/main.js
@@ -8,7 +8,7 @@ import {GNMSamplers} from './SemanticSampler.js';
 import {GNMSpatialUI} from './GNMSpatialUI.js';
 
 const CDN_ASSETS_BASE =
-  'https://rawcdn.githack.com/xrblocks/assets-gnm/8480138a42ae746a2f7c9808a51ef23af7648653';
+  'https://rawcdn.githack.com/xrblocks/assets-gnm/35ab2adcfd38ebc8741b89c8fa96b19e39076cf8';
 const LOCAL_ASSETS_BASE = './assets';
 const USE_LOCAL_ASSETS = false;
 
@@ -16,6 +16,13 @@ const useLocalAssets = xb.getUrlParamBool('localAssets', USE_LOCAL_ASSETS);
 const assetsBase = useLocalAssets ? LOCAL_ASSETS_BASE : CDN_ASSETS_BASE;
 const headModelUrl = `${assetsBase}/gnm_head_web.bin`;
 const samplersUrl = `${assetsBase}/gnm_samplers_web.bin`;
+// Texturing assets, fetched only when the Mona Lisa button is first pressed.
+const skinTextureUrls = [`${assetsBase}/gnm_skin_mona_lisa.png`];
+// The head container predates UVs; this sidecar adds them for ~400 kB instead
+// of re-downloading the 35 MB model.
+const uvSidecarUrls = [`${assetsBase}/gnm_head_uvs.bin`];
+// Her hooded eye shape, used only when fitting to the painting is unavailable.
+const skinPoseUrls = [`${assetsBase}/gnm_skin_mona_lisa_pose.json`];
 
 function setLoadingProgress(fraction, label) {
   const bar = document.querySelector('#gnm-loading .bar div');
@@ -47,6 +54,9 @@ async function start() {
     setLoadingProgress(1, 'Starting XR Blocks…');
 
     const scene = new GNMScene(model, samplers);
+    scene.skinTextureUrls = skinTextureUrls;
+    scene.uvSidecarUrls = uvSidecarUrls;
+    scene.skinPoseUrls = skinPoseUrls;
     scene.spatialUI = new GNMSpatialUI(scene);
     xb.add(scene);
 


### PR DESCRIPTION
# GNM UV Texture - Mona Lisa

## Description

Added uv texture mapping for GNM Head demo and a Mona Lisa texture generated with Nano Banana.

It's not the perfect mapping and could be improved by external contributors!

## Type of Change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

- **Simulator Recording**: 
<img width="1276" height="890" alt="monalisa" src="https://github.com/user-attachments/assets/ab133a15-caea-4506-92f1-03f6ad6ccdc4" />

## Checklist

- [x] **Tested in simulator only**: Verified functionality in desktop simulator and/or physical hardware (where applicable).
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.
