### PR TITLE
release direct touch when hand tracking is lost

### DIFF
--- a/docs/docs/manual/Interaction.md
+++ b/docs/docs/manual/Interaction.md
@@ -167,6 +167,8 @@ Releasing a pinch can end grab and manipulation while touch and selection
 continue. Call `event.preventDefault()` in touch start when contact must not
 start the default selection.
 
+Direct touch requires a tracked hand and index-tip pose. When either loses tracking, its last position is ignored and any active contact ends as `source-lost`, without completing a click. This releases touch suppression so a tracked controller ray can target again. Touch resumes when valid hand poses return.
+
 ## Automatic manipulation
 
 Configure manipulation on the owner object. Do not create a manager:

--- a/src/input/Input.test.ts
+++ b/src/input/Input.test.ts
@@ -1,13 +1,29 @@
 import * as THREE from 'three';
+import {WebXRController} from 'three/src/renderers/webxr/WebXRController.js';
 import {describe, expect, it, vi} from 'vitest';
 
 import {Options} from '../core/Options';
+import {ScriptsManager} from '../core/components/ScriptsManager';
 import {XRSystems} from '../core/components/XRSystems';
+import {Interaction} from '../interaction/Interaction';
+import {Reticle} from '../interaction/reticle/Reticle';
+import {UIButton} from '../ui/components/UIButton';
 import {Input} from './Input';
 import {Controller} from './Controller';
 
 function updateInput(input: Input) {
   input.sampleSources();
+}
+
+function trackedHand() {
+  const hand = new WebXRController().getHandSpace();
+  const indexTip = Object.assign(new THREE.Group(), {jointRadius: 0.01});
+  const wrist = Object.assign(new THREE.Group(), {jointRadius: 0.01});
+  hand.joints['index-finger-tip'] = indexTip;
+  hand.joints.wrist = wrist;
+  hand.add(indexTip, wrist);
+  hand.visible = true;
+  return {hand, indexTip, wrist};
 }
 
 describe('Input head gestures', () => {
@@ -34,14 +50,9 @@ describe('Input direct touch', () => {
     const input = new Input();
     const controller = new THREE.Object3D() as Controller;
     controller.userData.selected = true;
-    const indexTip = new THREE.Object3D();
-    const wrist = new THREE.Object3D();
+    const {hand, wrist} = trackedHand();
     input.controllers = [controller];
-    input.hands = [
-      {
-        joints: {'index-finger-tip': indexTip, wrist},
-      } as unknown as THREE.XRHandSpace,
-    ];
+    input.hands = [hand];
     input.controllersEnabled = false;
 
     updateInput(input);
@@ -57,7 +68,94 @@ describe('Input direct touch', () => {
     });
     expect(frame.directTouches[0].point.toArray()).toEqual([0, 0, 0]);
     expect(frame.directTouches[0]).not.toHaveProperty('intersections');
+    input.dispose();
   });
+
+  it.each(['hand', 'index tip'])(
+    'ignores retained poses when the %s is untracked and resumes when it returns',
+    (lost) => {
+      const input = new Input();
+      const controller = new THREE.Object3D() as Controller;
+      const {hand, indexTip} = trackedHand();
+      input.controllers = [controller];
+      input.hands = [hand];
+      const lostSpace = lost === 'hand' ? hand : indexTip;
+      updateInput(input);
+      expect(input.getFrame().directTouches).toHaveLength(1);
+      lostSpace.visible = false;
+      updateInput(input);
+      expect(input.getFrame().directTouches).toHaveLength(0);
+      lostSpace.visible = true;
+      updateInput(input);
+      expect(input.getFrame().directTouches).toHaveLength(1);
+      input.dispose();
+    }
+  );
+
+  it.each(['hand', 'index tip'])(
+    'restores controller targeting after %s tracking is lost over a touchable button',
+    async (lost) => {
+      const input = new Input();
+      const controller = new THREE.Object3D() as Controller;
+      controller.userData = {id: 0, connected: true, selected: false};
+      controller.inputSource = {targetRayMode: 'tracked-pointer'};
+      const reticle = new Reticle();
+      controller.reticle = reticle;
+      const {hand, indexTip} = trackedHand();
+      indexTip.position.set(2, 0, -1);
+      input.controllers = [controller];
+      input.hands = [hand];
+      const callbacks = new ScriptsManager(async () => {});
+      const interaction = new Interaction({
+        callbacks,
+        scene: new THREE.Scene(),
+      });
+      const clicked = vi.fn();
+      const button = new UIButton({label: 'Keyboard', onClick: clicked});
+      const surface = new THREE.Mesh(
+        new THREE.BoxGeometry(0.4, 0.4, 0.1),
+        new THREE.MeshBasicMaterial()
+      );
+      surface.position.z = -1;
+      await callbacks.initScript(button);
+      const unregister = interaction.registerHitSurface(surface, button);
+      const sample = () => {
+        input.sampleSources();
+        interaction.update(input.getFrame());
+      };
+      try {
+        sample();
+        expect(interaction.getResolvedRay(controller)?.target).toBe(button);
+        expect(reticle.visible).toBe(true);
+        indexTip.position.x = 0;
+        sample();
+        expect(interaction.getResolvedRay(controller)).toBeUndefined();
+        expect(reticle.visible).toBe(false);
+        const lostSpace = lost === 'hand' ? hand : indexTip;
+        lostSpace.visible = false;
+        sample();
+        expect(controller.userData.connected).toBe(true);
+        expect(controller.visible).toBe(true);
+        expect(interaction.getResolvedRay(controller)?.target).toBe(button);
+        expect(reticle.visible).toBe(true);
+        expect(clicked).not.toHaveBeenCalled();
+
+        controller.userData.selected = true;
+        sample();
+        controller.userData.selected = false;
+        sample();
+        expect(clicked).toHaveBeenCalledTimes(1);
+      } finally {
+        interaction.clear();
+        unregister();
+        button.dispose();
+        surface.geometry.dispose();
+        surface.material.dispose();
+        reticle.dispose();
+        input.dispose();
+      }
+    }
+  );
 });
 
 describe('Input events', () => {

--- a/src/input/Input.ts
+++ b/src/input/Input.ts
@@ -477,8 +477,11 @@ export class Input {
     this.directTouchInputs.length = 0;
     for (let handIndex = 0; handIndex < NUM_HANDS; handIndex++) {
       const controller = this.controllers[handIndex];
-      const indexTip = this.hands[handIndex]?.joints?.['index-finger-tip'];
-      if (!controller || !indexTip) continue;
+      const hand = this.hands[handIndex];
+      const indexTip = hand?.joints?.['index-finger-tip'];
+      // Three.js retains joint poses after tracking is lost. A stale touch
+      // would keep suppressing the controller's ray and reticle.
+      if (!controller || !hand?.visible || !indexTip?.visible) continue;
       let input = this.directTouchSlots[handIndex];
       if (!input) {
         input = {
@@ -491,7 +494,7 @@ export class Input {
         this.directTouchSlots[handIndex] = input;
       }
       input.controller = controller;
-      input.hand = this.hands[handIndex]?.joints?.wrist;
+      input.hand = hand.joints?.wrist;
       indexTip.getWorldPosition(input.point);
       controller.getWorldQuaternion(input.orientation!);
       input.selected = controller.userData.selected === true;


### PR DESCRIPTION
## Description

controller cursor disappears and clicks stop landing after hand tracking drops out, with the controller still connected and tracked.

three.js keeps the hand and index-tip joint transforms around after tracking goes away, it just marks the spaces invisible. `updateDirectTouchInputs` only checked that the joint existed, so a fingertip last seen hovering a `UIButton` keeps feeding a direct touch forever. that stale touch suppresses the ray and reticle for that controller, so there's no cursor and select does nothing.

now needs a visible hand space and a visible index-tip joint before sampling. losing either drops the input, the contact ends as `source-lost` without completing a click, ray targeting and clicking work again, and touch resumes once valid poses come back. simulator direct touch with `controllersEnabled=false` is unchanged.

four regressions cover whole-hand and index-tip loss plus recovery, two of them through Input + Interaction with a registered `UIButton` so the ray hit is asserted before the touch and again after tracking is lost. all four fail on the old condition.

Also fixed in #571 

## Type of Change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] New demo or sample
- [x] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

- **Simulator Recording**: Not attached
- **Device Recording**: Not attached

## Checklist

- [ ] **Tested in simulator & device**: Verified functionality in desktop simulator and/or physical hardware (where applicable).
- [ ] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN. N/A, no assets in this PR.
- [ ] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime. N/A, no new dependencies.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.