### PR TITLE
reuse obstacle bounds after a rejected placement candidate

### DIFF
--- a/src/world/HorizontalPlacement.test.ts
+++ b/src/world/HorizontalPlacement.test.ts
@@ -1,0 +1,164 @@
+import * as THREE from 'three';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {WaitFrame} from '../core/components/WaitFrame';
+
+import {placeOnHorizontalSurface} from './HorizontalPlacement';
+import {DetectedPlane} from './planes/DetectedPlane';
+import {PlaneDetector} from './planes/PlaneDetector';
+
+function createPlacement() {
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera();
+  camera.position.y = 1.6;
+  const planes = new PlaneDetector();
+  const plane = new DetectedPlane(null, new THREE.MeshBasicMaterial(), {
+    type: 'horizontal',
+    label: 'table',
+    area: 9,
+    position: new THREE.Vector3(0, 0.7, -1.5),
+    quaternion: new THREE.Quaternion(),
+    polygon: [
+      new THREE.Vector2(-1.5, -1.5),
+      new THREE.Vector2(1.5, -1.5),
+      new THREE.Vector2(1.5, 1.5),
+      new THREE.Vector2(-1.5, 1.5),
+    ],
+  });
+  planes.add(plane);
+  vi.spyOn(planes, 'get').mockReturnValue([plane]);
+
+  const object = new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.2, 0.2));
+  object.position.set(0, 2, 1);
+  const distant = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1));
+  distant.position.x = 10;
+  const blocker = new THREE.Mesh(new THREE.BoxGeometry(8, 4, 8));
+  blocker.position.set(0, 1, -1.5);
+  scene.add(camera, planes, object, distant, blocker);
+  scene.updateMatrixWorld(true);
+
+  let elapsed = 0;
+  const timer = new THREE.Timer();
+  vi.spyOn(timer, 'getElapsed').mockImplementation(() => elapsed);
+  const waitFrame = new WaitFrame();
+  const wait = vi.spyOn(waitFrame, 'waitFrame').mockImplementation(async () => {
+    elapsed = 1;
+  });
+
+  return {
+    scene,
+    object,
+    distant,
+    blocker,
+    wait,
+    place: () =>
+      placeOnHorizontalSurface(
+        object,
+        camera,
+        scene,
+        planes,
+        undefined,
+        waitFrame,
+        timer,
+        {milliseconds: 500},
+        9
+      ),
+  };
+}
+
+/**
+ * Records which objects get an entry in the obstacle bounds cache, so tests can
+ * assert both that caching happens and that it is skipped where it must be.
+ */
+function recordCachedBounds() {
+  const cached: THREE.Object3D[] = [];
+  const original = Map.prototype.set;
+  vi.spyOn(Map.prototype, 'set').mockImplementation(function (
+    this: Map<unknown, unknown>,
+    key: unknown,
+    value: unknown
+  ) {
+    if (value instanceof THREE.Box3) cached.push(key as THREE.Object3D);
+    return original.call(this, key, value);
+  });
+  return cached;
+}
+
+describe('horizontal placement obstacle bounds', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('computes fixed bounds at most twice across rejected candidates', async () => {
+    const {object, distant, blocker, place} = createPlacement();
+    const originalPosition = object.position.clone();
+    const originalQuaternion = object.quaternion.clone();
+    const bounds = vi.spyOn(THREE.Box3.prototype, 'setFromObject');
+
+    await expect(place()).resolves.toBe(false);
+
+    for (const obstacle of [distant, blocker]) {
+      expect(
+        bounds.mock.calls.filter(([target]) => target === obstacle).length
+      ).toBe(2);
+    }
+    expect(object.position).toEqual(originalPosition);
+    expect(object.quaternion.equals(originalQuaternion)).toBe(true);
+  });
+
+  it('refreshes obstacle bounds when retrying after the next frame', async () => {
+    const {object, blocker, wait, place} = createPlacement();
+    wait.mockImplementationOnce(async () => {
+      blocker.position.x = 10;
+    });
+    const bounds = vi.spyOn(THREE.Box3.prototype, 'setFromObject');
+
+    await expect(place()).resolves.toBe(true);
+
+    expect(wait).toHaveBeenCalledOnce();
+    expect(
+      bounds.mock.calls.filter(([target]) => target === blocker).length
+    ).toBe(3);
+    expect(
+      new THREE.Box3()
+        .setFromObject(object)
+        .intersectsBox(new THREE.Box3().setFromObject(blocker))
+    ).toBe(false);
+  });
+
+  it('never caches ancestor bounds that include the moving object', async () => {
+    const {scene, object, distant, blocker, place} = createPlacement();
+    scene.remove(blocker);
+    const ancestor = new THREE.Mesh(new THREE.BoxGeometry(0.1, 0.1, 0.1));
+    ancestor.add(object);
+    scene.add(ancestor);
+    const cached = recordCachedBounds();
+
+    // Caching the ancestor would let a later candidate pass against bounds
+    // captured while the object sat somewhere else.
+    await expect(place()).resolves.toBe(false);
+
+    expect(cached).toContain(distant);
+    expect(cached).not.toContain(ancestor);
+  });
+
+  it('reuses one scratch box when the first candidate succeeds', async () => {
+    const {blocker, distant, place} = createPlacement();
+    blocker.position.x = 10;
+    const receivers: THREE.Box3[] = [];
+    const original = THREE.Box3.prototype.setFromObject;
+    vi.spyOn(THREE.Box3.prototype, 'setFromObject').mockImplementation(
+      function (this: THREE.Box3, target: THREE.Object3D, precise?: boolean) {
+        if (target === blocker || target === distant) receivers.push(this);
+        return original.call(this, target, precise);
+      }
+    );
+    const cached = recordCachedBounds();
+
+    await expect(place()).resolves.toBe(true);
+
+    expect(receivers).toHaveLength(2);
+    expect(receivers[0]).toBe(receivers[1]);
+    expect(cached).toHaveLength(0);
+  });
+});

--- a/src/world/HorizontalPlacement.ts
+++ b/src/world/HorizontalPlacement.ts
@@ -244,6 +244,14 @@ export async function placeOnHorizontalSurface(
     const origPosition = objectToPlace.position.clone();
     const origQuaternion = objectToPlace.quaternion.clone();
 
+    // Scratch box reused while evaluating the first candidate. Obstacle bounds
+    // only get cached once a candidate has been rejected, so the common
+    // first-candidate success never pays for the cache. The cache lives inside
+    // the frame loop so it is rebuilt after yielding, picking up obstacles that
+    // moved in the meantime.
+    const obstacleBox = new THREE.Box3();
+    let obstacleBounds: Map<THREE.Object3D, THREE.Box3> | undefined;
+
     for (const cand of candidates) {
       // Verify timeout inside the validation loop to abort quickly if running slow
       if (timer.getElapsed() - startElapsed >= timeoutSeconds) {
@@ -289,14 +297,22 @@ export async function placeOnHorizontalSurface(
       const collisionBox = objectBox.clone();
 
       let collision = false;
-      const obstacleBox = new THREE.Box3();
       for (const obstacle of collidableObjects) {
         if (obstacle === cand.plane) {
           continue;
         }
-        obstacle.updateMatrixWorld(true);
-        obstacleBox.setFromObject(obstacle);
-        if (collisionBox.intersectsBox(obstacleBox)) {
+        let bounds = obstacleBounds?.get(obstacle);
+        if (!bounds) {
+          obstacle.updateMatrixWorld(true);
+          bounds = obstacleBox.setFromObject(obstacle);
+          // Ancestor bounds include the moving object, so they change from one
+          // candidate to the next and must not be cached.
+          if (obstacleBounds && !isDescendantOf(objectToPlace, obstacle)) {
+            bounds = bounds.clone();
+            obstacleBounds.set(obstacle, bounds);
+          }
+        }
+        if (collisionBox.intersectsBox(bounds)) {
           collision = true;
           break;
         }
@@ -306,6 +322,10 @@ export async function placeOnHorizontalSurface(
         placed = true;
         break; // Successful placement!
       }
+
+      // Start caching only once a candidate has been rejected, since more
+      // candidates will now be tested against the same obstacles.
+      obstacleBounds ??= new Map();
     }
 
     if (placed) {


### PR DESCRIPTION
## Description

<!-- Brief summary of changes. For new demos/samples, include the directory path (e.g., `demos/my_demo/`). -->

`placeOnHorizontalSurface` walks the same obstacle geometry again for every candidate it rejects in a crowded scene.

Keeps the first candidate on one scratch box, then caches obstacle bounds if it fails. The cache resets after each frame yield, and bounds containing the moving object are never cached. Collision testing, scoring, transform restoration and timeout behaviour are unchanged, and there is no public API or configuration change.

In an isolated controlled Chrome 152 / Apple M4 benchmark with 56 candidates and 151 obstacle meshes, synchronous search-pass time went from 3.332 +/- 0.232 ms to 0.338 +/- 0.034 ms across five interleaved pairs. No clear change when the first choice was free. This is less search work, not an FPS or full placement-latency claim.

Checked in the desktop simulator with a cluttered surface: the same spot is chosen as before the change, with obstacle bounds calculations falling from 839 to 105 for that placement.

Colocated coverage includes first-choice scratch reuse with nothing cached, bounded recomputation, moved obstacles after a yield, ancestor bounds never being cached, and restoring the target after a failed pass.

## Type of Change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] New demo or sample
- [ ] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

- **Simulator Recording**: <!-- Attach video/GIF running in desktop simulator --> Not attached; no visual change intended.
- **Device Recording**: <!-- Attach video/GIF running on physical hardware --> Not attached; no physical-device run.

## Checklist

- [ ] **Tested in simulator & device**: Automated geometry cases plus a scripted desktop simulator run comparing placement before and after; no physical-device run.
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN. N/A, no assets added.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime. N/A, no dependencies added.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.