### PR TITLE
Allow per-call object detection snapshots and backends

### DIFF
--- a/demos/objects_3d/index.html
+++ b/demos/objects_3d/index.html
@@ -1693,13 +1693,7 @@
         }
       }
 
-      // Reentrancy guard. detect() runs for tens of seconds while monkey-
-      // patching xb.core.deviceCamera.getSnapshot; a concurrent press
-      // would capture our wrapper as its "original" and leave it
-      // installed when it restored, plus other SDK consumers calling
-      // getSnapshot during the overlap would receive the wrong cached
-      // frame. We disable the button in the UI but also gate here so
-      // programmatic callers (e.g. tests, playwright) can't trigger it.
+      // Prevent overlapping fitting/fusion runs, including programmatic calls.
       let _detectInFlight = false;
 
       async function detect() {
@@ -1804,13 +1798,9 @@
           if (detectBtn) detectBtn.disabled = false;
           return;
         }
-        const _origGetSnapshot = xb.core.deviceCamera.getSnapshot.bind(
-          xb.core.deviceCamera
-        );
-        xb.core.deviceCamera.getSnapshot = async (opts) => {
-          if (opts?.outputFormat === 'base64') return snapBase64;
-          if (opts?.outputFormat === 'imageData') return snapImageData;
-          return _origGetSnapshot(opts);
+        const detectionSnapshot = {
+          base64: snapBase64,
+          imageData: snapImageData,
         };
         // Start SAM init + encode in parallel with detection. Both
         // network (gemini) and GPU (SAM encoder) work happens concurrently
@@ -1828,35 +1818,30 @@
           })();
           samPrep.catch(() => {});
         }
-        // Everything from here runs inside try/finally so the
-        // getSnapshot monkey-patch, the depth-mesh snapshot, the BVH
-        // bounds tree, the reentrancy flag, and the button-disabled
-        // state always come back even on detection / SAM / fitting
-        // failures. Without this, repeated failed presses leak memory
-        // and the cached-snapshot getter stays installed for other
-        // consumers.
+        // Release the frozen depth mesh and reset the UI even if detection,
+        // segmentation, or fitting fails.
         try {
           let detected = [];
           try {
             if (DETECT_BACKEND === 'both') {
-              // Run both detectors and union with IoU dedupe. Two
-              // separate runDetection calls because the SDK only exposes
-              // one activeBackend at a time. Run mediapipe first so its
-              // deterministic COCO results anchor the dedupe, then add
-              // gemini's open-vocab finds that don't overlap.
-              const cfg = xb.core.world.objects.options.objects.backendConfig;
-              const prev = cfg.activeBackend;
-              try {
-                cfg.activeBackend = 'mediapipe';
-                const mp = await xb.core.world.objects.runDetection();
-                cfg.activeBackend = 'gemini';
-                const gm = await xb.core.world.objects.runDetection();
-                detected = unionDetections(mp, gm);
-              } finally {
-                cfg.activeBackend = prev;
-              }
+              // Submit together to retain the same frame pose. The detector
+              // queues the runs; MediaPipe results anchor the IoU dedupe.
+              const [mp, gm] = await Promise.all([
+                xb.core.world.objects.runDetection({
+                  backend: 'mediapipe',
+                  snapshot: detectionSnapshot,
+                }),
+                xb.core.world.objects.runDetection({
+                  backend: 'gemini',
+                  snapshot: detectionSnapshot,
+                }),
+              ]);
+              detected = unionDetections(mp, gm);
             } else {
-              detected = await xb.core.world.objects.runDetection();
+              detected = await xb.core.world.objects.runDetection({
+                backend: DETECT_BACKEND,
+                snapshot: detectionSnapshot,
+              });
             }
           } catch (e) {
             console.warn('[objects_3d] detection threw', e);
@@ -1904,11 +1889,6 @@
           // runDetection so SAM masks line up exactly with the bboxes the
           // detectors returned.
           const snapshot = snapImageData;
-          // Restore the original snapshot getter; everything downstream
-          // (fitting, raycasting) uses the cached pixel data and the
-          // frozen camera, so there's no need to keep the monkey-patch
-          // active. The outer finally restores it too as a safety net.
-          xb.core.deviceCamera.getSnapshot = _origGetSnapshot;
           setStatus('fitting boxes…');
           const floorY = estimateFloorY();
           // Pipeline the per-object work: mask decode (serial on GPU via
@@ -2104,13 +2084,6 @@
             `fit ${kept} / ${detected.length} oriented boxes (press again from a new angle to refine)`
           );
         } finally {
-          // Centralized cleanup: every exit path from the inner try
-          // (success, "nothing detected", thrown detection, sam encoder
-          // fail) lands here. Restore the snapshot getter even if the
-          // inner happy-path already did it (idempotent), release the
-          // BVH index and geometry, free the material, and clear the
-          // reentrancy gate so the next press can run.
-          xb.core.deviceCamera.getSnapshot = _origGetSnapshot;
           if (frozenDepthMesh.geometry) {
             if (frozenDepthMesh.geometry.disposeBoundsTree) {
               frozenDepthMesh.geometry.disposeBoundsTree();

--- a/docs/docs/manual/World.mdx
+++ b/docs/docs/manual/World.mdx
@@ -74,7 +74,7 @@ uses depth to ground them in world space. Choose the backend explicitly.
 
 ### Backends
 
-Under the hood, object detection uses pluggable backends selected via `options.world.objects.backend`:
+Under the hood, object detection uses pluggable backends selected via `options.world.objects.backendConfig.activeBackend`:
 
 - **`GeminiDetectorBackend`**: Queries Gemini models using visual camera frames (requires AI API keys, see the [Generative AI](AI.mdx) guide).
 - **`MediaPipeDetectorBackend`**: Runs local MediaPipe object detection model.
@@ -112,10 +112,24 @@ for (const object of objects) {
 }
 ```
 
-Concurrent calls share the active detection. A new run clears previous
+Concurrent calls without overrides share the active detection. A new run clears previous
 detected-object scene nodes before publishing current results. Treat `[]` as a
 normal warm-up, empty, unavailable, or failed result and update application
 state accordingly.
+
+To use a captured frame or a different backend for one call without changing the defaults:
+
+```js
+const imageData = xb.core.deviceCamera.getSnapshot({outputFormat: 'imageData'});
+const objects = await xb.world.objects.runDetection({
+  backend: 'mediapipe',
+  snapshot: {imageData},
+});
+```
+
+Both fields are optional. Gemini snapshots require a `base64` data URL; MediaPipe snapshots require `imageData`. Supply both representations of the same frame when sharing a snapshot between backends. A missing representation rejects the request rather than capturing a different image.
+
+Calls supplying either field queue separate runs, in submission order, after any ongoing detection. A failed run does not block later requests. Capture and submit a snapshot in the same frame: its camera pose and depth mesh are frozen at submission, including while queued. Do not modify the supplied pixels until the request completes. Without a supplied snapshot, the run captures from the live camera. Camera and depth prerequisites still apply.
 
 For continuous ownership, pair the same client object:
 
@@ -130,6 +144,8 @@ Use `options.world.objects.pollingIntervalMs` to control cadence. The desktop
 simulator can supply deterministic object ground truth when
 `options.world.objects.simulatorOverride = true` and its environment defines
 detectable objects.
+
+Simulator ground truth takes precedence over per-call inputs when enabled. Disable `simulatorOverride` to exercise the camera backends in the simulator.
 
 ## Human pose detection
 

--- a/src/addons/objects3d/Object3DDetector.test.ts
+++ b/src/addons/objects3d/Object3DDetector.test.ts
@@ -1,0 +1,115 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  runDetection: vi.fn(),
+  getSnapshot: vi.fn(),
+}));
+
+vi.mock('xrblocks', async () => {
+  const THREE = await import('three');
+  return {
+    Script: THREE.Object3D,
+    enableAcceleratedRaycast: vi.fn().mockResolvedValue(false),
+    core: {
+      camera: new THREE.PerspectiveCamera(),
+      deviceCamera: Object.freeze({getSnapshot: mocks.getSnapshot}),
+      depth: {depthMesh: new THREE.Mesh(new THREE.BoxGeometry())},
+      world: {
+        objects: {runDetection: mocks.runDetection},
+        options: {
+          objects: {
+            backendConfig: Object.freeze({activeBackend: 'gemini'}),
+          },
+        },
+      },
+    },
+  };
+});
+
+vi.mock('./masks/SamMask', () => ({
+  getSam: vi.fn(),
+  samEncodeSnapshot: vi.fn(),
+  samMaskFromBbox: vi.fn(),
+}));
+
+vi.mock('./masks/SegmenterMask', () => ({
+  segmenterMaskFromSnapshot: vi.fn(),
+}));
+
+import {Object3DDetector} from './Object3DDetector';
+
+describe('Object3DDetector per-call inputs', () => {
+  const imageData: ImageData = {
+    width: 1,
+    height: 1,
+    data: new Uint8ClampedArray(4),
+    colorSpace: 'srgb',
+  };
+  const base64 = 'data:image/jpeg;base64,c25hcHNob3Q=';
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    mocks.getSnapshot.mockReturnValue(imageData);
+    mocks.runDetection.mockResolvedValue([]);
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      putImageData: vi.fn(),
+    } as CanvasRenderingContext2D);
+    vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue(base64);
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  it.each(['gemini', 'mediapipe'] as const)(
+    'passes the captured frame to %s without mutating shared state',
+    async (backend) => {
+      const detector = new Object3DDetector({
+        detectBackend: backend,
+        maskBackend: 'mediapipe',
+      });
+
+      await detector.detect();
+
+      expect(mocks.getSnapshot).toHaveBeenCalledTimes(1);
+      expect(mocks.runDetection).toHaveBeenCalledExactlyOnceWith({
+        backend,
+        snapshot: {base64, imageData},
+      });
+    }
+  );
+
+  it('reuses the same snapshot across both backend requests', async () => {
+    const pending = Promise.withResolvers<[]>();
+    mocks.runDetection.mockReturnValueOnce(pending.promise);
+    const detector = new Object3DDetector({
+      detectBackend: 'both',
+      maskBackend: 'mediapipe',
+    });
+
+    const detection = detector.detect();
+    await Promise.resolve();
+
+    expect(mocks.getSnapshot).toHaveBeenCalledTimes(1);
+    expect(mocks.runDetection).toHaveBeenNthCalledWith(1, {
+      backend: 'mediapipe',
+      snapshot: {base64, imageData},
+    });
+    expect(mocks.runDetection).toHaveBeenNthCalledWith(2, {
+      backend: 'gemini',
+      snapshot: {base64, imageData},
+    });
+    pending.resolve([]);
+    await detection;
+  });
+
+  it('can run again after a per-call request fails', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mocks.runDetection.mockRejectedValueOnce(new Error('detection failed'));
+    const detector = new Object3DDetector({maskBackend: 'mediapipe'});
+
+    await detector.detect();
+    await detector.detect();
+
+    expect(mocks.runDetection).toHaveBeenCalledTimes(2);
+    expect(mocks.getSnapshot).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/addons/objects3d/Object3DDetector.ts
+++ b/src/addons/objects3d/Object3DDetector.ts
@@ -241,20 +241,9 @@ export class Object3DDetector extends Script {
         return this._results;
       }
 
-      // Monkey-patch getSnapshot so the SDK detector backends read our cached
-      // frame instead of the live video (which may have drifted by the time
-      // they call it).
-      type SnapFn = typeof deviceCamera.getSnapshot;
-      const origGetSnapshot = deviceCamera.getSnapshot.bind(
-        deviceCamera
-      ) as SnapFn;
-      const mutableCamera = deviceCamera as unknown as {
-        getSnapshot: (opts?: {outputFormat?: string}) => unknown;
-      };
-      mutableCamera.getSnapshot = (opts?: {outputFormat?: string}) => {
-        if (opts?.outputFormat === 'base64') return Promise.resolve(snapBase64);
-        if (opts?.outputFormat === 'imageData') return snapImageData;
-        return (origGetSnapshot as (opts?: unknown) => unknown)(opts);
+      const detectionSnapshot = {
+        base64: snapBase64,
+        imageData: snapImageData,
       };
 
       // Start SAM init + encode in parallel with 2-D detection.
@@ -274,26 +263,23 @@ export class Object3DDetector extends Script {
         let detected: Awaited<ReturnType<typeof worldObjects.runDetection>>;
         try {
           if (this._opts.detectBackend === 'both') {
-            const cfg = core.world!.options.objects.backendConfig;
-            const prev = cfg.activeBackend;
-            try {
-              cfg.activeBackend = 'mediapipe';
-              const mp = await worldObjects.runDetection();
-              cfg.activeBackend = 'gemini';
-              const gm = await worldObjects.runDetection();
-              detected = unionDetections(mp, gm) as typeof mp;
-            } finally {
-              cfg.activeBackend = prev;
-            }
+            // Submit both now so their queued runs retain the same frame pose.
+            const [mp, gm] = await Promise.all([
+              worldObjects.runDetection({
+                backend: 'mediapipe',
+                snapshot: detectionSnapshot,
+              }),
+              worldObjects.runDetection({
+                backend: 'gemini',
+                snapshot: detectionSnapshot,
+              }),
+            ]);
+            detected = unionDetections(mp, gm);
           } else {
-            const cfg = core.world!.options.objects.backendConfig;
-            const prev = cfg.activeBackend;
-            cfg.activeBackend = this._opts.detectBackend;
-            try {
-              detected = await worldObjects.runDetection();
-            } finally {
-              cfg.activeBackend = prev;
-            }
+            detected = await worldObjects.runDetection({
+              backend: this._opts.detectBackend,
+              snapshot: detectionSnapshot,
+            });
           }
         } catch (e) {
           console.warn('[Object3DDetector] runDetection threw', e);
@@ -316,10 +302,6 @@ export class Object3DDetector extends Script {
             return this._results;
           }
         }
-
-        // Restore the snapshot getter; fitting uses the frozen camera / mesh.
-        (deviceCamera as unknown as {getSnapshot: SnapFn}).getSnapshot =
-          origGetSnapshot;
 
         const floorY = this._estimateFloorY();
 
@@ -505,9 +487,6 @@ export class Object3DDetector extends Script {
 
         return this._results;
       } finally {
-        // Always restore the snapshot getter and clean up the frozen mesh.
-        (deviceCamera as unknown as {getSnapshot: SnapFn}).getSnapshot =
-          origGetSnapshot;
         if (frozenDepthMesh.geometry) {
           const geom = frozenDepthMesh.geometry as THREE.BufferGeometry & {
             disposeBoundsTree?: () => void;

--- a/src/world/objects/ObjectDetector.test.ts
+++ b/src/world/objects/ObjectDetector.test.ts
@@ -3,6 +3,7 @@ import {beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {AI} from '../../ai/AI';
 import {AIOptions} from '../../ai/AIOptions';
+import {getCameraParametersSnapshot} from '../../camera/CameraUtils';
 import {XRDeviceCamera} from '../../camera/XRDeviceCamera';
 import {Depth} from '../../depth/Depth';
 import {WorldOptions} from '../WorldOptions';
@@ -11,7 +12,7 @@ import {DetectedObject} from './DetectedObject';
 import {ObjectDetector} from './ObjectDetector';
 
 vi.mock('../../camera/CameraUtils', () => ({
-  getCameraParametersSnapshot: vi.fn().mockReturnValue({}),
+  getCameraParametersSnapshot: vi.fn(),
 }));
 
 interface PrivateObjectDetector {
@@ -35,17 +36,36 @@ describe('ObjectDetector Multi-Client API', () => {
   let detector: ObjectDetector;
   let mockBackend: {run: ReturnType<typeof vi.fn>};
   let options: WorldOptions;
+  let depthMesh: THREE.Mesh;
+
+  const imageData: ImageData = {
+    width: 1,
+    height: 1,
+    data: new Uint8ClampedArray(4),
+    colorSpace: 'srgb',
+  };
+  const snapshot = {
+    base64: 'data:image/jpeg;base64,c25hcHNob3Q=',
+    imageData,
+  };
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.mocked(getCameraParametersSnapshot).mockClear().mockReturnValue({
+      clipFromView: new THREE.Matrix4(),
+      viewFromClip: new THREE.Matrix4(),
+      worldFromView: new THREE.Matrix4(),
+      worldFromClip: new THREE.Matrix4(),
+    });
 
     options = new WorldOptions();
     options.objects.enable();
     const ai = {} as unknown as AI;
     const aiOptions = {} as unknown as AIOptions;
     const deviceCamera = {} as unknown as XRDeviceCamera;
+    depthMesh = new THREE.Mesh(new THREE.BoxGeometry());
     const depth = {
-      depthMesh: new THREE.Mesh(new THREE.BoxGeometry()),
+      depthMesh,
       options: {
         depthMesh: {
           updateFullResolutionGeometry: false,
@@ -71,7 +91,9 @@ describe('ObjectDetector Multi-Client API', () => {
     });
 
     mockBackend = {
-      run: vi.fn().mockResolvedValue([createDetectedObject('chair')]),
+      run: vi
+        .fn()
+        .mockImplementation(async () => [createDetectedObject('chair')]),
     };
     vi.spyOn(
       detector as unknown as PrivateObjectDetector,
@@ -171,6 +193,291 @@ describe('ObjectDetector Multi-Client API', () => {
 
     await runPromise;
     expect(mockBackend.run).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares a one-off run when no overrides are supplied', async () => {
+    const first = detector.runDetection();
+
+    expect(detector.runDetection()).toBe(first);
+    expect(detector.runDetection({})).toBe(first);
+    await first;
+    expect(mockBackend.run).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses a per-call backend and snapshot without changing the default', async () => {
+    const results = await detector.runDetection({
+      backend: 'mediapipe',
+      snapshot,
+    });
+
+    expect(results.map((object) => object.label)).toEqual(['chair']);
+    expect(
+      (detector as unknown as PrivateObjectDetector).getOrCreateDetectorBackend
+    ).toHaveBeenCalledWith('mediapipe', expect.any(Object));
+    expect(mockBackend.run).toHaveBeenCalledWith(
+      expect.any(THREE.Mesh),
+      expect.any(Object),
+      snapshot
+    );
+    expect(options.objects.backendConfig.activeBackend).toBe('gemini');
+  });
+
+  it('uses the configured backend for a snapshot-only request', async () => {
+    await detector.runDetection({snapshot});
+
+    expect(
+      (detector as unknown as PrivateObjectDetector).getOrCreateDetectorBackend
+    ).toHaveBeenCalledWith('gemini', expect.any(Object));
+    expect(mockBackend.run.mock.calls[0][2]).toEqual(snapshot);
+  });
+
+  it('queues explicit requests in order while ordinary calls share the active run', async () => {
+    const pending = Promise.withResolvers<DetectedObject<unknown>[]>();
+    mockBackend.run.mockReturnValueOnce(pending.promise);
+    const first = detector.runDetection();
+    await Promise.resolve();
+
+    const second = detector.runDetection({
+      backend: 'mediapipe',
+      snapshot,
+    });
+    const thirdSnapshot = {base64: 'data:image/jpeg;base64,dGhpcmQ='};
+    const third = detector.runDetection({
+      backend: 'gemini',
+      snapshot: thirdSnapshot,
+    });
+
+    expect(second).not.toBe(first);
+    expect(third).not.toBe(second);
+    expect(detector.runDetection()).toBe(first);
+    detector.update();
+    expect(mockBackend.run).toHaveBeenCalledTimes(1);
+
+    pending.resolve([createDetectedObject('first')]);
+    await first;
+    await second;
+    await third;
+
+    const factory = vi.mocked(
+      (detector as unknown as PrivateObjectDetector).getOrCreateDetectorBackend
+    );
+    expect(factory.mock.calls.map(([backend]) => backend)).toEqual([
+      'gemini',
+      'mediapipe',
+      'gemini',
+    ]);
+    expect(mockBackend.run.mock.calls.map((call) => call[2])).toEqual([
+      undefined,
+      snapshot,
+      thirdSnapshot,
+    ]);
+    expect(options.objects.backendConfig.activeBackend).toBe('gemini');
+  });
+
+  it('continues queued requests after an earlier run rejects', async () => {
+    const pending = Promise.withResolvers<DetectedObject<unknown>[]>();
+    mockBackend.run.mockReturnValueOnce(pending.promise);
+    const first = detector.runDetection();
+    const firstFailure = expect(first).rejects.toThrow('first failed');
+    const second = detector.runDetection({backend: 'mediapipe'});
+
+    pending.reject(new Error('first failed'));
+
+    await firstFailure;
+    await expect(second).resolves.toHaveLength(1);
+    await detector.runDetection();
+    expect(mockBackend.run).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not let continuous detection overtake a queued request', async () => {
+    const pending = Promise.withResolvers<DetectedObject<unknown>[]>();
+    mockBackend.run.mockReturnValueOnce(pending.promise);
+    const first = detector.runDetection();
+    const resumed = first.then(() => {
+      detector.start({});
+      detector.update();
+    });
+    const second = detector.runDetection({backend: 'mediapipe'});
+
+    pending.resolve([]);
+    await resumed;
+    await second;
+
+    const factory = vi.mocked(
+      (detector as unknown as PrivateObjectDetector).getOrCreateDetectorBackend
+    );
+    expect(factory.mock.calls.map(([backend]) => backend)).toEqual([
+      'gemini',
+      'mediapipe',
+    ]);
+  });
+
+  it('preserves the submitted frame pose and depth while a snapshot waits', async () => {
+    const pending = Promise.withResolvers<DetectedObject<unknown>[]>();
+    mockBackend.run.mockReturnValueOnce(pending.promise);
+    const first = detector.runDetection();
+    await Promise.resolve();
+
+    const cameraSnapshot = {
+      clipFromView: new THREE.Matrix4(),
+      viewFromClip: new THREE.Matrix4(),
+      worldFromView: new THREE.Matrix4().makeTranslation(1, 2, 3),
+      worldFromClip: new THREE.Matrix4(),
+    };
+    vi.mocked(getCameraParametersSnapshot).mockReturnValueOnce(cameraSnapshot);
+    const capturedGeometry = depthMesh.geometry.clone();
+    vi.spyOn(depthMesh.geometry, 'clone').mockReturnValueOnce(capturedGeometry);
+    const disposeGeometry = vi.spyOn(capturedGeometry, 'dispose');
+    const second = detector.runDetection({snapshot});
+
+    depthMesh.position.set(10, 20, 30);
+    depthMesh.geometry.translate(10, 20, 30);
+    pending.resolve([]);
+    await first;
+    await second;
+
+    const [frozenMesh, frozenCamera] = mockBackend.run.mock.calls[1];
+    expect(frozenCamera).toBe(cameraSnapshot);
+    expect(frozenMesh.position).toEqual(new THREE.Vector3());
+    expect(frozenMesh.geometry).toBe(capturedGeometry);
+    expect(capturedGeometry.boundingBox?.max.x).toBe(0.5);
+    expect(disposeGeometry).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures request settings before callers change them while queued', async () => {
+    const pending = Promise.withResolvers<DetectedObject<unknown>[]>();
+    mockBackend.run.mockReturnValueOnce(pending.promise);
+    const first = detector.runDetection();
+    const submittedSnapshot = {...snapshot};
+    const second = detector.runDetection({snapshot: submittedSnapshot});
+
+    submittedSnapshot.base64 = 'a later frame';
+    options.objects.backendConfig.activeBackend = 'mediapipe';
+    pending.resolve([]);
+    await first;
+    await second;
+
+    expect(
+      (detector as unknown as PrivateObjectDetector).getOrCreateDetectorBackend
+    ).toHaveBeenLastCalledWith('gemini', expect.any(Object));
+    expect(mockBackend.run.mock.calls[1][2]).toEqual(snapshot);
+    expect(options.objects.backendConfig.activeBackend).toBe('mediapipe');
+  });
+
+  it('does not re-ground a queued snapshot if its original camera pose was unavailable', async () => {
+    const pending = Promise.withResolvers<DetectedObject<unknown>[]>();
+    mockBackend.run.mockReturnValueOnce(pending.promise);
+    const first = detector.runDetection();
+    vi.mocked(getCameraParametersSnapshot).mockReturnValueOnce(null);
+    const second = detector.runDetection({snapshot});
+
+    pending.resolve([]);
+    await first;
+    await expect(second).resolves.toEqual([]);
+    expect(mockBackend.run).toHaveBeenCalledTimes(1);
+    expect(getCameraParametersSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not change continuous detection defaults after an explicit request', async () => {
+    detector.start({});
+    await detector.runDetection();
+    await detector.runDetection({backend: 'mediapipe'});
+
+    detector.update();
+    await detector.runDetection();
+
+    const factory = vi.mocked(
+      (detector as unknown as PrivateObjectDetector).getOrCreateDetectorBackend
+    );
+    expect(factory.mock.calls.map(([backend]) => backend)).toEqual([
+      'gemini',
+      'mediapipe',
+      'gemini',
+    ]);
+    expect(detector.detectedObjects).toHaveLength(1);
+  });
+
+  it.each([
+    {backend: 'gemini', snapshot: {imageData}, field: 'base64'},
+    {
+      backend: 'mediapipe',
+      snapshot: {base64: snapshot.base64},
+      field: 'imageData',
+    },
+    {backend: 'gemini', snapshot: {}, field: 'base64'},
+  ] as const)(
+    'rejects a $backend snapshot missing $field rather than capturing another frame',
+    async ({backend, snapshot, field}) => {
+      await expect(detector.runDetection({backend, snapshot})).rejects.toThrow(
+        field
+      );
+
+      expect(mockBackend.run).not.toHaveBeenCalled();
+      expect(getCameraParametersSnapshot).not.toHaveBeenCalled();
+      await expect(detector.runDetection()).resolves.toHaveLength(1);
+    }
+  );
+
+  it('keeps simulator ground truth authoritative when it is installed', async () => {
+    const source = {detect: vi.fn().mockReturnValue([])};
+    detector.setSimulatorSource(source);
+
+    await detector.runDetection({backend: 'mediapipe', snapshot});
+
+    expect(source.detect).toHaveBeenCalledTimes(1);
+    expect(mockBackend.run).not.toHaveBeenCalled();
+    expect(getCameraParametersSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported per-call backend names', async () => {
+    await expect(
+      // @ts-expect-error Exercise input validation for JavaScript callers.
+      detector.runDetection({backend: 'unsupported'})
+    ).rejects.toThrow("backend 'unsupported' is not supported");
+    expect(mockBackend.run).not.toHaveBeenCalled();
+  });
+
+  it('releases a supplied frame when its backend rejects and allows another request', async () => {
+    const capturedGeometry = depthMesh.geometry.clone();
+    vi.spyOn(depthMesh.geometry, 'clone').mockReturnValueOnce(capturedGeometry);
+    const disposeGeometry = vi.spyOn(capturedGeometry, 'dispose');
+    mockBackend.run.mockRejectedValueOnce(new Error('backend failed'));
+    const first = detector.runDetection({snapshot});
+    const firstFailure = expect(first).rejects.toThrow('backend failed');
+    const second = detector.runDetection({backend: 'mediapipe'});
+
+    await firstFailure;
+    await expect(second).resolves.toHaveLength(1);
+    expect(disposeGeometry).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not capture another frame for requests made after disposal', async () => {
+    detector.dispose();
+
+    await expect(detector.runDetection({snapshot})).rejects.toThrow('disposed');
+    expect(getCameraParametersSnapshot).not.toHaveBeenCalled();
+    expect(mockBackend.run).not.toHaveBeenCalled();
+  });
+
+  it('releases queued frame resources and rejects the request after disposal', async () => {
+    const pending = Promise.withResolvers<DetectedObject<unknown>[]>();
+    mockBackend.run.mockReturnValueOnce(pending.promise);
+    const first = detector.runDetection();
+    await Promise.resolve();
+
+    const capturedGeometry = depthMesh.geometry.clone();
+    vi.spyOn(depthMesh.geometry, 'clone').mockReturnValueOnce(capturedGeometry);
+    const disposeGeometry = vi.spyOn(capturedGeometry, 'dispose');
+    const second = detector.runDetection({snapshot});
+    const secondFailure = expect(second).rejects.toThrow('disposed');
+
+    detector.dispose();
+    pending.resolve([]);
+    await first;
+    await secondFailure;
+
+    expect(mockBackend.run).toHaveBeenCalledTimes(1);
+    expect(disposeGeometry).toHaveBeenCalledTimes(1);
   });
 
   it('disposes temporary depth mesh snapshots after detection', async () => {

--- a/src/world/objects/ObjectDetector.ts
+++ b/src/world/objects/ObjectDetector.ts
@@ -2,7 +2,10 @@ import * as THREE from 'three';
 
 import {AI} from '../../ai/AI';
 import {AIOptions} from '../../ai/AIOptions';
-import {getCameraParametersSnapshot} from '../../camera/CameraUtils';
+import {
+  getCameraParametersSnapshot,
+  type CameraParametersSnapshot,
+} from '../../camera/CameraUtils';
 import {XRDeviceCamera} from '../../camera/XRDeviceCamera';
 import {Script} from '../../core/Script';
 import {Depth} from '../../depth/Depth';
@@ -44,6 +47,24 @@ export interface CameraSnapshot {
   imageData?: ImageData;
 }
 
+/** Inputs for one object detection run, without changing shared options. */
+export interface ObjectDetectionOptions {
+  /** Uses this backend for this run only; otherwise uses the configured backend. */
+  backend?: WorldOptions['objects']['backendConfig']['activeBackend'];
+  /**
+   * Uses this frame instead of capturing another one. Gemini requires
+   * `base64`; MediaPipe requires `imageData`. Both may be supplied for the
+   * same frame. Capture and submit in the same frame so the camera pose and
+   * depth mesh match, and do not modify the pixels until the run completes.
+   */
+  snapshot?: CameraSnapshot;
+}
+
+interface ObjectDetectionFrame {
+  cameraParametersSnapshot: CameraParametersSnapshot;
+  depthMeshSnapshot: THREE.Mesh;
+}
+
 export interface SimulatorDetectedObjectInput<T = unknown> {
   label: string;
   position: THREE.Vector3;
@@ -81,6 +102,8 @@ export class ObjectDetector extends Script {
   >();
   private activeClients = new Set<object>();
   private currentDetectionPromise: Promise<DetectedObject<unknown>[]> | null =
+    null;
+  private pendingDetectionPromise: Promise<DetectedObject<unknown>[]> | null =
     null;
   private lastContinuousDetectionStartedAtMs = -Infinity;
   private disposed = false;
@@ -185,7 +208,11 @@ export class ObjectDetector extends Script {
    * ensures the continuous object detection is running.
    */
   override update() {
-    if (this.activeClients.size === 0 || this.currentDetectionPromise) {
+    if (
+      this.activeClients.size === 0 ||
+      this.currentDetectionPromise ||
+      this.pendingDetectionPromise
+    ) {
       return;
     }
 
@@ -202,7 +229,7 @@ export class ObjectDetector extends Script {
   }
 
   private runContinuousDetection() {
-    if (this.currentDetectionPromise) {
+    if (this.currentDetectionPromise || this.pendingDetectionPromise) {
       return;
     }
     this.lastContinuousDetectionStartedAtMs = performance.now();
@@ -226,22 +253,86 @@ export class ObjectDetector extends Script {
    * - If continuous detection is not started, performs a one-off detection and
    *   returns the result. If a one-off detection is already in progress, returns
    *   the promise for that ongoing detection.
+   * - Supplying a snapshot or backend queues a separate one-off run after
+   *   pending detections, without changing the continuous detector's options.
+   *   Supplied snapshots retain the camera pose and depth at submission time.
+   *   Simulator ground truth, when installed, still takes precedence.
    *
+   * @param options - Optional inputs for this run only.
    * @returns A promise that resolves with an
    * array of detected `DetectedObject` instances.
+   * @throws If an explicit backend or snapshot is invalid, or the detector
+   * is disposed before a queued request starts.
    */
-  runDetection<T = null>(): Promise<DetectedObject<T>[]> {
+  runDetection<T = null>(
+    options: ObjectDetectionOptions = {}
+  ): Promise<DetectedObject<T>[]> {
+    if (this.disposed) {
+      return Promise.reject(new Error('ObjectDetector has been disposed.'));
+    }
+    if (options.backend !== undefined || options.snapshot !== undefined) {
+      return this.runDetectionWithOverrides<T>(options);
+    }
     if (this.currentDetectionPromise) {
       return this.currentDetectionPromise as Promise<DetectedObject<T>[]>;
+    }
+    if (this.pendingDetectionPromise) {
+      return this.pendingDetectionPromise as Promise<DetectedObject<T>[]>;
     }
     if (this.activeClients.size > 0) {
       this.runContinuousDetection();
       return this.currentDetectionPromise! as Promise<DetectedObject<T>[]>;
     }
-    this.currentDetectionPromise = this.runDetectionInternal().finally(() => {
-      this.currentDetectionPromise = null;
+    return this.runOneOffDetection() as Promise<DetectedObject<T>[]>;
+  }
+
+  private async runDetectionWithOverrides<T>(
+    options: ObjectDetectionOptions
+  ): Promise<DetectedObject<T>[]> {
+    const backend =
+      options.backend ?? this.options.objects.backendConfig.activeBackend;
+    if (backend !== 'gemini' && backend !== 'mediapipe') {
+      throw new Error(`ObjectDetector backend '${backend}' is not supported.`);
+    }
+    const snapshot =
+      options.snapshot === undefined ? undefined : {...options.snapshot};
+    const requiredField = backend === 'gemini' ? 'base64' : 'imageData';
+    if (snapshot && !snapshot[requiredField]) {
+      throw new Error(
+        `ObjectDetector snapshot for '${backend}' must include ${requiredField}.`
+      );
+    }
+
+    const frame =
+      snapshot && !this.simulatorSource
+        ? this.captureDetectionFrame()
+        : undefined;
+    const run = () => this.runOneOffDetection({backend, snapshot}, frame);
+    const previous =
+      this.pendingDetectionPromise ?? this.currentDetectionPromise;
+    // A failed request rejects its own caller, but must not block later runs.
+    const pending = (previous ? previous.then(run, run) : run()).finally(() => {
+      if (this.pendingDetectionPromise === pending) {
+        this.pendingDetectionPromise = null;
+      }
     });
-    return this.currentDetectionPromise as Promise<DetectedObject<T>[]>;
+    this.pendingDetectionPromise = pending;
+    return pending as Promise<DetectedObject<T>[]>;
+  }
+
+  private runOneOffDetection(
+    options: ObjectDetectionOptions = {},
+    frame?: ObjectDetectionFrame | null
+  ): Promise<DetectedObject<unknown>[]> {
+    const current = this.runDetectionInternal<unknown>(options, frame).finally(
+      () => {
+        if (this.currentDetectionPromise === current) {
+          this.currentDetectionPromise = null;
+        }
+      }
+    );
+    this.currentDetectionPromise = current;
+    return current;
   }
 
   /** Installs or removes the desktop simulator's ground-truth detector. */
@@ -250,63 +341,68 @@ export class ObjectDetector extends Script {
     return this;
   }
 
-  private async runDetectionInternal<T = null>(): Promise<DetectedObject<T>[]> {
-    this.clearDetectedObjects(); // Clear previous scene results before starting a new detection.
-
-    if (this.simulatorSource) {
-      const detectedObjects = this.simulatorSource.detect().map((input) => {
-        const object = new DetectedObject(
-          input.label,
-          null,
-          input.boundingBox,
-          input.data ?? {}
-        );
-        object.position.copy(input.position);
-        return object;
-      });
-      for (const object of detectedObjects) {
-        this._detectedObjects.set(object.uuid, object);
-        this.add(object);
+  private async runDetectionInternal<T = null>(
+    options: ObjectDetectionOptions = {},
+    frame?: ObjectDetectionFrame | null
+  ): Promise<DetectedObject<T>[]> {
+    let detectionFrame = frame;
+    try {
+      if (this.disposed) {
+        throw new Error('ObjectDetector has been disposed.');
       }
-      return detectedObjects as DetectedObject<T>[];
-    }
+      this.clearDetectedObjects(); // Clear previous scene results before starting a new detection.
 
-    const cameraParametersSnapshot = getCameraParametersSnapshot(
-      this.camera,
-      this.renderer.xr.getCamera(),
-      this.deviceCamera,
-      this.targetDevice
-    );
-    if (!cameraParametersSnapshot) {
-      // Device camera not ready yet (warming up); skip until it is available.
-      return [];
-    }
+      if (this.simulatorSource) {
+        const detectedObjects = this.simulatorSource.detect().map((input) => {
+          const object = new DetectedObject(
+            input.label,
+            null,
+            input.boundingBox,
+            input.data ?? {}
+          );
+          object.position.copy(input.position);
+          return object;
+        });
+        for (const object of detectedObjects) {
+          this._detectedObjects.set(object.uuid, object);
+          this.add(object);
+        }
+        return detectedObjects as DetectedObject<T>[];
+      }
 
-    const context = this.getDetectorContext();
-    const activeBackend = this.options.objects.backendConfig.activeBackend;
-    const detectorBackendPromise = this.getOrCreateDetectorBackend<T>(
-      activeBackend,
-      context
-    );
+      if (detectionFrame === undefined) {
+        detectionFrame = this.captureDetectionFrame();
+      }
+      if (!detectionFrame) {
+        // Device camera not ready yet (warming up); skip until it is available.
+        return [];
+      }
 
-    let detectorBackend: BaseDetectorBackend<T>;
-    try {
-      detectorBackend = await detectorBackendPromise;
-    } catch (error) {
-      console.warn(
-        `Failed to load or initialize ObjectDetector backend '${activeBackend}':`,
-        error
+      const context = this.getDetectorContext();
+      const activeBackend =
+        options.backend ?? this.options.objects.backendConfig.activeBackend;
+      const detectorBackendPromise = this.getOrCreateDetectorBackend<T>(
+        activeBackend,
+        context
       );
-      return [];
-    }
-    if (this.disposed) {
-      return [];
-    }
-    const depthMeshSnapshot = this.getDepthMeshSnapshot();
-    try {
+
+      let detectorBackend: BaseDetectorBackend<T>;
+      try {
+        detectorBackend = await detectorBackendPromise;
+      } catch (error) {
+        console.warn(
+          `Failed to load or initialize ObjectDetector backend '${activeBackend}':`,
+          error
+        );
+        return [];
+      }
+      if (this.disposed) {
+        return [];
+      }
       const detectedObjects = await detectorBackend.run(
-        depthMeshSnapshot,
-        cameraParametersSnapshot
+        detectionFrame.depthMeshSnapshot,
+        detectionFrame.cameraParametersSnapshot,
+        options.snapshot
       );
       if (this.disposed) {
         return [];
@@ -317,8 +413,25 @@ export class ObjectDetector extends Script {
       }
       return detectedObjects;
     } finally {
-      this.disposeDepthMeshSnapshot(depthMeshSnapshot);
+      if (detectionFrame) {
+        this.disposeDepthMeshSnapshot(detectionFrame.depthMeshSnapshot);
+      }
     }
+  }
+
+  private captureDetectionFrame(): ObjectDetectionFrame | null {
+    const cameraParametersSnapshot = getCameraParametersSnapshot(
+      this.camera,
+      this.renderer.xr.getCamera(),
+      this.deviceCamera,
+      this.targetDevice
+    );
+    return cameraParametersSnapshot
+      ? {
+          cameraParametersSnapshot,
+          depthMeshSnapshot: this.getDepthMeshSnapshot(),
+        }
+      : null;
   }
 
   private getDetectorContext(): DetectorBackendContext {

--- a/src/world/objects/ObjectDetectorBackend.test.ts
+++ b/src/world/objects/ObjectDetectorBackend.test.ts
@@ -1,0 +1,97 @@
+import * as THREE from 'three';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {
+  cropImage,
+  transformRgbUvToWorld,
+  type CameraParametersSnapshot,
+} from '../../camera/CameraUtils';
+import {WorldOptions} from '../WorldOptions';
+import type {CameraSnapshot} from './ObjectDetector';
+import {
+  BaseDetectorBackend,
+  type DetectorBackendContext,
+} from './ObjectDetectorBackend';
+
+vi.mock('../../camera/CameraUtils', () => ({
+  cropImage: vi.fn(),
+  transformRgbUvToWorld: vi.fn(),
+}));
+
+class SnapshotBackend extends BaseDetectorBackend<null> {
+  isAvailable = vi.fn().mockResolvedValue(true);
+  getSnapshot = vi.fn().mockResolvedValue({base64: 'live-frame'});
+  detect = vi
+    .fn()
+    .mockResolvedValue([
+      {xmin: 0, ymin: 0, xmax: 1, ymax: 1, objectName: 'chair'},
+    ]);
+  visualize = vi.fn();
+}
+
+describe('Object detector backend snapshots', () => {
+  let backend: SnapshotBackend;
+  let options: WorldOptions;
+  const depthMesh = new THREE.Mesh(new THREE.BoxGeometry());
+  const cameraSnapshot: CameraParametersSnapshot = {
+    clipFromView: new THREE.Matrix4(),
+    viewFromClip: new THREE.Matrix4(),
+    worldFromView: new THREE.Matrix4(),
+    worldFromClip: new THREE.Matrix4(),
+  };
+  const snapshots: CameraSnapshot[] = [
+    {base64: 'provided-frame'},
+    {
+      imageData: {
+        width: 1,
+        height: 1,
+        data: new Uint8ClampedArray(4),
+        colorSpace: 'srgb',
+      },
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(cropImage).mockResolvedValue('cropped-frame');
+    vi.mocked(transformRgbUvToWorld).mockReturnValue({
+      worldPosition: new THREE.Vector3(1, 2, 3),
+      worldNormal: new THREE.Vector3(0, 1, 0),
+      depthInMeters: 4,
+    });
+    options = new WorldOptions();
+    backend = new SnapshotBackend({options} as DetectorBackendContext);
+  });
+
+  it('captures a live frame when no snapshot is supplied', async () => {
+    await backend.run(depthMesh, cameraSnapshot);
+
+    expect(backend.getSnapshot).toHaveBeenCalledTimes(1);
+    expect(backend.detect).toHaveBeenCalledWith({base64: 'live-frame'});
+    expect(cropImage).toHaveBeenCalledWith(
+      'live-frame',
+      expect.any(THREE.Box2)
+    );
+  });
+
+  it.each(snapshots)(
+    'uses the supplied snapshot for detection, crops, and visualization (%#)',
+    async (snapshot) => {
+      options.objects.showDebugVisualizations = true;
+
+      const objects = await backend.run(depthMesh, cameraSnapshot, snapshot);
+
+      expect(backend.getSnapshot).not.toHaveBeenCalled();
+      expect(backend.detect).toHaveBeenCalledWith(snapshot);
+      expect(cropImage).toHaveBeenCalledWith(
+        snapshot.imageData ?? snapshot.base64,
+        expect.any(THREE.Box2)
+      );
+      expect(backend.visualize).toHaveBeenCalledWith(
+        snapshot,
+        expect.any(Array)
+      );
+      expect(objects[0].position).toEqual(new THREE.Vector3(1, 2, 3));
+    }
+  );
+});

--- a/src/world/objects/ObjectDetectorBackend.ts
+++ b/src/world/objects/ObjectDetectorBackend.ts
@@ -50,13 +50,14 @@ export abstract class BaseDetectorBackend<T> {
 
   async run(
     depthMeshSnapshot: THREE.Mesh,
-    cameraParametersSnapshot: CameraParametersSnapshot
+    cameraParametersSnapshot: CameraParametersSnapshot,
+    snapshotOverride?: CameraSnapshot
   ): Promise<DetectedObject<T>[]> {
     if (!(await this.isAvailable())) {
       return [];
     }
 
-    const snapshot = await this.getSnapshot();
+    const snapshot = snapshotOverride ?? (await this.getSnapshot());
     if (!snapshot) return [];
 
     let normalizedDetections: NormalizedDetectedObject<T>[] = [];


### PR DESCRIPTION
## Description

<!-- Brief summary of changes. For new demos/samples, include the directory path (e.g., `demos/my_demo/`). -->

the 3D detector has to patch the shared camera getter and switch the global backend to reuse a captured frame. overlapping calls can also pick up an in-flight result for the wrong request. this is the `runDetection({snapshot, backend})` follow-up from #417.

adds per-call inputs and queues explicit requests separately, keeping their camera/depth state while they wait. calls without inputs still share the active detection, and simulator ground truth keeps taking precedence. switches the addon and demo callers over; the larger demo migration stays in #487.

tested in the desktop simulator with real MediaPipe, and manually in the browser with live Gemini. also ran 41 browser cases for queueing, errors and cleanup (Gemini responses mocked in those automated cases). full SlimSAM validation and headset testing remain outstanding.

## Type of Change

- [x] Bug fix
- [x] New feature / enhancement
- [ ] New demo or sample
- [x] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

- **Simulator Recording**: <!-- Attach video/GIF running in desktop simulator --> No recording attached.
- **Device Recording**: <!-- Attach video/GIF running on physical hardware --> Not recorded; physical XR hardware was not tested.

## Checklist

- [x] **Tested in simulator & device**: Verified functionality in desktop simulator and/or physical hardware (where applicable). Desktop simulator only.
- [x] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN. N/A; no large assets added.
- [x] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime. N/A; no new SDK dependencies.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.