### PR TITLE
fix: support wrist-driven X/Z rotation

### DIFF
--- a/src/interaction/manipulation/drivers/RotateDriver.test.ts
+++ b/src/interaction/manipulation/drivers/RotateDriver.test.ts
@@ -1,0 +1,173 @@
+import * as THREE from 'three';
+import {describe, expect, it} from 'vitest';
+
+import type {ManipulationDriverSession} from './DriverTypes';
+import type {RotateOptions} from '../ManipulationTypes';
+import type {InteractionSourceState, SelectionCapture} from '../../InteractionTypes';
+import {RotateDriver} from './RotateDriver';
+
+describe('RotateDriver', () => {
+  function createSession(
+    options: Partial<RotateOptions> = {},
+    sourceType: 'controller' | 'mouse' = 'controller'
+  ): ManipulationDriverSession {
+    const owner = new THREE.Object3D();
+    return {
+      owner,
+      config: {rotate: {sensitivity: 10, space: 'world', ...options}},
+      primary: {
+        capture: {} as unknown as SelectionCapture,
+        snapshot: {
+          sourceType,
+          selected: true,
+          position: new THREE.Vector3(),
+          orientation: new THREE.Quaternion(),
+        } as unknown as InteractionSourceState,
+      },
+    };
+  }
+
+  it('proposes zero angle when delta is zero', () => {
+    const driver = new RotateDriver();
+    const session = createSession({axis: 'x', sensitivity: 10});
+    const baseline = driver.capture(session)!;
+    const proposal = driver.propose(session, baseline);
+    expect(proposal?.angle).toBe(0);
+  });
+
+  it('ignores wrist-only rotation for Y-axis, keeping translation behavior unchanged', () => {
+    const driver = new RotateDriver();
+    const session = createSession({axis: 'y', sensitivity: 2});
+    const baseline = driver.capture(session)!;
+
+    session.primary.snapshot.orientation.setFromAxisAngle(
+      new THREE.Vector3(0, 1, 0),
+      0.5
+    );
+    let proposal = driver.propose(session, baseline);
+    expect(proposal?.angle).toBe(0);
+
+    session.primary.snapshot.position.x = 0.5;
+    proposal = driver.propose(session, baseline);
+    expect(proposal?.angle).toBeCloseTo(1.0);
+  });
+
+  it('drives X-axis rotation using wrist orientation (positive and negative)', () => {
+    const driver = new RotateDriver();
+    const session = createSession({axis: 'x', sensitivity: 1});
+    const baseline = driver.capture(session)!;
+
+    session.primary.snapshot.orientation.setFromAxisAngle(
+      new THREE.Vector3(1, 0, 0),
+      Math.PI / 4
+    );
+    let proposal = driver.propose(session, baseline);
+    expect(proposal?.angle).toBeCloseTo(Math.PI / 4);
+
+    session.primary.snapshot.orientation.setFromAxisAngle(
+      new THREE.Vector3(1, 0, 0),
+      -Math.PI / 6
+    );
+    proposal = driver.propose(session, baseline);
+    expect(proposal?.angle).toBeCloseTo(-Math.PI / 6);
+  });
+
+  it('extracts target-axis twist correctly even when combined with orthogonal swing', () => {
+    const driver = new RotateDriver();
+    const session = createSession({axis: 'x', sensitivity: 1});
+    const baseline = driver.capture(session)!;
+
+    const twist = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), Math.PI / 4);
+    const swing = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), Math.PI / 3);
+    
+    session.primary.snapshot.orientation.copy(swing).multiply(twist);
+    
+    const proposal = driver.propose(session, baseline);
+    expect(proposal?.angle).toBeCloseTo(Math.PI / 4);
+  });
+
+  it('wraps twist angle to take the shortest path around 180 degrees', () => {
+    const driver = new RotateDriver();
+    const session = createSession({axis: 'x', sensitivity: 1});
+    const baseline = driver.capture(session)!;
+
+    const angle179 = (179 * Math.PI) / 180;
+    session.primary.snapshot.orientation.setFromAxisAngle(
+      new THREE.Vector3(1, 0, 0),
+      angle179
+    );
+    let proposal = driver.propose(session, baseline);
+    expect(proposal?.angle).toBeCloseTo(angle179);
+
+    session.primary.snapshot.orientation.setFromAxisAngle(
+      new THREE.Vector3(1, 0, 0),
+      Math.PI
+    );
+    proposal = driver.propose(session, baseline);
+    expect(Math.abs(proposal?.angle ?? 0)).toBeCloseTo(Math.PI);
+
+    const angle181 = (181 * Math.PI) / 180;
+    session.primary.snapshot.orientation.setFromAxisAngle(
+      new THREE.Vector3(1, 0, 0),
+      angle181
+    );
+    proposal = driver.propose(session, baseline);
+    expect(proposal?.angle).toBeCloseTo(angle181 - 2 * Math.PI);
+  });
+
+  it('drives Z-axis rotation using wrist orientation', () => {
+    const driver = new RotateDriver();
+    const session = createSession({axis: 'z', sensitivity: 1});
+    const baseline = driver.capture(session)!;
+
+    session.primary.snapshot.orientation.setFromAxisAngle(
+      new THREE.Vector3(0, 0, 1),
+      Math.PI / 3
+    );
+    const proposal = driver.propose(session, baseline);
+    expect(proposal?.angle).toBeCloseTo(Math.PI / 3);
+  });
+
+  it('ignores wrist-only rotation for arbitrary custom axes', () => {
+    const driver = new RotateDriver();
+    const axis = new THREE.Vector3(1, 1, 0).normalize();
+    const session = createSession({axis, sensitivity: 2});
+    const baseline = driver.capture(session)!;
+
+    session.primary.snapshot.orientation.setFromAxisAngle(axis, 0.5);
+    let proposal = driver.propose(session, baseline);
+    expect(proposal?.angle).toBe(0);
+
+    session.primary.snapshot.position.x = 0.5;
+    proposal = driver.propose(session, baseline);
+    expect(proposal?.angle).toBeCloseTo(1.0);
+  });
+
+  it('correctly maps wrist orientation to a local-space rotated frame', () => {
+    const driver = new RotateDriver();
+    const session = createSession({axis: 'x', space: 'local', sensitivity: 1});
+    session.owner.quaternion.setFromAxisAngle(new THREE.Vector3(0, 1, 0), Math.PI / 2);
+    session.owner.updateMatrixWorld(true);
+
+    const baseline = driver.capture(session)!;
+
+    session.primary.snapshot.orientation.setFromAxisAngle(
+      new THREE.Vector3(0, 0, -1),
+      Math.PI / 5
+    );
+    const proposal = driver.propose(session, baseline);
+    expect(proposal?.angle).toBeCloseTo(Math.PI / 5);
+  });
+
+  it('preserves existing mouse behavior', () => {
+    const driver = new RotateDriver();
+    const session = createSession({axis: 'x', sensitivity: 2}, 'mouse');
+    const baseline = driver.capture(session)!;
+
+    session.primary.snapshot.orientation.setFromEuler(
+      new THREE.Euler(0.5, 0.3, 0.1, 'YXZ')
+    );
+    const proposal = driver.propose(session, baseline);
+    expect(proposal?.angle).toBeCloseTo(-0.3 * 2);
+  });
+});

--- a/src/interaction/manipulation/drivers/RotateDriver.test.ts
+++ b/src/interaction/manipulation/drivers/RotateDriver.test.ts
@@ -3,7 +3,10 @@ import {describe, expect, it} from 'vitest';
 
 import type {ManipulationDriverSession} from './DriverTypes';
 import type {RotateOptions} from '../ManipulationTypes';
-import type {InteractionSourceState, SelectionCapture} from '../../InteractionTypes';
+import type {
+  InteractionSourceState,
+  SelectionCapture,
+} from '../../InteractionTypes';
 import {RotateDriver} from './RotateDriver';
 
 describe('RotateDriver', () => {
@@ -77,11 +80,17 @@ describe('RotateDriver', () => {
     const session = createSession({axis: 'x', sensitivity: 1});
     const baseline = driver.capture(session)!;
 
-    const twist = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), Math.PI / 4);
-    const swing = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), Math.PI / 3);
-    
+    const twist = new THREE.Quaternion().setFromAxisAngle(
+      new THREE.Vector3(1, 0, 0),
+      Math.PI / 4
+    );
+    const swing = new THREE.Quaternion().setFromAxisAngle(
+      new THREE.Vector3(0, 1, 0),
+      Math.PI / 3
+    );
+
     session.primary.snapshot.orientation.copy(swing).multiply(twist);
-    
+
     const proposal = driver.propose(session, baseline);
     expect(proposal?.angle).toBeCloseTo(Math.PI / 4);
   });
@@ -146,7 +155,10 @@ describe('RotateDriver', () => {
   it('correctly maps wrist orientation to a local-space rotated frame', () => {
     const driver = new RotateDriver();
     const session = createSession({axis: 'x', space: 'local', sensitivity: 1});
-    session.owner.quaternion.setFromAxisAngle(new THREE.Vector3(0, 1, 0), Math.PI / 2);
+    session.owner.quaternion.setFromAxisAngle(
+      new THREE.Vector3(0, 1, 0),
+      Math.PI / 2
+    );
     session.owner.updateMatrixWorld(true);
 
     const baseline = driver.capture(session)!;

--- a/src/interaction/manipulation/drivers/RotateDriver.ts
+++ b/src/interaction/manipulation/drivers/RotateDriver.ts
@@ -46,8 +46,10 @@ export class RotateDriver implements ManipulationDriver<RotateBaseline> {
         -new THREE.Euler().setFromQuaternion(deltaRotation, 'YXZ').y *
         baseline.options.sensitivity;
     } else {
-      const isX = baseline.axis.x === 1 || baseline.axis.x === -1;
-      const isZ = baseline.axis.z === 1 || baseline.axis.z === -1;
+      // Wrist rotation drives X and Z axes (pitch and roll).
+      // For Y-axis (turntable) and arbitrary custom axes, retain translation-driven sliding.
+      const isX = Math.abs(Math.abs(baseline.axis.x) - 1) < 1e-4;
+      const isZ = Math.abs(Math.abs(baseline.axis.z) - 1) < 1e-4;
       if (isX || isZ) {
         const worldAxis =
           baseline.options.space === 'local'

--- a/src/interaction/manipulation/drivers/RotateDriver.ts
+++ b/src/interaction/manipulation/drivers/RotateDriver.ts
@@ -46,11 +46,37 @@ export class RotateDriver implements ManipulationDriver<RotateBaseline> {
         -new THREE.Euler().setFromQuaternion(deltaRotation, 'YXZ').y *
         baseline.options.sensitivity;
     } else {
-      const localDelta = snapshot.position
-        .clone()
-        .sub(baseline.sourcePosition)
-        .applyQuaternion(baseline.sourceOrientationInverse);
-      angle = localDelta.x * baseline.options.sensitivity;
+      const isX = baseline.axis.x === 1 || baseline.axis.x === -1;
+      const isZ = baseline.axis.z === 1 || baseline.axis.z === -1;
+      if (isX || isZ) {
+        const worldAxis =
+          baseline.options.space === 'local'
+            ? baseline.axis.clone().applyQuaternion(baseline.worldQuaternion)
+            : baseline.axis;
+
+        const deltaRotation = snapshot.orientation
+          .clone()
+          .multiply(baseline.sourceOrientationInverse);
+
+        let twistDot =
+          deltaRotation.x * worldAxis.x +
+          deltaRotation.y * worldAxis.y +
+          deltaRotation.z * worldAxis.z;
+        let twistW = deltaRotation.w;
+
+        if (twistW < 0) {
+          twistDot = -twistDot;
+          twistW = -twistW;
+        }
+
+        angle = 2 * Math.atan2(twistDot, twistW) * baseline.options.sensitivity;
+      } else {
+        const localDelta = snapshot.position
+          .clone()
+          .sub(baseline.sourcePosition)
+          .applyQuaternion(baseline.sourceOrientationInverse);
+        angle = localDelta.x * baseline.options.sensitivity;
+      }
     }
     const offset = new THREE.Quaternion().setFromAxisAngle(
       baseline.axis,


### PR DESCRIPTION
## Description

Fixes #558 by allowing XR controller/hand wrist rotation to drive X/Z-axis rotations instead of relying on horizontal translation.

For Y-axis and arbitrary custom axes, the existing translation-driven behavior is preserved unchanged. The wrist rotation is projected into the configured local/world rotation axis, including rotated local-space frames.

Focused tests cover X/Z wrist rotation, swing + twist extraction, shortest-path wrapping around 180°, Y/custom-axis regressions, local-space rotation, and existing mouse behavior.

## Type of Change

* [x] Bug fix
* [x] New feature / enhancement
* [ ] New demo or sample
* [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

* **Simulator Recording**: Not provided
* **Device Recording**: Not provided

## Checklist

* [ ] **Tested in simulator & device**: Unit tests verified; not tested on physical XR device.
* [ ] **Large Assets ($\ge$ 1MB)**: No large assets added.
* [ ] **SDK Dynamic Dependencies**: No new SDK dependencies.
* [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.

## Test

### Before and after commit comparison cmd.

```powershell
$ErrorActionPreference='Stop'; $repo="$env:TEMP\xrblocks-review"; if(Test-Path "$repo\.git"){Remove-Item -Recurse -Force $repo}; git clone -q https://github.com/google/xrblocks.git $repo; Set-Location $repo; git remote add fork https://github.com/su-jin1425/xrblocks.git; git fetch -q --no-tags fork fix-rotate-driver-wrist-x-axis; npm ci --silent 2>$null | Out-Null; $repro=@'
import * as THREE from "three";
import {expect,it} from "vitest";
import {RotateDriver} from "./RotateDriver";

const createSession=()=>({
  owner:new THREE.Object3D(),
  config:{rotate:{axis:"x",sensitivity:1,space:"world"}},
  primary:{
    capture:{} as any,
    snapshot:{
      sourceType:"controller",
      selected:true,
      position:new THREE.Vector3(),
      orientation:new THREE.Quaternion()
    } as any
  }
});

it("#558: wrist X rotation drives rotation",()=>{
  const d=new RotateDriver();
  const s=createSession();
  const b=d.capture(s)!;
  s.primary.snapshot.orientation.setFromAxisAngle(new THREE.Vector3(1,0,0),Math.PI/4);
  expect(d.propose(s,b)?.angle).toBeCloseTo(Math.PI/4);
});
'@; $test="$repo\src\interaction\manipulation\drivers\RotateDriver.issue558.repro.test.ts"; Set-Content $test $repro -Encoding utf8; git checkout -q --detach c72896c78962ad257425250a37f05e4fe04e9536; Write-Host "`n=== BEFORE: c72896c ===" -ForegroundColor Yellow; & "$repo\node_modules\.bin\vitest.cmd" run $test --reporter=dot 2>&1 | Select-String "Test Files|Tests|FAIL"; $before=$LASTEXITCODE; if($before -eq 0){throw "Issue did not reproduce before the fix."}; Write-Host "BEFORE: #558 reproduced" -ForegroundColor Green; git checkout -q --detach 68fcffc509161a86d21562073633a1ccbe197107; Write-Host "`n=== AFTER: 68fcffc ===" -ForegroundColor Green; & "$repo\node_modules\.bin\vitest.cmd" run $test --reporter=dot 2>&1 | Select-String "Test Files|Tests|PASS|FAIL"; if($LASTEXITCODE -ne 0){throw "Fix did not pass reproduction."}; Write-Host "AFTER: #558 fixed" -ForegroundColor Green; Remove-Item $test -Force; git checkout -q --detach c2ce9c619cffbc0f34505c5f30cbce90a13cdee0; Write-Host "`n=== REGRESSION: c2ce9c61 ===" -ForegroundColor Cyan; & "$repo\node_modules\.bin\vitest.cmd" run src/interaction/manipulation/drivers/RotateDriver.test.ts --reporter=dot 2>&1 | Select-String "Test Files|Tests|PASS|FAIL"; if($LASTEXITCODE -ne 0){throw "Regression tests failed."}; Write-Host "REGRESSION: 9/9 RotateDriver tests passed" -ForegroundColor Green; Write-Host "`n=== COMMITS ===" -ForegroundColor Magenta; git log --oneline -3
```

## Output
<img width="1157" height="545" alt="image" src="https://github.com/user-attachments/assets/ffd46bc0-32cd-4987-805c-05de944fe681" />
