### PR TITLE
Update simulator hands mode with Left Shift navigation and Right Click Look around

### DIFF
--- a/src/simulator/controlModes/SimulatorControlMode.ts
+++ b/src/simulator/controlModes/SimulatorControlMode.ts
@@ -164,7 +164,7 @@ export class SimulatorControlMode {
     }
   }
 
-  private applyYawRelativeMovement(
+  protected applyYawRelativeMovement(
     localX: number,
     localY: number,
     localZ: number,

--- a/src/simulator/controlModes/SimulatorControllerMode.test.ts
+++ b/src/simulator/controlModes/SimulatorControllerMode.test.ts
@@ -1,0 +1,195 @@
+import * as THREE from 'three';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {GamepadController} from '../../input/GamepadController';
+import {Input} from '../../input/Input';
+import {Keycodes} from '../../utils/Keycodes';
+import {SimulatorControllerState} from '../SimulatorControllerState';
+import {SimulatorHands} from '../SimulatorHands';
+import {SimulatorOptions} from '../SimulatorOptions';
+import {SimulatorNavMesh} from '../internal/navmesh/SimulatorNavMesh';
+import {SimulatorControllerMode} from './SimulatorControllerMode';
+
+describe('SimulatorControllerMode', () => {
+  let camera: THREE.Camera;
+  let controllerState: SimulatorControllerState;
+  let downKeys: Set<Keycodes>;
+  let hands: SimulatorHands;
+  let input: Input;
+  let mode: SimulatorControllerMode;
+  let navMesh: SimulatorNavMesh;
+  let simulatorOptions: SimulatorOptions;
+  let timer: THREE.Timer;
+
+  beforeEach(() => {
+    camera = new THREE.Camera();
+    camera.position.set(0, 1.5, 0);
+    camera.quaternion.identity();
+
+    controllerState = new SimulatorControllerState();
+    controllerState.currentControllerIndex = 0;
+    controllerState.localControllerPositions[0].set(0.2, -0.2, -0.5);
+    controllerState.localControllerPositions[1].set(-0.2, -0.2, -0.5);
+    controllerState.localControllerOrientations[0].identity();
+    controllerState.localControllerOrientations[1].identity();
+
+    downKeys = new Set<Keycodes>();
+
+    hands = {
+      showHands: vi.fn(),
+      hideHands: vi.fn(),
+      toggleHandedness: vi.fn(),
+      setLeftHandPinching: vi.fn(),
+      setRightHandPinching: vi.fn(),
+      leftController: new THREE.Object3D(),
+      rightController: new THREE.Object3D(),
+    } as unknown as SimulatorHands;
+
+    const gamepadController = {
+      init: vi.fn(),
+      update: vi.fn(),
+      userData: {connected: false},
+      menuActive: false,
+    } as unknown as GamepadController;
+
+    input = {
+      controllers: [
+        new THREE.Object3D() as THREE.XRTargetRaySpace,
+        new THREE.Object3D() as THREE.XRTargetRaySpace,
+      ],
+      gamepadController,
+      dispatchEvent: vi.fn(),
+    } as unknown as Input;
+
+    navMesh = new SimulatorNavMesh();
+    simulatorOptions = new SimulatorOptions();
+
+    timer = {
+      getDelta: vi.fn().mockReturnValue(1.0),
+    } as unknown as THREE.Timer;
+
+    mode = new SimulatorControllerMode(
+      controllerState,
+      downKeys,
+      hands,
+      navMesh,
+      vi.fn(),
+      vi.fn()
+    );
+
+    mode.init({
+      camera,
+      input,
+      timer,
+      simulatorOptions,
+    });
+  });
+
+  describe('Left Shift + WASD movement', () => {
+    it('moves camera and does not move hand when Left Shift + W is pressed without modeToggle conflict', () => {
+      downKeys.add(Keycodes.LEFT_SHIFT_CODE);
+      downKeys.add(Keycodes.W_CODE);
+
+      const initialHandPos =
+        controllerState.localControllerPositions[0].clone();
+      const initialCameraZ = camera.position.z;
+
+      mode.update();
+
+      // Camera should have moved forward (-Z in yaw relative movement)
+      expect(camera.position.z).toBeLessThan(initialCameraZ);
+      // Hand local position relative to camera should not change
+      expect(controllerState.localControllerPositions[0]).toEqual(
+        initialHandPos
+      );
+    });
+
+    it('moves hand and does not move camera when Left Shift + W conflicts with modeToggle', () => {
+      simulatorOptions.modeToggle.enabled = true;
+      simulatorOptions.modeToggle.toggleKey = Keycodes.LEFT_SHIFT_CODE;
+
+      downKeys.add(Keycodes.LEFT_SHIFT_CODE);
+      downKeys.add(Keycodes.W_CODE);
+
+      const initialCameraZ = camera.position.z;
+      const initialHandZ = controllerState.localControllerPositions[0].z;
+
+      mode.update();
+
+      // Camera should not move because Left Shift is reserved for modeToggle
+      expect(camera.position.z).toBe(initialCameraZ);
+      // Hand should move forward (-Z)
+      expect(controllerState.localControllerPositions[0].z).toBeLessThan(
+        initialHandZ
+      );
+    });
+
+    it('moves hand and does not move camera when W is pressed without Left Shift', () => {
+      downKeys.add(Keycodes.W_CODE);
+
+      const initialCameraZ = camera.position.z;
+      const initialHandZ = controllerState.localControllerPositions[0].z;
+
+      mode.update();
+
+      expect(camera.position.z).toBe(initialCameraZ);
+      expect(controllerState.localControllerPositions[0].z).toBeLessThan(
+        initialHandZ
+      );
+    });
+  });
+
+  describe('Mouse pointer controls', () => {
+    it('rotates camera on right mouse button drag (buttons & 2)', () => {
+      const initialCameraRot = camera.quaternion.clone();
+      const initialHandRot =
+        controllerState.localControllerOrientations[0].clone();
+
+      const event = new MouseEvent('pointermove', {
+        movementX: 10,
+        movementY: 5,
+      });
+      Object.defineProperty(event, 'buttons', {value: 2});
+
+      mode.onPointerMove(event);
+
+      expect(camera.quaternion.equals(initialCameraRot)).toBe(false);
+      expect(
+        controllerState.localControllerOrientations[0].equals(initialHandRot)
+      ).toBe(true);
+    });
+
+    it('rotates active hand orientation on left mouse button drag (buttons & 1)', () => {
+      const initialCameraRot = camera.quaternion.clone();
+      const initialHandRot =
+        controllerState.localControllerOrientations[0].clone();
+
+      const event = new MouseEvent('pointermove', {
+        movementX: 10,
+        movementY: 5,
+      });
+      Object.defineProperty(event, 'buttons', {value: 1});
+
+      mode.onPointerMove(event);
+
+      expect(camera.quaternion.equals(initialCameraRot)).toBe(true);
+      expect(
+        controllerState.localControllerOrientations[0].equals(initialHandRot)
+      ).toBe(false);
+    });
+  });
+
+  describe('Key actions', () => {
+    it('toggles active hand on T key', () => {
+      const event = new KeyboardEvent('keydown', {code: Keycodes.T_CODE});
+      mode.onKeyDown(event);
+      expect(hands.toggleHandedness).toHaveBeenCalled();
+    });
+
+    it('toggles pinch on Space key', () => {
+      const event = new KeyboardEvent('keydown', {code: Keycodes.SPACE_CODE});
+      mode.onKeyDown(event);
+      expect(hands.setLeftHandPinching).toHaveBeenCalledWith(true);
+    });
+  });
+});

--- a/src/simulator/controlModes/SimulatorControllerMode.ts
+++ b/src/simulator/controlModes/SimulatorControllerMode.ts
@@ -5,12 +5,30 @@ import {Keycodes} from '../../utils/Keycodes';
 import {SimulatorControlMode} from './SimulatorControlMode';
 
 const vector3 = new THREE.Vector3();
-const {A_CODE, D_CODE, E_CODE, Q_CODE, S_CODE, SPACE_CODE, T_CODE, W_CODE} =
-  Keycodes;
+const {
+  A_CODE,
+  D_CODE,
+  E_CODE,
+  LEFT_SHIFT_CODE,
+  Q_CODE,
+  S_CODE,
+  SPACE_CODE,
+  T_CODE,
+  W_CODE,
+} = Keycodes;
 
 export class SimulatorControllerMode extends SimulatorControlMode {
-  onPointerMove(event: MouseEvent) {
-    if (event.buttons) {
+  private isLeftShiftMovementActive(): boolean {
+    const modeToggle = this.simulatorOptions?.modeToggle;
+    const hasConflict =
+      Boolean(modeToggle?.enabled) && modeToggle?.toggleKey === LEFT_SHIFT_CODE;
+    return !hasConflict && this.downKeys.has(LEFT_SHIFT_CODE);
+  }
+
+  override onPointerMove(event: MouseEvent) {
+    if (event.buttons & 2) {
+      this.rotateOnPointerMove(event, this.camera.quaternion);
+    } else if (event.buttons & 1) {
       const controllerOrientation =
         this.simulatorControllerState.localControllerOrientations[
           this.simulatorControllerState.currentControllerIndex
@@ -21,28 +39,47 @@ export class SimulatorControllerMode extends SimulatorControlMode {
 
   override update() {
     this.updateGamepad();
+    this.updateCameraPosition();
     this.updateControllerPositions();
+  }
+
+  override updateCameraPosition() {
+    if (!this.isLeftShiftMovementActive()) return;
+
+    const deltaTime = this.timer.getDelta();
+    const downKeys = this.downKeys;
+    this.applyYawRelativeMovement(
+      Number(downKeys.has(D_CODE)) - Number(downKeys.has(A_CODE)),
+      this.navMesh.constrained
+        ? 0
+        : Number(downKeys.has(Q_CODE)) - Number(downKeys.has(E_CODE)),
+      Number(downKeys.has(S_CODE)) - Number(downKeys.has(W_CODE)),
+      deltaTime
+    );
   }
 
   onModeActivated() {
     this.enableSimulatorHands();
   }
 
-  updateControllerPositions() {
+  override updateControllerPositions() {
     const deltaTime = this.timer.getDelta();
     const downKeys = this.downKeys;
     const idx = this.simulatorControllerState.currentControllerIndex;
     const localPos =
       this.simulatorControllerState.localControllerPositions[idx];
-    vector3
-      .set(
-        Number(downKeys.has(D_CODE)) - Number(downKeys.has(A_CODE)),
-        Number(downKeys.has(Q_CODE)) - Number(downKeys.has(E_CODE)),
-        Number(downKeys.has(S_CODE)) - Number(downKeys.has(W_CODE))
-      )
-      .multiplyScalar(deltaTime);
-    this.limitMovementAtReachEdge(idx, localPos, vector3);
-    localPos.add(vector3);
+
+    if (!this.isLeftShiftMovementActive()) {
+      vector3
+        .set(
+          Number(downKeys.has(D_CODE)) - Number(downKeys.has(A_CODE)),
+          Number(downKeys.has(Q_CODE)) - Number(downKeys.has(E_CODE)),
+          Number(downKeys.has(S_CODE)) - Number(downKeys.has(W_CODE))
+        )
+        .multiplyScalar(deltaTime);
+      this.limitMovementAtReachEdge(idx, localPos, vector3);
+      localPos.add(vector3);
+    }
 
     // Gamepad: left stick moves hand on XZ; configurable buttons on Y.
     // Skip when the tab isn't focused so background tabs don't react to

--- a/src/simulator/internal/interface/instructions/HandsInstructions.ts
+++ b/src/simulator/internal/interface/instructions/HandsInstructions.ts
@@ -24,15 +24,17 @@ export class HandsInstructions extends SimulatorInstructionsCard {
     return html`
       <h2>Hands Mode</h2>
       <p>
-        From Navigation Mode, press <strong>Left Shift</strong> to enter
-        <strong>Hands Mode</strong>. This mode allows for precise manipulation
-        of virtual hands.
+        Hands Mode allows for precise manipulation of virtual hands while
+        navigating the environment.
       </p>
       <ul>
         <li>
-          <strong>Move Hand:</strong> Use the W, A, S, D keys to move it
-          forward, left, backward, and right.
+          <strong>Move Around:</strong> Hold Left Shift and use the W, A, S, D
+          keys to navigate.
         </li>
+        <li><strong>Look Around:</strong> Right-click and drag the mouse.</li>
+        <li><strong>Rotate Hand:</strong> Left-click and drag the mouse.</li>
+        <li><strong>Move Hand:</strong> Use the W, A, S, D keys.</li>
         <li>
           <strong>Elevate Hand:</strong> Use the Q (up) and E (down) keys.
         </li>


### PR DESCRIPTION

## Description

- Allow moving around with Left Shift + WASD in Hands mode (SimulatorControllerMode), provided Left Shift does not conflict with modeToggle.
- Allow looking around with Right Mouse Click + Drag in Hands mode, while preserving Left Mouse Click + Drag to rotate the active virtual hand.
- Update in-browser Hands Mode instruction modal to reflect new controls.
- Add colocated unit tests in SimulatorControllerMode.test.ts.

## Type of Change

- [x] New feature / enhancement

## Media / Screen Recordings & Screenshots (If Applicable)


https://github.com/user-attachments/assets/9fca3af2-df3f-4d57-ba85-856aa0f6a8f2



## Checklist

- [x] **Tested in simulator & device**: Verified functionality in desktop simulator and/or physical hardware (where applicable).
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.
