### PR TITLE
docs: remove redundant heading from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-# Pull Request Template
-
 ## Description
 
 <!-- Brief summary of changes. For new demos/samples, include the directory path (e.g., `demos/my_demo/`). -->


### PR DESCRIPTION
## Description

<!-- Brief summary of changes. For new demos/samples, include the directory path (e.g., `demos/my_demo/`). -->

new PRs inherit a `Pull Request Template` heading because it's visible text at the top of the template.

removes that heading and the blank line after it. keeps the actual sections, prompts and checklist unchanged.

## Type of Change

- [ ] Bug fix
- [ ] New feature / enhancement
- [ ] New demo or sample
- [x] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

- **Simulator Recording**: <!-- Attach video/GIF running in desktop simulator --> N/A (template-only change).
- **Device Recording**: <!-- Attach video/GIF running on physical hardware --> N/A (template-only change).

## Checklist

- [ ] **Tested in simulator & device**: Verified functionality in desktop simulator and/or physical hardware (where applicable). N/A (template-only change).
- [ ] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN. N/A (no assets added).
- [ ] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime. N/A (no dependencies added).
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.