### PR TITLE
refresh the headset camera before scripts run

### DIFF
--- a/src/core/Core.test.ts
+++ b/src/core/Core.test.ts
@@ -170,6 +170,36 @@ describe('Core frame and simulator lifecycle', () => {
     expect(core.renderer.render).toHaveBeenCalledWith(core.scene, core.camera);
   });
 
+  it.each([false, true])(
+    'updates the headset camera before scripts (postprocessing: %s)',
+    async (postprocessing) => {
+      if (postprocessing) {
+        core.effects = {
+          render: vi.fn(),
+          dispose: vi.fn(),
+        } as unknown as Core['effects'];
+      }
+      const observedPosition = new THREE.Vector3();
+      const script = new Script();
+      vi.spyOn(script, 'update').mockImplementation(() => {
+        observedPosition.copy(core.camera.position);
+      });
+      await scripts(core).initScript(script);
+      core.renderer.xr.isPresenting = true;
+      core.renderer.xr.updateCamera = vi.fn((camera: THREE.Camera) => {
+        camera.position.set(0.4, 1.65, -0.2);
+        camera.updateMatrixWorld();
+      });
+
+      (
+        core as unknown as {update: (time: number, frame: XRFrame) => void}
+      ).update(1000, {} as XRFrame);
+
+      expect(core.renderer.xr.updateCamera).toHaveBeenCalledWith(core.camera);
+      expect(observedPosition.toArray()).toEqual([0.4, 1.65, -0.2]);
+    }
+  );
+
   it('shares one in-flight simulator start and ignores later starts once running', async () => {
     vi.spyOn(
       core as unknown as {initialize(options: Options): Promise<void>},

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -779,10 +779,9 @@ export class Core {
       this.lighting.update();
     }
 
-    // XREffects renders each eye manually with XR camera auto-update disabled.
-    // Keep the public camera at the current headset pose so view-space UI and
-    // scripts do not use the stale pose from before the XR session started.
-    if (this.effects && this.renderer.xr.isPresenting) {
+    // Rendering updates this camera too late for first-frame UI placement.
+    // Scripts and input need the current headset pose before they run.
+    if (this.renderer.xr.isPresenting) {
       this.renderer.xr.updateCamera(this.camera);
     }
 


### PR DESCRIPTION
# Pull Request Template

## Description

on XR entry the public camera still holds the pose from before the session started, so input and scripts run against a stale headset pose for that frame while rendering updates it afterwards. anything that reads the camera to place view-space UI gets the wrong pose, and any frame where the render-time update is the only refresh has the same ordering problem.

`Core.update` already pulled the current pose via `renderer.xr.updateCamera`, but only when `effects` was set, since XREffects renders each eye manually with three's auto camera update off. without postprocessing the public camera only gets refreshed during render, which is after input sampling and script updates have already run.

drops the effects condition so the pose refresh happens whenever we're presenting. the effects path and non-XR behavior are unchanged. new Core test runs both with and without postprocessing and checks a script's `update` observes the headset position, it fails on the no-postprocessing case without the fix.

extracted from #571 so it can land on its own.

## Type of Change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

- **Simulator Recording**: Not attached
- **Device Recording**: Not attached

## Checklist

- [ ] **Tested in simulator & device**: N/A, no manual simulator or device run for this one. the new Core regression passes both with and without postprocessing, and fails on the no-postprocessing case when the fix is reverted. separately, a default `npm test` run here also hits one unrelated failure in `Core.test.ts > shares one in-flight simulator start and ignores later starts once running`, which reproduces on pristine main at the same base with this change reverted, so it is a baseline flake rather than anything from this fix.
- [ ] **Large Assets ($\ge$ 1MB)**: N/A, no assets in this change.
- [ ] **SDK Dynamic Dependencies**: N/A, no new SDK dependencies.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.