### PR TITLE
perf(context): skip redundant transform refreshes in semantic snapshots

### DIFF
--- a/src/context/scene/semantic-tree/SemanticTreeBuilder.test.ts
+++ b/src/context/scene/semantic-tree/SemanticTreeBuilder.test.ts
@@ -1,0 +1,167 @@
+import * as THREE from 'three';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {registerUIPresentationObject} from '../../../ui/UIElement';
+import {UICard} from '../../../ui/components/UICard';
+import {UIPanel} from '../../../ui/components/UIPanel';
+import {SemanticIdRegistry} from '../../shared/SemanticIdRegistry';
+import {buildSemanticTree} from './SemanticTreeBuilder';
+
+function findNode(
+  tree: ReturnType<typeof buildSemanticTree>,
+  name: string
+): (typeof tree.tree.nodes)[string] | undefined {
+  return Object.values(tree.tree.nodes).find((node) => node.name === name);
+}
+
+describe('buildSemanticTree', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('reports world positions and bounds under a transformed parent', () => {
+    const scene = new THREE.Scene();
+    const parent = new THREE.Group();
+    parent.name = 'Parent';
+    parent.position.set(1, 2, 3);
+    const child = new THREE.Mesh(new THREE.BoxGeometry(2, 2, 2));
+    child.name = 'Child';
+    child.userData.semantic = {name: 'Child'};
+    child.position.x = 2;
+    parent.add(child);
+    scene.add(parent);
+
+    const tree = buildSemanticTree({
+      scene,
+      registry: new SemanticIdRegistry(),
+      capturedAt: 0,
+    });
+
+    const node = findNode(tree, 'Child');
+    expect(node?.position).toEqual([3, 2, 3]);
+    expect(node?.bounds).toEqual({center: [3, 2, 3], size: [2, 2, 2]});
+  });
+
+  it('picks up transforms that changed since the previous snapshot', () => {
+    const scene = new THREE.Scene();
+    const parent = new THREE.Group();
+    parent.name = 'Parent';
+    const child = new THREE.Mesh(new THREE.BoxGeometry(2, 2, 2));
+    child.name = 'Child';
+    child.userData.semantic = {name: 'Child'};
+    parent.add(child);
+    scene.add(parent);
+    const registry = new SemanticIdRegistry();
+
+    buildSemanticTree({scene, registry, capturedAt: 0});
+    parent.position.set(4, 5, 6);
+    parent.scale.setScalar(2);
+    child.position.x = 1;
+    const tree = buildSemanticTree({scene, registry, capturedAt: 16});
+
+    const node = findNode(tree, 'Child');
+    expect(node?.position).toEqual([6, 5, 6]);
+    expect(node?.bounds).toEqual({center: [6, 5, 6], size: [4, 4, 4]});
+  });
+
+  it('does not force a subtree refresh for each semantic node', () => {
+    const scene = new THREE.Scene();
+    const parent = new THREE.Group();
+    parent.name = 'Parent';
+    const child = new THREE.Group();
+    child.name = 'Child';
+    const leaf = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1));
+    leaf.name = 'Leaf';
+    leaf.userData.semantic = {name: 'Leaf'};
+    child.add(leaf);
+    parent.add(child);
+    scene.add(parent);
+    const parentUpdate = vi.spyOn(parent, 'updateMatrixWorld');
+    const childUpdate = vi.spyOn(child, 'updateMatrixWorld');
+    const leafUpdate = vi.spyOn(leaf, 'updateMatrixWorld');
+
+    buildSemanticTree({
+      scene,
+      registry: new SemanticIdRegistry(),
+      capturedAt: 0,
+    });
+
+    // Only counts forced updateMatrixWorld walks. Bounds still refresh
+    // descendants through Box3.setFromObject.
+    expect(parentUpdate).toHaveBeenCalledOnce();
+    expect(childUpdate).toHaveBeenCalledOnce();
+    expect(leafUpdate).toHaveBeenCalledOnce();
+  });
+
+  it('keeps a custom getWorldPosition override authoritative', () => {
+    class PresentedObject extends THREE.Mesh {
+      readonly presentation = new THREE.Object3D();
+
+      override getWorldPosition(target: THREE.Vector3): THREE.Vector3 {
+        return this.presentation.getWorldPosition(target);
+      }
+    }
+    const scene = new THREE.Scene();
+    const object = new PresentedObject(new THREE.BoxGeometry(1, 1, 1));
+    object.name = 'Presented';
+    object.userData.semantic = {name: 'Presented'};
+    object.position.set(1, 1, 1);
+    object.presentation.position.set(-3, 0, 5);
+    scene.add(object, object.presentation);
+
+    const tree = buildSemanticTree({
+      scene,
+      registry: new SemanticIdRegistry(),
+      capturedAt: 0,
+    });
+
+    expect(findNode(tree, 'Presented')?.position).toEqual([-3, 0, 5]);
+  });
+
+  it('reports a UI element from its registered presentation object', () => {
+    const scene = new THREE.Scene();
+    const card = new UICard({size: {width: 0.6, height: 0.4}});
+    const panel = new UIPanel();
+    panel.name = 'PresentedPanel';
+    card.add(panel);
+    card.position.set(1, 1, 1);
+    scene.add(card);
+
+    // The UI backend renders elements under a private root that the semantic
+    // walk prunes, so the element node is the only place this position shows up.
+    const renderRoot = new THREE.Object3D();
+    renderRoot.userData.xrblocksPrivate = true;
+    renderRoot.position.set(-4, 0, 4);
+    const presentation = new THREE.Mesh(new THREE.BoxGeometry(0.4, 0.2, 0.01));
+    presentation.position.set(1, 0.5, 1);
+    renderRoot.add(presentation);
+    scene.add(renderRoot);
+    const unregister = registerUIPresentationObject(panel, presentation);
+
+    try {
+      const tree = buildSemanticTree({
+        scene,
+        registry: new SemanticIdRegistry(),
+        capturedAt: 0,
+      });
+
+      scene.updateMatrixWorld(true);
+      const logicalPosition = new THREE.Vector3().setFromMatrixPosition(
+        panel.matrixWorld
+      );
+      expect(logicalPosition.toArray()).toEqual([1, 1, 1]);
+
+      const node = findNode(tree, 'PresentedPanel');
+      expect(node?.position).toEqual([-3, 0.5, 5]);
+      expect(node?.bounds).toEqual({
+        center: [-3, 0.5, 5],
+        size: [0.4, 0.2, 0.01],
+      });
+      expect(
+        Object.values(tree.tree.nodes).some(
+          (candidate) => candidate.objectId === presentation.id
+        )
+      ).toBe(false);
+    } finally {
+      unregister();
+    }
+  });
+});

--- a/src/context/scene/semantic-tree/SemanticTreeBuilder.ts
+++ b/src/context/scene/semantic-tree/SemanticTreeBuilder.ts
@@ -296,7 +296,8 @@ function createSemanticNode(
   semantic: NonNullable<ReturnType<typeof describeSemanticObject>>,
   parentId: string | undefined
 ): SemanticNode {
-  object.updateMatrixWorld(true);
+  // buildSemanticTree refreshes the whole scene before traversal, so this only
+  // needs the ancestor walk that getWorldPosition already does.
   object.getWorldPosition(tempPosition);
 
   const node: SemanticNode = {


### PR DESCRIPTION
## Description

`buildSemanticTree` already calls `scene.updateMatrixWorld(true)` once before it traverses the scene. Despite that, `createSemanticNode` called `object.updateMatrixWorld(true)` again for every node it visited, which forced a full recursive refresh of that node's subtree. In a deep hierarchy the same descendants get refreshed once per ancestor, so the cost grows with depth while the matrices are already current.

This removes that per-node call. The scene-wide refresh at the start of the snapshot stays exactly where it is, and `object.getWorldPosition(tempPosition)` stays too, since it performs the ancestor walk the node actually needs. Bounds are unaffected because `getObjectBounds` / `getUIObjectBounds` refresh their own subtrees, and `Box3.expandByObject` updates each object it visits.

Keeping `getWorldPosition` matters for correctness, not just style. `UIElement` overrides it so a UI node reports the world position of its registered uikit presentation object rather than its logical transform. Reading `matrixWorld` directly instead, as a first pass did, silently reports the wrong position for those elements once the logical and presentation transforms diverge.

There is no caching across frames or snapshots, no change to camera or XR pose timing, and no public API change.

On performance, this is a redundant-work cleanup rather than a headline win. An isolated synthetic benchmark over a deep semantic snapshot showed a small, repeatable reduction in per-snapshot build time. Semantic context polling defaults to 3000 ms, so this is not expected to move frame rate in a typical app.

Covered by a new colocated `SemanticTreeBuilder.test.ts`:

- positions and bounds for objects beneath transformed, rotated, and scaled parents
- fresh values on a later snapshot after objects move and rescale
- no forced per-node subtree refresh during a snapshot
- a custom `getWorldPosition` override remains authoritative
- a real `UICard` / `UIPanel` registered through the presentation helper under a separate render root, where the logical and presentation transforms differ

Three of those cases fail against the behavior they guard, so they are live regressions rather than restatements.

Verified in Chromium as well as in unit tests: the same page was loaded against a build with and a build without this change, and the resulting semantic trees, visible-object contexts, and bounds were byte-identical across three snapshots taken before and after moving, rotating, and scaling both plain meshes and spatial UI.

## Type of Change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

- **Simulator Recording**: not applicable, there is no visible behavior change. Verified in the desktop simulator by comparing semantic snapshots before and after the change.
- **Device Recording**: not applicable.

## Checklist

- [x] **Tested in simulator & device**: Verified in the desktop simulator. Not tested on physical hardware.
- [ ] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.