### PR TITLE
show XR entry failures and keep retries safe

### DIFF
--- a/src/core/components/WebXRSessionManager.ts
+++ b/src/core/components/WebXRSessionManager.ts
@@ -6,6 +6,7 @@ export enum WebXRSessionEventType {
   READY = 'ready',
   SESSION_START = 'sessionstart',
   SESSION_END = 'sessionend',
+  SESSION_ERROR = 'sessionerror',
 }
 
 export type WebXRSessionManagerEventMap = THREE.Object3DEventMap & {
@@ -13,6 +14,7 @@ export type WebXRSessionManagerEventMap = THREE.Object3DEventMap & {
   [WebXRSessionEventType.READY]: {sessionOptions: XRSessionInit};
   [WebXRSessionEventType.SESSION_START]: {session: XRSession};
   [WebXRSessionEventType.SESSION_END]: object;
+  [WebXRSessionEventType.SESSION_ERROR]: {error: unknown};
 };
 
 /**
@@ -91,7 +93,7 @@ export class WebXRSessionManager extends THREE.EventDispatcher<WebXRSessionManag
   }
 
   /**
-   * Ends the WebXR session.
+   * Requests and initializes a WebXR session.
    */
   public startSession() {
     if (this.disposed) {
@@ -108,10 +110,10 @@ export class WebXRSessionManager extends THREE.EventDispatcher<WebXRSessionManag
     this.waitingForXRSession = true;
     navigator
       .xr!.requestSession(this.mode, this.sessionOptions)
+      .then(this.onSessionStartedInternal)
       .finally(() => {
         this.waitingForXRSession = false;
       })
-      .then(this.onSessionStartedInternal)
       .catch((err) => {
         console.error(
           'Error requesting session',
@@ -121,6 +123,12 @@ export class WebXRSessionManager extends THREE.EventDispatcher<WebXRSessionManag
           'sesionOptions:',
           this.sessionOptions
         );
+        if (!this.disposed) {
+          this.dispatchEvent({
+            type: WebXRSessionEventType.SESSION_ERROR,
+            error: err,
+          });
+        }
       });
   }
 
@@ -163,6 +171,14 @@ export class WebXRSessionManager extends THREE.EventDispatcher<WebXRSessionManag
       await this.renderer.xr.setSession(session);
     } catch (error) {
       session.removeEventListener('end', this.onSessionEndedInternal);
+      try {
+        await session.end();
+      } catch (cleanupError) {
+        throw new AggregateError(
+          [error, cleanupError],
+          'XR renderer setup failed and the session could not be closed.'
+        );
+      }
       throw error;
     }
     if (this.disposed) {

--- a/src/core/components/XRButton.test.ts
+++ b/src/core/components/XRButton.test.ts
@@ -1,0 +1,229 @@
+// @vitest-environment jsdom
+
+import * as THREE from 'three';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {PermissionsManager} from './PermissionsManager';
+import {WebXRSessionManager} from './WebXRSessionManager';
+import {XRButton} from './XRButton';
+
+function createSession() {
+  const events = new EventTarget();
+  return Object.assign(events, {
+    end: vi.fn(async () => {
+      events.dispatchEvent(new Event('end'));
+    }),
+  }) as unknown as XRSession;
+}
+
+async function flushRequests() {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+describe('XR entry feedback', () => {
+  const requestSession = vi.fn<XRSystem['requestSession']>();
+  const setSession = vi.fn<THREE.WebGLRenderer['xr']['setSession']>();
+  let manager: WebXRSessionManager;
+  let permissions: PermissionsManager;
+  let button: XRButton;
+
+  beforeEach(async () => {
+    requestSession.mockReset();
+    setSession.mockReset().mockResolvedValue(undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubGlobal('navigator', {
+      xr: {
+        isSessionSupported: vi.fn().mockResolvedValue(true),
+        requestSession,
+      },
+    });
+    manager = new WebXRSessionManager(
+      {xr: {setSession}} as unknown as THREE.WebGLRenderer,
+      {requiredFeatures: ['hand-tracking']},
+      'immersive-vr'
+    );
+    permissions = new PermissionsManager();
+    button = new XRButton(manager, permissions);
+    document.body.appendChild(button.domElement);
+    await manager.initialize();
+  });
+
+  afterEach(async () => {
+    button.dispose();
+    await manager.dispose();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    document.body.replaceChildren();
+  });
+
+  it('shows a rejected XR request instead of silently leaving Enter XR unchanged', async () => {
+    requestSession.mockRejectedValue(
+      new DOMException(
+        'The requested session configuration is not supported.',
+        'NotSupportedError'
+      )
+    );
+
+    button.xrButtonElement.click();
+    await flushRequests();
+
+    expect(button.domElement.textContent).toContain('NotSupportedError');
+    expect(button.domElement.textContent).toContain(
+      'The requested session configuration is not supported.'
+    );
+    expect(
+      button.domElement.querySelector<HTMLElement>('[role="alert"]')?.hidden
+    ).toBe(false);
+    expect(button.xrButtonElement.disabled).toBe(false);
+  });
+
+  it('shows pending entry and prevents duplicate requests while the browser is responding', async () => {
+    const pending = Promise.withResolvers<XRSession>();
+    requestSession.mockReturnValue(pending.promise);
+
+    button.xrButtonElement.click();
+    expect(button.xrButtonElement.textContent).toContain('ENTERING XR');
+    expect(button.xrButtonElement.disabled).toBe(true);
+    button.xrButtonElement.click();
+    await flushRequests();
+    expect(requestSession).toHaveBeenCalledOnce();
+
+    pending.resolve(createSession());
+    await flushRequests();
+    expect(button.xrButtonElement.textContent).toBe('END XR');
+    expect(button.xrButtonElement.disabled).toBe(false);
+  });
+
+  it('clears the error and successfully retries a rejected request', async () => {
+    const session = createSession();
+    requestSession
+      .mockRejectedValueOnce(new Error('First request failed.'))
+      .mockResolvedValueOnce(session);
+
+    button.xrButtonElement.click();
+    await flushRequests();
+    button.xrButtonElement.click();
+    await flushRequests();
+
+    expect(requestSession).toHaveBeenCalledTimes(2);
+    expect(manager.currentSession).toBe(session);
+    expect(button.xrButtonElement.textContent).toBe('END XR');
+    expect(button.domElement.textContent).not.toContain(
+      'First request failed.'
+    );
+  });
+
+  it('shows denied browser permissions without requesting an XR session', async () => {
+    vi.spyOn(permissions, 'checkAndRequestPermissions').mockResolvedValue({
+      granted: false,
+      status: 'denied',
+      error: 'Microphone permission was denied.',
+    });
+
+    button.xrButtonElement.click();
+    await flushRequests();
+
+    expect(button.domElement.textContent).toContain(
+      'Microphone permission was denied.'
+    );
+    expect(button.xrButtonElement.disabled).toBe(false);
+    expect(requestSession).not.toHaveBeenCalled();
+  });
+
+  it('shows rejected permission checks and allows retry', async () => {
+    vi.spyOn(permissions, 'checkAndRequestPermissions').mockRejectedValue(
+      new Error('The permission check failed.')
+    );
+
+    button.xrButtonElement.click();
+    await flushRequests();
+
+    expect(button.domElement.textContent).toContain(
+      'The permission check failed.'
+    );
+    expect(button.xrButtonElement.disabled).toBe(false);
+    expect(requestSession).not.toHaveBeenCalled();
+  });
+
+  it('ends a session whose renderer setup fails so another attempt is possible', async () => {
+    const session = createSession();
+    requestSession.mockResolvedValue(session);
+    setSession.mockRejectedValue(new Error('XR rendering could not start.'));
+
+    button.xrButtonElement.click();
+    await flushRequests();
+
+    expect(session.end).toHaveBeenCalledOnce();
+    expect(manager.currentSession).toBeUndefined();
+    expect(button.domElement.textContent).toContain(
+      'XR rendering could not start.'
+    );
+    expect(button.xrButtonElement.disabled).toBe(false);
+  });
+
+  it('keeps the request guard active while renderer setup is still pending', async () => {
+    const pending = Promise.withResolvers<void>();
+    setSession.mockReturnValue(pending.promise);
+    requestSession.mockResolvedValue(createSession());
+
+    manager.startSession();
+    await flushRequests();
+    expect(() => manager.startSession()).toThrow(
+      'Waiting for session to start'
+    );
+
+    pending.resolve();
+    await flushRequests();
+    expect(manager.currentSession).toBeDefined();
+    expect(requestSession).toHaveBeenCalledOnce();
+  });
+
+  it('does not start XR if the entry UI was disposed during permission setup', async () => {
+    const pending =
+      Promise.withResolvers<
+        Awaited<ReturnType<PermissionsManager['checkAndRequestPermissions']>>
+      >();
+    vi.spyOn(permissions, 'checkAndRequestPermissions').mockReturnValue(
+      pending.promise
+    );
+
+    button.xrButtonElement.click();
+    button.dispose();
+    pending.resolve({granted: true, status: 'granted'});
+    await flushRequests();
+
+    expect(requestSession).not.toHaveBeenCalled();
+    expect(button.domElement.isConnected).toBe(false);
+  });
+
+  it('publishes the original request failure for session listeners', async () => {
+    const error = new DOMException(
+      'Session permission denied.',
+      'SecurityError'
+    );
+    const onError = vi.fn();
+    manager.addEventListener('sessionerror', onError);
+    requestSession.mockRejectedValue(error);
+
+    manager.startSession();
+    await flushRequests();
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({error}));
+  });
+
+  it('does not publish a late request failure after disposal', async () => {
+    const pending = Promise.withResolvers<XRSession>();
+    const onError = vi.fn();
+    manager.addEventListener('sessionerror', onError);
+    requestSession.mockReturnValue(pending.promise);
+
+    manager.startSession();
+    button.dispose();
+    await manager.dispose();
+    pending.reject(new Error('The pending request failed after disposal.'));
+    await flushRequests();
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/components/XRButton.ts
+++ b/src/core/components/XRButton.ts
@@ -11,6 +11,7 @@ export class XRButton {
   public domElement = document.createElement('div');
   public simulatorButtonElement = document.createElement('button');
   public xrButtonElement = document.createElement('button');
+  private errorElement = document.createElement('p');
   private disposed = false;
 
   constructor(
@@ -38,6 +39,7 @@ export class XRButton {
     if (showEnterSimulatorButton) {
       this.createSimulatorButton();
     }
+    this.createErrorElement();
 
     this.sessionManager.addEventListener(
       WebXRSessionEventType.UNSUPPORTED,
@@ -55,12 +57,40 @@ export class XRButton {
       WebXRSessionEventType.SESSION_END,
       this.onSessionEnd
     );
+    this.sessionManager.addEventListener(
+      WebXRSessionEventType.SESSION_ERROR,
+      this.onSessionError
+    );
   }
 
   private onUnsupported = () => this.showXRNotSupported();
   private onReady = () => this.onSessionReady();
   private onSessionStart = () => this.onSessionStarted();
   private onSessionEnd = () => this.onSessionEnded();
+  private onSessionError = (event: {error: unknown}) =>
+    this.showError(event.error);
+
+  private createErrorElement() {
+    this.errorElement.className = 'XRButtonError';
+    this.errorElement.setAttribute('role', 'alert');
+    this.errorElement.style.maxWidth = 'min(90vw, 40rem)';
+    this.errorElement.hidden = true;
+    this.domElement.appendChild(this.errorElement);
+  }
+
+  private showError(error: unknown) {
+    if (this.disposed) return;
+    const detail =
+      error instanceof Error
+        ? `${error.name}: ${error.message}`
+        : String(error);
+    this.errorElement.textContent = `XR could not start. ${detail}`;
+    this.errorElement.hidden = false;
+    this.xrButtonElement.textContent = this.sessionManager.currentSession
+      ? this.endText
+      : this.startText;
+    this.xrButtonElement.disabled = false;
+  }
 
   private createSimulatorButton() {
     this.simulatorButtonElement.classList.add(XRBUTTON_CLASS);
@@ -98,6 +128,8 @@ export class XRButton {
   }
 
   private onSessionReady() {
+    this.errorElement.textContent = '';
+    this.errorElement.hidden = true;
     const button = this.xrButtonElement;
     button.style.display = '';
     button.innerHTML = this.startText;
@@ -108,6 +140,10 @@ export class XRButton {
       ?.optionalFeatures?.includes('camera-access');
 
     button.onclick = () => {
+      this.errorElement.textContent = '';
+      this.errorElement.hidden = true;
+      button.textContent = 'ENTERING XR...';
+      button.disabled = true;
       this.permissionsManager
         .checkAndRequestPermissions(this.permissions, {
           allowVideoFallback: allowsVideoFallback,
@@ -117,10 +153,12 @@ export class XRButton {
           if (result.granted) {
             this.sessionManager.startSession();
           } else {
-            this.xrButtonElement.textContent =
-              'Error:' + result.error + '\nPlease try again.';
+            this.showError(
+              new Error(result.error || 'Browser permission was not granted.')
+            );
           }
-        });
+        })
+        .catch((error) => this.showError(error));
     };
   }
 
@@ -130,7 +168,10 @@ export class XRButton {
   }
 
   private async onSessionStarted() {
+    this.errorElement.textContent = '';
+    this.errorElement.hidden = true;
     this.xrButtonElement.innerHTML = this.endText;
+    this.xrButtonElement.disabled = false;
     this.xrButtonElement.onclick = () => {
       void this.sessionManager.endSession();
     };
@@ -158,6 +199,10 @@ export class XRButton {
     this.sessionManager.removeEventListener(
       WebXRSessionEventType.SESSION_END,
       this.onSessionEnd
+    );
+    this.sessionManager.removeEventListener(
+      WebXRSessionEventType.SESSION_ERROR,
+      this.onSessionError
     );
     this.simulatorButtonElement.onclick = null;
     this.xrButtonElement.onclick = null;


### PR DESCRIPTION
## Description

hit Enter XR, the request gets rejected, and nothing happens. the button keeps saying ENTER XR, no message anywhere, and clicking again looks exactly like the first click. the only way to find out what went wrong is the devtools console.

`WebXRSessionManager` now dispatches a `SESSION_ERROR` event carrying the original error, holds the pending-request guard until renderer init actually finishes instead of dropping it as soon as `requestSession` resolves, and ends a session whose `renderer.xr.setSession` threw so the device isn't left holding one nothing owns. if that close also fails, both errors come back as an `AggregateError`. `XRButton` shows `ENTERING XR...` while a request is in flight, surfaces the failure in a `role="alert"`, and puts the button back in a usable state after a permission denial, a rejected request, or a failed setup.

extracted from #571 so it can land on its own.

## Type of Change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

- **Simulator Recording**: Not attached
- **Device Recording**: Not attached

## Checklist

- [ ] **Tested in simulator & device**: no manual simulator or device run was performed. covered by the new `XRButton.test.ts` (jsdom). `npm test` (668 pass), `npm run lint`, prettier, and `npm run build:sdk` are all clean.
- [ ] **Large Assets ($\ge$ 1MB)**: N/A, no assets added.
- [ ] **SDK Dynamic Dependencies**: N/A, no new dependencies.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.