### PR TITLE
don't drive the simulator while a text field has focus

### DIFF
--- a/docs/docs/manual/Simulator.mdx
+++ b/docs/docs/manual/Simulator.mdx
@@ -80,6 +80,8 @@ options.simulator.modeToggle.enabled = true;
 When mode toggling is enabled, the configured toggle key cycles through
 `options.simulator.modeToggle.toggleOrder`.
 
+Keyboard navigation and simulator shortcuts are suspended while an input, textarea, select, or editable region has focus, including text controls inside open shadow roots. Focusing a text control clears held movement keys; leaving it does not resume movement until another navigation key is pressed. Text editing and its normal key events are not blocked, and IME composition does not trigger simulator shortcuts.
+
 ## Automation preset
 
 Use the shared preset for automated or external browser runs:

--- a/src/simulator/SimulatorControls.test.ts
+++ b/src/simulator/SimulatorControls.test.ts
@@ -1,4 +1,4 @@
-import {afterEach, describe, expect, it, vi} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {SimulatorControllerState} from './SimulatorControllerState';
 import {SimulatorControls} from './SimulatorControls';
@@ -17,17 +17,16 @@ function createControls() {
   );
 }
 
-describe('SimulatorControls wheel input', () => {
+describe('SimulatorControls input', () => {
   const connectedControls: SimulatorControls[] = [];
 
   afterEach(() => {
     for (const controls of connectedControls) {
-      document.removeEventListener('keyup', controls.onKeyUp);
-      document.removeEventListener('keydown', controls.onKeyDown);
-      window.removeEventListener('blur', controls.onBlur);
-      document.removeEventListener('visibilitychange', controls.onBlur);
+      controls.disconnect();
     }
     connectedControls.length = 0;
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
   });
 
   it('prevents browser wheel defaults only when the active mode handles them', () => {
@@ -95,7 +94,148 @@ describe('SimulatorControls wheel input', () => {
     expect(controls.downKeys.size).toBe(0);
     expect(pointerUp).toHaveBeenCalledTimes(3);
   });
+
+  describe('text entry', () => {
+    let controls: SimulatorControls;
+
+    beforeEach(() => {
+      controls = createControls();
+      controls.renderer = {
+        domElement: document.createElement('canvas'),
+      } as never;
+      vi.spyOn(controls.simulatorModeControls, 'onKeyDown').mockImplementation(
+        () => {}
+      );
+      connectedControls.push(controls);
+      controls.connect();
+    });
+
+    it.each(['input', 'textarea', 'select'])(
+      'leaves %s keys to the field without activating simulator shortcuts',
+      (tag) => {
+        const field = document.createElement(tag);
+        const onFieldKey = vi.fn();
+        field.addEventListener('keydown', onFieldKey);
+        document.body.appendChild(field);
+        field.focus();
+
+        const event = keyDown(field);
+
+        expect(controls.downKeys.size).toBe(0);
+        expect(controls.simulatorModeControls.onKeyDown).not.toHaveBeenCalled();
+        expect(onFieldKey).toHaveBeenCalledOnce();
+        expect(event.defaultPrevented).toBe(false);
+      }
+    );
+
+    it('ignores keys from descendants of an editable region', () => {
+      const editor = document.createElement('div');
+      editor.contentEditable = 'true';
+      editor.tabIndex = 0;
+      // jsdom does not implement inherited isContentEditable state.
+      Object.defineProperty(editor, 'isContentEditable', {value: true});
+      const text = document.createElement('span');
+      editor.appendChild(text);
+      document.body.appendChild(editor);
+      editor.focus();
+
+      keyDown(text);
+
+      expect(controls.downKeys.size).toBe(0);
+      expect(controls.simulatorModeControls.onKeyDown).not.toHaveBeenCalled();
+    });
+
+    it('recognizes a text field inside an open shadow root', () => {
+      const host = document.createElement('div');
+      const field = document.createElement('input');
+      host.attachShadow({mode: 'open'}).appendChild(field);
+      document.body.appendChild(host);
+      field.focus();
+      expect(document.activeElement).toBe(host);
+
+      keyDown(field);
+
+      expect(controls.downKeys.size).toBe(0);
+      expect(controls.simulatorModeControls.onKeyDown).not.toHaveBeenCalled();
+    });
+
+    it('respects text focus even when a key is dispatched on the document', () => {
+      const field = document.createElement('input');
+      document.body.appendChild(field);
+      field.focus();
+
+      keyDown(document, {code: Keycodes.DIGIT_1});
+
+      expect(controls.downKeys.size).toBe(0);
+      expect(controls.simulatorModeControls.onKeyDown).not.toHaveBeenCalled();
+    });
+
+    it('stops held movement on text focus and resumes only with a new navigation key', () => {
+      keyDown(document);
+      expect(controls.downKeys.has(Keycodes.W_CODE)).toBe(true);
+      const field = document.createElement('input');
+      document.body.appendChild(field);
+      field.focus();
+      expect(controls.downKeys.size).toBe(0);
+
+      keyDown(field, {repeat: true});
+      field.blur();
+      expect(controls.downKeys.size).toBe(0);
+      keyDown(document);
+      expect(controls.downKeys.has(Keycodes.W_CODE)).toBe(true);
+      document.dispatchEvent(
+        new KeyboardEvent('keyup', {code: Keycodes.W_CODE})
+      );
+      expect(controls.downKeys.size).toBe(0);
+    });
+
+    it('still clears a held key when its release happens over a text field', () => {
+      const field = document.createElement('input');
+      document.body.appendChild(field);
+      field.focus();
+      controls.downKeys.add(Keycodes.W_CODE);
+
+      field.dispatchEvent(
+        new KeyboardEvent('keyup', {code: Keycodes.W_CODE, bubbles: true})
+      );
+
+      expect(controls.downKeys.size).toBe(0);
+    });
+
+    it('ignores composing keys and clears any previously held movement', () => {
+      controls.downKeys.add(Keycodes.W_CODE);
+
+      keyDown(document, {isComposing: true});
+
+      expect(controls.downKeys.size).toBe(0);
+      expect(controls.simulatorModeControls.onKeyDown).not.toHaveBeenCalled();
+    });
+
+    it('removes keyboard and text-focus listeners when disconnected', () => {
+      controls.disconnect();
+      controls.downKeys.add(Keycodes.W_CODE);
+      const field = document.createElement('input');
+      document.body.appendChild(field);
+      field.focus();
+      keyDown(document, {code: Keycodes.A_CODE});
+
+      expect([...controls.downKeys]).toEqual([Keycodes.W_CODE]);
+      expect(controls.simulatorModeControls.onKeyDown).not.toHaveBeenCalled();
+    });
+  });
 });
+
+function keyDown(target: EventTarget, init: KeyboardEventInit = {}) {
+  const event = new KeyboardEvent('keydown', {
+    code: Keycodes.W_CODE,
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    ...init,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
 
 function pointerEvent(type: string, pointerId: number): PointerEvent {
   return Object.assign(new MouseEvent(type), {pointerId}) as PointerEvent;

--- a/src/simulator/SimulatorControls.ts
+++ b/src/simulator/SimulatorControls.ts
@@ -24,6 +24,14 @@ function preventDefault(event: Event) {
   event.preventDefault();
 }
 
+function isTextEntry(event: Event): boolean {
+  return [...event.composedPath(), document.activeElement].some(
+    (target) =>
+      target instanceof HTMLElement &&
+      (target.matches('input, textarea, select') || target.isContentEditable)
+  );
+}
+
 export class SimulatorControls {
   pointerDown = false;
   downKeys = new Set<Keycodes>();
@@ -164,6 +172,7 @@ export class SimulatorControls {
     if (!domElement) throw new Error('SimulatorControls is not initialized.');
     document.addEventListener('keyup', this.onKeyUp);
     document.addEventListener('keydown', this.onKeyDown);
+    document.addEventListener('focusin', this.onFocusIn);
     domElement.addEventListener('pointermove', this.onPointerMove);
     domElement.addEventListener('pointerdown', this.onPointerDown);
     domElement.addEventListener('pointerup', this.onPointerUp);
@@ -188,6 +197,7 @@ export class SimulatorControls {
     }
     document.removeEventListener('keyup', this.onKeyUp);
     document.removeEventListener('keydown', this.onKeyDown);
+    document.removeEventListener('focusin', this.onFocusIn);
     domElement.removeEventListener('pointermove', this.onPointerMove);
     domElement.removeEventListener('pointerdown', this.onPointerDown);
     domElement.removeEventListener('pointerup', this.onPointerUp);
@@ -249,6 +259,10 @@ export class SimulatorControls {
 
   onKeyDown = (event: KeyboardEvent) => {
     if (!this.enabled) return;
+    if (event.isComposing || isTextEntry(event)) {
+      this.downKeys.clear();
+      return;
+    }
     // On macOS, keyup events are not fired for keys held when Command (Meta)
     // is pressed. Clear all keys to prevent stuck movement.
     if (
@@ -279,6 +293,10 @@ export class SimulatorControls {
   onBlur = () => {
     this.downKeys.clear();
     this.cancelPointerInteraction();
+  };
+
+  private onFocusIn = (event: FocusEvent) => {
+    if (isTextEntry(event)) this.downKeys.clear();
   };
 
   setSimulatorMode(mode: SimulatorMode) {


### PR DESCRIPTION
## Description

typing into a text field in the desktop simulator also drives the simulator. `w`/`a`/`s`/`d` walk the camera while you type, `1` and `2` flip the stereo render mode, and backtick toggles the UI. and a movement key you were already holding when the field took focus stays held, so the camera keeps moving while you type into the field.

`SimulatorControls.onKeyDown` now bails when the composed path or `document.activeElement` is an input, textarea, select or contenteditable, so text controls inside open shadow roots are covered too. IME composition keys are skipped for the same reason. a `focusin` listener clears held navigation keys when you click into a field so movement stops instead of sticking, and it comes back off on disconnect.

keyup is deliberately left alone so a key released over a text field still clears. leaving a field doesn't resume movement until you press a navigation key again. normal text editing and its key events aren't blocked.

some apps guard this by hand, e.g. the aisimulator panel swallows every keydown on its text input with `stopPropagation()` purely so the simulator doesn't see it. plenty don't: netblocks' chat box and room-code field are plain inputs with no guard, so typing a room code today also steers the camera. the hand-rolled guards still work and aren't broken by this, but neither kind of app should need one now that the controls check focus themselves.

pulled out of #571 so it can land on its own ahead of the larger feature.

## Type of Change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] New demo or sample
- [x] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

- **Simulator Recording**: Not attached
- **Device Recording**: Not attached

## Checklist

- [ ] **Tested in simulator & device**: Verified functionality in desktop simulator and/or physical hardware (where applicable).
- [ ] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [ ] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.

N/A for large assets (no assets added) and for SDK dynamic dependencies (no new dependencies), so those two are left unchecked rather than asserted.

no manual simulator or device run, so that box is unchecked too. the behavior is covered by unit tests in `SimulatorControls.test.ts` instead: each field type, shadow-root inputs, editable-region descendants, keys dispatched on the document while a field holds focus, the held-key clear on focus, keyup still clearing, IME composition, and listener removal on disconnect. that file is 12/12 green, and `eslint src`, prettier on the changed files, and `rollup -c --failAfterWarnings` are all clean.

one unrelated test fails in the default full run, `src/core/Core.test.ts > Core frame and simulator lifecycle > shares one in-flight simulator start and ignores later starts once running`. it reproduces the same way on unchanged main and passes when that file runs on its own. capping the pool with `--maxWorkers=2` also gets the whole suite green, so it's a pre-existing concurrency flake rather than something this branch introduces. left alone.