### PR TITLE
add a standalone Chrome profiler with HTML reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
       - 'build'
     paths:
       - 'src/**'
+      - 'tools/**'
       - 'package.json'
       - 'package-lock.json'
       - 'tsconfig*.json'

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ then set Prettier as your default formatter.
 
 #### Devtools
 
-For local before/after Chrome measurements, see the [standalone profiler](tools/README.md). It records interleaved samples and raw traces and generates a static HTML report, with optional WebGL depth-call counters.
+For local before/after Chrome measurements, see the [standalone profiler](https://github.com/google/xrblocks/blob/main/tools/README.md). It records interleaved samples and raw traces and generates a static HTML report, with optional WebGL depth-call counters.
 
 For additional agent-first development tools including UI visualizers, 3d model visualizers, CLI based embodied XR Blocks runners, and automatic agent controls, see [XR Blocks Devtools](https://github.com/xrblocks/xrblocks-devtools).
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ then set Prettier as your default formatter.
 
 #### Devtools
 
+For local before/after Chrome measurements, see the [standalone profiler](tools/README.md). It records interleaved samples and raw traces and generates a static HTML report, with optional WebGL depth-call counters.
+
 For additional agent-first development tools including UI visualizers, 3d model visualizers, CLI based embodied XR Blocks runners, and automatic agent controls, see [XR Blocks Devtools](https://github.com/xrblocks/xrblocks-devtools).
 
 #### Notice

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,10 @@ export default defineConfig(
       languageOptions: {globals: {...globals.browser}},
     },
     {
-      files: ['rollup.config.js', 'docs/docusaurus.config.js', 'src/addons/**/server/**/*.js'],
+      files: ['rollup.config.js', 'docs/docusaurus.config.js', 'src/addons/**/server/**/*.js', 'tools/**/*.js', 'tools/**/*.ts'],
       languageOptions: {globals: {...globals.node}}
+    },
+    {
+      files: ['tools/profile.js'],
+      languageOptions: {globals: {...globals.browser, ...globals.node}}
     });

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "echo \"Building xrblocks.js...\" && rollup -c --failAfterWarnings",
     "build:sdk": "rollup -c --failAfterWarnings --forceExit --environment XRBLOCKS_BUILD:sdk",
     "prepare": "npm run build",
-    "lint": "eslint src",
+    "lint": "eslint src tools",
     "format": "npm run format:fix",
     "format:check": "prettier \"**/*.{cjs,html,js,json,md,mdx,ts,css}\" --check",
     "format:fix": "prettier \"**/*.{cjs,html,js,json,md,mdx,ts,css}\" --write",

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,113 @@
+# Chrome profiling
+
+`profile.js` compares two running HTTP(S) pages using Chrome's DevTools Protocol. It is a manual developer tool for investigations such as [#505](https://github.com/google/xrblocks/pull/505), not an SDK feature, an XR-device benchmark, or a CI performance gate. The runner works with ordinary web pages; the optional depth counters are specific to WebGL.
+
+## Run a comparison
+
+Use Node.js 22 or later and an installed Chrome or Chromium executable. The profiler and its sibling modules use only Node built-ins, so they do not require `npm install`. Building and serving the application being measured is separate.
+
+Serve the before and after applications at separate URLs. From this checkout, run:
+
+```sh
+node tools/profile.js \
+  --chrome "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  "http://127.0.0.1:8080/" \
+  "http://127.0.0.1:8081/" \
+  --runs 5 --warmup 3 --duration 8 \
+  --out .cache/profile-comparison
+```
+
+On Linux, pass the installed executable path, such as `/usr/bin/google-chrome`. On Windows, pass the full path to `chrome.exe`. No browser is downloaded, and the profiler does not attach to your existing browser.
+
+Each sample starts a fresh Chrome process with a temporary profile and a 1280 by 720 CSS-pixel viewport at device scale factor 1. The profiler waits for page load, then for `--ready`, then for the warm-up interval. The default readiness expression is `document.readyState === "complete"`; use an application-specific condition when scene loading or other initialization continues after page load.
+
+Pairs alternate `before, after`, then `after, before`, and so on. This interleaves the variants and counterbalances order rather than running all baselines first. It reduces some drift and ordering effects but cannot eliminate thermal, power, scheduling, or background-work noise.
+
+Chrome opens a window by default. For headless runs, add `--chrome-arg=--headless=new`. Additional Chrome flags are repeatable, for example `--chrome-arg=--force_high_performance_gpu`. That flag is only a platform-dependent hint; the recorded renderer string, not the launch flag, tells you which WebGL backend was observed. Profile and debugging overrides are rejected to preserve isolation.
+
+## Frame pacing and FPS caps
+
+By default, the profiler leaves Chrome's frame limiter and GPU vsync alone. Animation callbacks are typically paced by the display refresh rate, not a fixed 60 FPS cap imposed by this tool. Headless Chrome can use different pacing. If both variants already reach that limit, an optimization can increase main-thread headroom without increasing callback rate.
+
+Use the default pacing for representative desktop behavior and headroom comparisons. For a separate uncapped throughput investigation, add these flags to the comparison command:
+
+```sh
+--chrome-arg=--disable-frame-rate-limit \
+--chrome-arg=--disable-background-timer-throttling \
+--chrome-arg=--disable-renderer-backgrounding
+```
+
+In [current Chromium](https://github.com/chromium/chromium/blob/main/components/viz/common/switches.cc), `--disable-frame-rate-limit` also implies `--disable-gpu-vsync`; the latter flag alone is not a substitute for removing the scheduler's frame limit. This does not guarantee an unlimited callback rate: application logic, the platform, and CPU/GPU throughput can still limit it. The profiler has no numeric `--fps` setting and does not override application-level render caps.
+
+The other two flags disable background timer throttling and renderer-process backgrounding. They are benchmark controls, not guarantees against every kind of scheduling or window-occlusion throttling. Keep a headed profiling window visible and unminimized; the profiler still rejects a measurement if the document becomes hidden.
+
+The same supplied flags are used for both variants and recorded in the output. Do not mix default-paced and uncapped samples in a comparison. An uncapped, faster variant may execute more frames and calls within the same window, so higher total call time or less idle time does not by itself indicate a regression. The reported callback rate remains a throughput proxy, not displayed FPS or an application render count.
+
+Keep the display refresh rate, Chrome version, headed/headless mode, renderer, scene, viewport, and device scale factor comparable. Keep power and thermal conditions stable, avoid unrelated CPU/GPU-heavy work, and do not open DevTools on the measured page. Repeat overall throughput runs without `--depth`, since its per-call instrumentation changes the workload.
+
+## XR Blocks depth example
+
+Build each SDK revision and serve its checkout separately. For example, after the build, `npm run serve` serves a checkout on port 8080; `./node_modules/.bin/http-server --cors -c-1 -a 127.0.0.1 -p 8081` serves the other checkout on port 8081.
+
+```sh
+node tools/profile.js \
+  --chrome "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  "http://127.0.0.1:8080/samples/advanced/portals/?xrAutomation=1&debug=1" \
+  "http://127.0.0.1:8081/samples/advanced/portals/?xrAutomation=1&debug=1" \
+  --ready 'window.xb?.core.simulatorRunning === true' \
+  --warmup 5 --duration 8 --runs 5 \
+  --depth \
+  --out .cache/portals-depth
+```
+
+The current Portals sample imports its checkout's local SDK bundle. Older revisions may use `demos/portals/` instead. The two URLs do not need identical paths, but they should run the same scene, assets, settings, viewport, and workload. The profiler does not build revisions, rewrite importmaps, or drive camera movement.
+
+`xrAutomation=1` starts the simulator; `debug=1` exposes `window.xb` and `window.xbReady`. See the [simulator manual](../docs/docs/manual/Simulator.mdx). Simulator startup is not proof that every application asset has finished loading. Increase warm-up or use a more specific readiness expression when needed.
+
+`--depth` wraps `getBufferSubData`, `getParameter`, and `clientWaitSync` on the main document's WebGL prototypes. During the measurement window, it records User Timing measures named `webgl:getBufferSubData`, `webgl:getParameter`, and `webgl:clientWaitSync`. These measures are included in the raw trace and summarized as time and call counts.
+
+This instrumentation is off by default. Wrapping calls, reading clocks, and emitting trace events add overhead, particularly for frequent short calls. Keep the flag identical for both variants and repeat the comparison without it when assessing overall performance. These measurements should not be treated as reproducing the historical numbers in #505.
+
+## Read the results
+
+The table reports the mean and sample standard deviation for each side and for the per-pair difference, `after - before`. The paired difference is calculated within each pair, not from the execution order. Standard deviation describes sample spread, not a confidence interval or statistical significance. A single pair has no sample standard deviation and prints `n/a`.
+
+| Metric               | Meaning                                                                                                                                                                                                                                                                 |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Window (ms)          | Actual interval between the page's trace markers. A busy page can run longer than the requested duration.                                                                                                                                                               |
+| rAF callbacks/s      | Rate of an added `requestAnimationFrame` observer. This is not the application's render count, presented FPS, or headset frame rate.                                                                                                                                    |
+| Main-thread idle (%) | Fraction of the marked interval not covered by renderer-main-thread `RunTask` or `ThreadControllerImpl::RunTask` spans. Overlapping spans are unioned. A blocking task counts as busy even while waiting for the GPU. Missing task events produce `n/a`, not 100% idle. |
+| Event (ms)           | Wall time covered by matching duration spans on the marked thread, clipped to the measured interval and unioned to avoid double counting. This is not GPU execution time or CPU utilization.                                                                            |
+| Event (calls)        | Number of matching duration spans that start inside the interval, including zero-duration User Timing measures. These only correspond to API calls for the instrumented depth events.                                                                                   |
+
+For idle percentages, the paired delta is in percentage points. Other deltas retain the row's units. Event totals cover the actual window, so inspect window lengths before comparing totals. The depth timers use the page's reduced-precision `performance.now()` clock; very short calls can have zero recorded duration.
+
+Use `--event Layout`, or repeat `--event` with other exact duration-event names, to inspect additional work. Captured categories are `toplevel`, `blink.user_timing`, `devtools.timeline`, and `disabled-by-default-devtools.timeline`. Event names and availability vary by Chrome version. An arbitrary event that never appears generates a warning; zero does not prove that the corresponding work never happened.
+
+The output directory must not already exist. By default it is created under the git-ignored `.cache/` directory. Results include:
+
+| File                       | Contents                                                                                                                           |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `run.json`                 | Input URLs, options, requested viewport, Node version, and OS metadata.                                                            |
+| `<pair>-<side>.trace.json` | Raw Chrome trace, including the measurement markers. Load it locally in Chrome's trace viewer or DevTools Performance panel.       |
+| `<pair>-<side>.json`       | That sample's Chrome version, observed renderers, actual URL and viewport, metrics, warnings, and trace filename.                  |
+| `summary.json`             | Completed samples, aggregate statistics, and comparison warnings. Written only after every sample succeeds.                        |
+| `report.html`              | Self-contained comparison tables, mean bar charts, warnings, run settings, and relative links to each sample's trace and metadata. |
+
+Every completed comparison generates `report.html` automatically and prints its path. Open that file directly in a browser; no web server, JavaScript, package install, or external assets are needed. The report automatically follows your system's light or dark color preference. Frame-limiter flags, headed/headless mode, and depth instrumentation are shown prominently. Charts use a separate zero-based scale for each metric and show means, not confidence intervals or pass/fail judgments.
+
+Keep the report beside the JSON and trace files so its relative links continue to work. The report contains the same URLs and environment details as the summary, so treat it as private too.
+
+HTTP errors, uncaught page exceptions, timeouts, hidden pages, lost WebGL contexts, invalid measurement markers, and reported trace data loss fail the run rather than producing a successful comparison. Already saved files remain available for diagnosis. Ctrl+C stops the run and cleans up the profiler's own browser and temporary profile.
+
+Temporary-profile removal retries transient filesystem failures. If cleanup still fails, the command reports the profile path and any original sampling error; it does not silently leave the profile behind or report a completed comparison.
+
+## Limits and privacy
+
+The renderer probe observes WebGL contexts obtained through the main document's HTML canvases. It does not identify WebGPU, worker or offscreen contexts, or iframe renderers. Missing unmasked renderer information is reported as unverified. SwiftShader and other recognizable software renderers produce warnings, as do differing renderer sets or Chrome versions across samples.
+
+Fresh profiles intentionally exclude your cookies, logins, extensions, service workers, and disk cache. Caches can still warm within a sample. CDN resources, random scenes, adaptive quality, lazy loading, and non-reproducible camera paths can make the inputs differ. Keep Chrome version, launch flags, power conditions, background load, and readiness comparable; repeat the entire experiment before drawing conclusions.
+
+Tracing itself affects performance. Headless and headed behavior can differ. This tool measures one desktop page's renderer thread, not end-to-end GPU performance or real WebXR-device behavior. It does not set automatic pass/fail performance thresholds.
+
+Trace files and metadata can contain URLs, query parameters, resource names, and page data. Avoid API keys or credentials in profiling URLs, keep output private, and inspect it before sharing. The profiler writes files locally and never uploads them; the pages it visits still make their normal network requests.

--- a/tools/profile-cdp.js
+++ b/tools/profile-cdp.js
@@ -1,0 +1,91 @@
+export class Cdp {
+  constructor(input, output, timeoutMs) {
+    this.input = input;
+    this.timeoutMs = timeoutMs;
+    this.nextId = 0;
+    this.pending = new Map();
+    this.error = null;
+    this.onEvent = null;
+    let buffer = '';
+    output.setEncoding('utf8');
+    output.on('data', (chunk) => {
+      buffer += chunk;
+      try {
+        let boundary;
+        while ((boundary = buffer.indexOf('\0')) !== -1) {
+          const message = JSON.parse(buffer.slice(0, boundary));
+          buffer = buffer.slice(boundary + 1);
+          this.receive(message);
+        }
+      } catch (error) {
+        this.fail(error);
+      }
+    });
+    input.on('error', (error) => this.fail(error));
+    output.on('error', (error) => this.fail(error));
+    output.on('end', () =>
+      this.fail(new Error('Chrome closed the DevTools pipe.'))
+    );
+  }
+
+  wait(key, label, timeoutMs = this.timeoutMs) {
+    if (this.error) return Promise.reject(this.error);
+    if (this.pending.has(key)) {
+      return Promise.reject(new Error(`Already waiting for ${label}.`));
+    }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(key);
+        reject(new Error(`Timed out waiting for ${label}.`));
+      }, timeoutMs);
+      this.pending.set(key, {resolve, reject, timer, label});
+    });
+  }
+
+  waitFor(method, sessionId) {
+    return this.wait(`event:${method}:${sessionId ?? ''}`, method);
+  }
+
+  send(method, params = {}, sessionId, timeoutMs = this.timeoutMs) {
+    const id = ++this.nextId;
+    const response = this.wait(`request:${id}`, method, timeoutMs);
+    if (!this.error) {
+      this.input.write(
+        JSON.stringify({id, method, params, sessionId}) + '\0',
+        (error) => {
+          if (error) this.fail(error);
+        }
+      );
+    }
+    return response;
+  }
+
+  receive(message) {
+    const key =
+      message.id === undefined
+        ? `event:${message.method}:${message.sessionId ?? ''}`
+        : `request:${message.id}`;
+    const request = this.pending.get(key);
+    if (request) {
+      this.pending.delete(key);
+      clearTimeout(request.timer);
+      if (message.error) {
+        request.reject(new Error(`${request.label}: ${message.error.message}`));
+      } else {
+        request.resolve(message.result ?? message.params);
+      }
+    }
+    if (message.method) {
+      this.onEvent?.(message.method, message.params, message.sessionId);
+    }
+  }
+
+  fail(error) {
+    this.error ??= error;
+    for (const request of this.pending.values()) {
+      clearTimeout(request.timer);
+      request.reject(this.error);
+    }
+    this.pending.clear();
+  }
+}

--- a/tools/profile-html.js
+++ b/tools/profile-html.js
@@ -1,0 +1,272 @@
+import {formatStats} from './profile-report.js';
+
+const ENTITIES = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+function escapeHtml(value) {
+  return String(value).replace(/[&<>"']/g, (character) => ENTITIES[character]);
+}
+
+function formatValue(value) {
+  return Number.isFinite(value) ? value.toFixed(2) : 'n/a';
+}
+
+function artifactLink(file, label, className = '') {
+  return `<a class="${escapeHtml(className)}" href="./${escapeHtml(encodeURIComponent(file))}" download>${escapeHtml(label)}</a>`;
+}
+
+function renderChart(row, index) {
+  const maximum = Math.max(row.before?.mean ?? 0, row.after?.mean ?? 0) || 1;
+  const bars = [
+    ['Before', 'before', row.before],
+    ['After', 'after', row.after],
+  ].map(([label, className, stats]) => {
+    const width = stats ? Math.round((stats.mean / maximum) * 10000) / 100 : 0;
+    return `<div class="bar-row">
+      <span>${label}</span>
+      <div class="track" aria-hidden="true">${stats ? `<div class="bar ${className}" style="width:${width}%"></div>` : ''}</div>
+      <span class="value">${formatValue(stats?.mean)}</span>
+    </div>`;
+  });
+  return `<article class="chart" aria-labelledby="chart-${index}">
+    <h3 id="chart-${index}">${escapeHtml(row.metric)}</h3>
+    ${bars.join('\n')}
+  </article>`;
+}
+
+function renderSample(sample) {
+  const renderer =
+    sample.renderers
+      .map((value) => `${value.renderer}${value.unmasked ? '' : ' (masked)'}`)
+      .join('; ') || 'unverified';
+  const warnings = sample.warnings.length
+    ? `<details><summary>Warnings (${sample.warnings.length})</summary><ul>${sample.warnings.map((warning) => `<li>${escapeHtml(warning)}</li>`).join('')}</ul></details>`
+    : '';
+  return `<tr>
+    <th scope="row">Pair ${escapeHtml(sample.pair)} / ${escapeHtml(sample.side)}
+      <small class="url">${escapeHtml(sample.measured.url)}</small>
+    </th>
+    <td class="numeric">${formatValue(sample.durationMs)}</td>
+    <td class="numeric">${formatValue(sample.metrics['rAF callbacks/s'])}</td>
+    <td class="numeric">${formatValue(sample.metrics['Main-thread idle (%)'])}</td>
+    <td>${escapeHtml(renderer)}<small>${escapeHtml(sample.browser.product)}</small></td>
+    <td class="artifacts">
+      ${artifactLink(sample.traceFile, 'Trace', 'trace')}
+      ${artifactLink(`${sample.pair}-${sample.side}.json`, 'Sample JSON')}
+      ${warnings}
+    </td>
+  </tr>`;
+}
+
+export function renderHtmlReport({
+  options,
+  environment,
+  samples,
+  rows,
+  warnings,
+}) {
+  const hasFlag = (name) =>
+    options.chromeArgs.some((argument) => argument.split('=')[0] === name);
+  const pacing = hasFlag('--disable-frame-rate-limit')
+    ? 'Frame limiter disabled (requested)'
+    : 'Chrome frame limiter unchanged';
+  const comparison = rows
+    .map(
+      (row) => `<tr>
+    <th scope="row">${escapeHtml(row.metric)}</th>
+    <td class="numeric">${escapeHtml(formatStats(row.before))}</td>
+    <td class="numeric">${escapeHtml(formatStats(row.after))}</td>
+    <td class="numeric">${escapeHtml(formatStats(row.delta))}</td>
+  </tr>`
+    )
+    .join('\n');
+  const warningSection = warnings.length
+    ? `<section id="warnings" class="warning" aria-labelledby="warning-title">
+        <h2 id="warning-title">Run warnings</h2>
+        <ul>${warnings.map((warning) => `<li>${escapeHtml(warning)}</li>`).join('')}</ul>
+      </section>`
+    : '';
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'">
+  <title>XR Blocks Chrome profile</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --text: #182133;
+      --page: #f4f6fb;
+      --surface: #ffffff;
+      --muted: #536179;
+      --link: #244db1;
+      --focus: #2563eb;
+      --border: #dce3ee;
+      --divider: #e7ebf3;
+      --header: #eaf0f9;
+      --track: #edf0f6;
+      --before: #2563eb;
+      --after: #7c3aed;
+      --warning-border: #e5c77d;
+      --warning-bg: #fff7df;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--text);
+      background: var(--page);
+      line-height: 1.55;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --text: #e6edf3;
+        --page: #0d1117;
+        --surface: #161b22;
+        --muted: #9da9b7;
+        --link: #91bfff;
+        --focus: #8db8ff;
+        --border: #303b4c;
+        --divider: #263244;
+        --header: #202c3d;
+        --track: #293549;
+        --before: #60a5fa;
+        --after: #a78bfa;
+        --warning-border: #79652c;
+        --warning-bg: #302810;
+      }
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; padding: 40px 24px; }
+    main { max-width: 1160px; margin: auto; }
+    h1, h2, h3, p { margin-top: 0; }
+    h1 { font-size: 36px; letter-spacing: -1px; margin-bottom: 8px; }
+    h2 { font-size: 21px; margin-bottom: 10px; }
+    h3 { font-size: 15px; margin-bottom: 18px; overflow-wrap: anywhere; }
+    header, section { margin-bottom: 28px; }
+    header { display: flex; justify-content: space-between; gap: 20px; flex-wrap: wrap; }
+    .eyebrow { color: var(--muted); font-size: 12px; font-weight: 700; letter-spacing: 2px; }
+    .muted, small { color: var(--muted); }
+    small { display: block; margin-top: 6px; font-weight: 400; }
+    a { color: var(--link); text-underline-offset: 3px; }
+    a:focus-visible, summary:focus-visible, [tabindex]:focus-visible {
+      outline: 3px solid var(--focus); outline-offset: 4px;
+    }
+    .downloads, .badges { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
+    .button, .badge { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 8px 12px; }
+    .button { font-size: 14px; font-weight: 600; text-decoration: none; }
+    .badge { font-size: 13px; }
+    .badges { margin-bottom: 20px; }
+    .sources, .charts { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr)); }
+    .source, .chart, .note, #settings {
+      background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 20px;
+    }
+    .source h2 { font-size: 14px; }
+    .source p { margin-bottom: 0; }
+    .url { overflow-wrap: anywhere; white-space: normal; }
+    code, pre, .numeric, .value { font-family: ui-monospace, SFMono-Regular, Consolas, monospace; }
+    code { font-size: 13px; }
+    .warning { border: 1px solid var(--warning-border); background: var(--warning-bg); border-radius: 12px; padding: 20px; }
+    .warning h2 { font-size: 17px; }
+    .warning ul, .warning li:last-child { margin-bottom: 0; }
+    li { margin-bottom: 6px; overflow-wrap: anywhere; }
+    .note { font-size: 14px; color: var(--muted); }
+    .table-wrap { overflow-x: auto; border: 1px solid var(--border); border-radius: 12px; background: var(--surface); }
+    table { width: 100%; border-collapse: collapse; font-size: 14px; }
+    th, td { padding: 14px 16px; text-align: left; vertical-align: top; }
+    thead { background: var(--header); }
+    tbody tr + tr { border-top: 1px solid var(--divider); }
+    tbody th { font-weight: 500; min-width: 190px; overflow-wrap: anywhere; }
+    .numeric { white-space: nowrap; font-variant-numeric: tabular-nums; }
+    .chart { min-width: 0; }
+    .bar-row { display: grid; grid-template-columns: 44px minmax(0, 1fr) 72px; gap: 10px; align-items: center; font-size: 12px; margin: 10px 0; }
+    .track { background: var(--track); height: 12px; border-radius: 3px; overflow: hidden; }
+    .bar { height: 100%; }
+    .before { background: var(--before); }
+    .after { background: var(--after); }
+    .value { text-align: right; }
+    .artifacts { min-width: 140px; }
+    .artifacts a { display: block; margin-bottom: 6px; }
+    #samples td { min-width: 120px; }
+    #samples th { max-width: 280px; }
+    details { margin-top: 12px; }
+    summary { cursor: pointer; font-weight: 600; }
+    pre { white-space: pre-wrap; overflow-wrap: anywhere; max-height: 420px; overflow: auto; font-size: 12px; }
+    footer { color: var(--muted); font-size: 13px; }
+    @media (max-width: 600px) {
+      body { padding: 24px 12px; }
+      h1 { font-size: 28px; }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <div>
+      <p class="eyebrow">XR BLOCKS / LOCAL PROFILER</p>
+      <h1>Before / after profile</h1>
+      <p class="muted">${escapeHtml(environment.startedAt)} &middot; ${escapeHtml(environment.platform)} / ${escapeHtml(environment.arch)}</p>
+    </div>
+    <nav class="downloads" aria-label="Report files">
+      ${artifactLink('summary.json', 'Summary JSON', 'button')}
+      ${artifactLink('run.json', 'Run settings', 'button')}
+    </nav>
+  </header>
+
+  <div class="badges" aria-label="Measurement configuration">
+    <span class="badge">${escapeHtml(options.runs)} ${options.runs === 1 ? 'pair' : 'pairs'} / ${samples.length} samples</span>
+    <span class="badge">${pacing}</span>
+    <span class="badge">${hasFlag('--headless') ? 'Headless' : 'Headed'}</span>
+    <span class="badge">Depth instrumentation ${options.depth ? 'on' : 'off'}</span>
+  </div>
+  <section class="sources" aria-label="Compared pages">
+    <article class="source"><h2>Before</h2><p class="url"><code>${escapeHtml(options.before)}</code></p></article>
+    <article class="source"><h2>After</h2><p class="url"><code>${escapeHtml(options.after)}</code></p></article>
+  </section>
+  ${warningSection}
+  <p class="note">rAF callbacks are not displayed FPS, and main-thread wall time is not GPU execution time.
+    No numeric FPS cap is imposed by the profiler. Uncapped runs can do more work per window.
+    Depth instrumentation adds overhead; compare the same flags and workloads.</p>
+
+  <section aria-labelledby="comparison-title">
+    <h2 id="comparison-title">Comparison</h2>
+    <p class="muted">Mean +/- sample standard deviation. Paired deltas use each matched pair, in the row's units
+      (percentage points for idle). These are not confidence intervals or pass/fail verdicts. Missing data is n/a, not zero.</p>
+    <div class="table-wrap" tabindex="0" role="region" aria-label="Comparison statistics">
+      <table id="comparison">
+        <thead><tr><th scope="col">Metric</th><th scope="col">Before</th><th scope="col">After</th><th scope="col">Paired delta (after - before)</th></tr></thead>
+        <tbody>${comparison}</tbody>
+      </table>
+    </div>
+  </section>
+  <section aria-labelledby="charts-title">
+    <h2 id="charts-title">Means at a glance</h2>
+    <p class="muted">Each chart has its own scale starting at zero. Bars show means only; see the table for sample spread.
+      Bar lengths are not comparable across different metrics.</p>
+    <div class="charts">${rows.map(renderChart).join('\n')}</div>
+  </section>
+  <section aria-labelledby="samples-title">
+    <h2 id="samples-title">Individual samples</h2>
+    <p class="muted">Actual execution order, observed renderer and Chrome version. Raw traces and sample metadata stay beside this report.</p>
+    <div class="table-wrap" tabindex="0" role="region" aria-label="Individual sample results">
+      <table id="samples">
+        <thead><tr><th scope="col">Run / final URL</th><th scope="col">Window (ms)</th><th scope="col">rAF callbacks/s</th><th scope="col">Idle (%)</th><th scope="col">Renderer</th><th scope="col">Files</th></tr></thead>
+        <tbody>${samples.map(renderSample).join('\n')}</tbody>
+      </table>
+    </div>
+  </section>
+  <section id="settings" aria-labelledby="settings-title">
+    <h2 id="settings-title">Run configuration</h2>
+    <p class="muted">Requested timing, viewport, readiness expression and exact Chrome flags, plus the recorded host environment.</p>
+    <details><summary>Show configuration</summary><pre tabindex="0">${escapeHtml(JSON.stringify({options, environment}, null, 2))}</pre></details>
+  </section>
+  <footer>Generated locally. No JavaScript, external assets or server required.
+    This report contains URLs and environment details; treat it as private, just like the JSON and raw traces.
+    Keep the files together to preserve the relative download links.</footer>
+</main>
+</body>
+</html>
+`;
+}

--- a/tools/profile-html.test.ts
+++ b/tools/profile-html.test.ts
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+
+import {describe, expect, it} from 'vitest';
+import {renderHtmlReport} from './profile-html.js';
+import {comparisonRows, runOrder} from './profile-report.js';
+
+function makeSummary() {
+  const chromeArgs: string[] = [];
+  const warnings: string[] = [];
+  const samples = runOrder(2).map(({pair, side}) => {
+    const metrics: Record<string, number | null> = {
+      'Window (ms)': 1000,
+      'rAF callbacks/s': side === 'before' ? 60 : 65,
+      'Main-thread idle (%)': side === 'before' ? 70 : 80,
+      'Readback (ms)': side === 'before' ? 20 : 10,
+    };
+    return {
+      pair,
+      side,
+      browser: {product: 'Chrome/152.0'},
+      renderers: [
+        {renderer: 'ANGLE (Test GPU)', vendor: 'Test', unmasked: true},
+      ],
+      measured: {
+        url: `http://127.0.0.1/${side}`,
+        viewport: {width: 1280, height: 720, dpr: 1},
+      },
+      durationMs: 1000,
+      metrics,
+      traceFile: `${pair}-${side}.trace.json`,
+      warnings: [],
+    };
+  });
+  return {
+    options: {
+      chrome: '/path/to/chrome',
+      before: 'http://127.0.0.1:8080/?a=1&b=2',
+      after: 'http://127.0.0.1:8081/',
+      runs: 2,
+      warmupMs: 3000,
+      durationMs: 1000,
+      ready: 'document.readyState === "complete"',
+      chromeArgs,
+      depth: false,
+    },
+    environment: {
+      startedAt: '2026-09-12T12:00:00.000Z',
+      platform: 'darwin',
+      arch: 'arm64',
+      osRelease: '25.0',
+      node: 'v22.0.0',
+      viewport: {width: 1280, height: 720, dpr: 1},
+    },
+    samples,
+    rows: comparisonRows(samples),
+    warnings,
+  };
+}
+
+const readReport = (summary = makeSummary()) =>
+  new DOMParser().parseFromString(renderHtmlReport(summary), 'text/html');
+
+describe('static HTML profile report', () => {
+  it('renders the existing comparison statistics and per-metric charts', () => {
+    const summary = makeSummary();
+    const original = structuredClone(summary);
+    const page = readReport(summary);
+    const rows = [...page.querySelectorAll('#comparison tbody tr')];
+    expect(rows).toHaveLength(summary.rows.length);
+    const readback = rows.find(
+      (row) => row.querySelector('th')?.textContent === 'Readback (ms)'
+    );
+    expect(readback?.textContent).toContain('20.00 +/- 0.00');
+    expect(readback?.textContent).toContain('10.00 +/- 0.00');
+    expect(readback?.textContent).toContain('-10.00 +/- 0.00');
+    expect(page.querySelectorAll('.chart')).toHaveLength(summary.rows.length);
+    expect(page.querySelector('.chart h3')?.textContent).toBe('Window (ms)');
+    expect(page.body.textContent).toContain('not displayed FPS');
+    expect(page.body.textContent).toContain('not confidence intervals');
+    expect(summary).toEqual(original);
+  });
+
+  it('includes local trace and JSON links in the actual sample order', () => {
+    const page = readReport();
+    expect(page.querySelector('a[href="./summary.json"]')).not.toBeNull();
+    expect(page.querySelector('a[href="./run.json"]')).not.toBeNull();
+    const links = [...page.querySelectorAll('#samples a.trace')];
+    expect(links.map((link) => link.getAttribute('href'))).toEqual([
+      './1-before.trace.json',
+      './1-after.trace.json',
+      './2-after.trace.json',
+      './2-before.trace.json',
+    ]);
+    expect(page.querySelector('a[href="./2-before.json"]')).not.toBeNull();
+  });
+
+  it('makes frame pacing, instrumentation and run settings visible', () => {
+    const summary = makeSummary();
+    summary.options.chromeArgs = [
+      '--headless=new',
+      '--disable-frame-rate-limit',
+      '--disable-renderer-backgrounding',
+    ];
+    summary.options.depth = true;
+    const page = readReport(summary);
+    expect(page.body.textContent).toContain(
+      'Frame limiter disabled (requested)'
+    );
+    expect(page.body.textContent).toContain('Headless');
+    expect(page.body.textContent).toContain('Depth instrumentation on');
+    expect(page.body.textContent).toContain('Chrome/152.0');
+    expect(page.body.textContent).toContain('ANGLE (Test GPU)');
+    expect(page.querySelector('#settings pre')?.textContent).toContain(
+      '--disable-renderer-backgrounding'
+    );
+    expect(readReport().body.textContent).toContain(
+      'Chrome frame limiter unchanged'
+    );
+  });
+
+  it('shows warnings prominently without assigning a pass/fail verdict', () => {
+    const summary = makeSummary();
+    summary.warnings = [
+      'Software WebGL renderer detected.',
+      'Only one pair; sample SD is unavailable.',
+    ];
+    const page = readReport(summary);
+    expect(page.querySelectorAll('#warnings li')).toHaveLength(2);
+    expect(page.querySelector('#warnings')?.textContent).toContain(
+      'Software WebGL'
+    );
+  });
+
+  it('keeps missing data, zero means and single-sample SD distinct', () => {
+    const summary = makeSummary();
+    summary.options.runs = 1;
+    summary.samples = summary.samples.slice(0, 2);
+    for (const sample of summary.samples) {
+      sample.metrics = {'Zero (ms)': 0, 'Unknown (%)': null};
+      sample.renderers = [];
+    }
+    summary.rows = comparisonRows(summary.samples);
+    const page = readReport(summary);
+    const rows = page.querySelectorAll('#comparison tbody tr');
+    expect(rows[0].textContent).toContain('0.00 +/- n/a');
+    expect(rows[1].querySelector('td')?.textContent).toBe('n/a');
+    expect(page.body.textContent).toContain('unverified');
+    expect(page.querySelectorAll('.chart .bar')).toHaveLength(2);
+    for (const bar of page.querySelectorAll<HTMLElement>('.bar')) {
+      expect(bar.style.width).toBe('0%');
+    }
+    expect(page.documentElement.outerHTML).not.toMatch(/NaN|Infinity/);
+  });
+
+  it('escapes metadata, URLs, metric names and warnings as text', () => {
+    const summary = makeSummary();
+    const payload = `"</td><img src="https://example.invalid/pixel" onerror="alert(1)"><script>alert('x')</script>`;
+    summary.options.before = `https://example.invalid/?q=${payload}`;
+    summary.options.ready = payload;
+    summary.options.chromeArgs = [`--custom=${payload}`];
+    summary.warnings = [payload];
+    summary.rows[0].metric = payload;
+    summary.samples[0].browser.product = payload;
+    summary.samples[0].renderers[0].renderer = payload;
+    summary.samples[0].traceFile = `javascript:${payload}`;
+    const page = readReport(summary);
+    expect(
+      page.querySelectorAll('script, img, iframe, form, base')
+    ).toHaveLength(0);
+    expect(page.body.textContent).toContain(payload);
+    expect(page.querySelector('a.trace')?.getAttribute('href')).toBe(
+      `./${encodeURIComponent(summary.samples[0].traceFile)}`
+    );
+    for (const link of page.querySelectorAll('a')) {
+      expect(link.getAttribute('href')).toMatch(/^\.\//);
+      expect(link.getAttribute('onclick')).toBeNull();
+    }
+  });
+
+  it('is self-contained, script-free and usable without a web server', () => {
+    const html = renderHtmlReport(makeSummary());
+    const page = new DOMParser().parseFromString(html, 'text/html');
+    expect(html).toMatch(/^<!doctype html>/i);
+    expect(page.documentElement.lang).toBe('en');
+    expect(page.querySelector('meta[name="viewport"]')).not.toBeNull();
+    expect(page.querySelectorAll('script, link, [src]')).toHaveLength(0);
+    expect(page.querySelector('style')?.textContent).not.toMatch(
+      /@import|url\s*\(/i
+    );
+    const policy = page.querySelector(
+      'meta[http-equiv="Content-Security-Policy"]'
+    );
+    expect(policy?.getAttribute('content')).toContain("default-src 'none'");
+    expect(policy?.getAttribute('content')).toContain("base-uri 'none'");
+    expect(page.querySelector('#settings details')).not.toBeNull();
+  });
+
+  it('provides light and dark palettes for every theme color without scripts', () => {
+    const page = readReport();
+    const css = page.querySelector('style')?.textContent ?? '';
+    expect(css).toContain('color-scheme: light dark');
+    const [light, dark] = css.split('@media (prefers-color-scheme: dark)');
+    expect(dark).toBeDefined();
+    const colors = [...css.matchAll(/var\((--[\w-]+)\)/g)].map(
+      (match) => match[1]
+    );
+    expect(colors.length).toBeGreaterThan(0);
+    for (const color of new Set(colors)) {
+      const declaration = new RegExp(`${color}: #[0-9a-f]{6};`);
+      expect(light).toMatch(declaration);
+      expect(dark).toMatch(declaration);
+    }
+    expect(page.querySelectorAll('script')).toHaveLength(0);
+  });
+});

--- a/tools/profile-report.js
+++ b/tools/profile-report.js
@@ -1,0 +1,197 @@
+const TASK_NAMES = new Set(['RunTask', 'ThreadControllerImpl::RunTask']);
+
+export function runOrder(runs) {
+  return Array.from({length: runs}, (_, index) => {
+    const sides = index % 2 ? ['after', 'before'] : ['before', 'after'];
+    return sides.map((side) => ({pair: index + 1, side}));
+  }).flat();
+}
+
+export function analyzeTrace(trace, prefix, eventNames) {
+  const events = trace.traceEvents;
+  if (!Array.isArray(events))
+    throw new Error('Trace has no traceEvents array.');
+  const start = events.find((event) => event.name === `${prefix}:start`);
+  const end = events.find(
+    (event) =>
+      event.name === `${prefix}:end` &&
+      event.pid === start?.pid &&
+      event.tid === start?.tid
+  );
+  if (!start || !end || !(end.ts > start.ts)) {
+    throw new Error('Trace is missing valid measurement markers.');
+  }
+
+  const wanted = new Set([...TASK_NAMES, ...eventNames]);
+  const spans = [];
+  const stack = [];
+  const asyncSpans = new Map();
+  const onThread = events
+    .filter((event) => event.pid === start.pid && event.tid === start.tid)
+    .sort((a, b) => a.ts - b.ts);
+  for (const event of onThread) {
+    if (event.ph === 'X') spans.push(event);
+    // Zero-duration User Timing measures are exported as async instants.
+    if (
+      event.ph === 'n' &&
+      event.cat?.split(',').includes('blink.user_timing')
+    ) {
+      spans.push({...event, dur: 0});
+    }
+    if (event.ph === 'B') stack.push(event);
+    if (event.ph === 'E') {
+      const begin = stack.pop();
+      if (begin) spans.push({...begin, dur: event.ts - begin.ts});
+    }
+    if (event.ph === 'b' || event.ph === 'e') {
+      const key = JSON.stringify([
+        event.cat,
+        event.name,
+        event.scope,
+        event.id2 ?? event.id,
+      ]);
+      if (event.ph === 'b') {
+        asyncSpans.set(key, event);
+      } else {
+        const begin = asyncSpans.get(key);
+        if (begin) {
+          spans.push({...begin, dur: event.ts - begin.ts});
+          asyncSpans.delete(key);
+        } else if (
+          wanted.has(event.name) &&
+          event.ts > start.ts &&
+          event.ts <= end.ts
+        ) {
+          throw new Error(`Incomplete trace span: ${event.name}.`);
+        }
+      }
+    }
+  }
+  for (const event of [...stack, ...asyncSpans.values()]) {
+    if (wanted.has(event.name) && event.ts < end.ts) {
+      throw new Error(`Incomplete trace span: ${event.name}.`);
+    }
+  }
+  for (const event of spans) {
+    if (
+      wanted.has(event.name) &&
+      (!Number.isFinite(event.dur) || event.dur < 0)
+    ) {
+      throw new Error(`Invalid trace duration: ${event.name}.`);
+    }
+  }
+
+  // Chrome can emit nested task aliases. Union them, rather than summing twice.
+  function wallTime(selected) {
+    const intervals = selected
+      .map((event) => [
+        Math.max(start.ts, event.ts),
+        Math.min(end.ts, event.ts + event.dur),
+      ])
+      .filter(([left, right]) => right > left)
+      .sort((a, b) => a[0] - b[0]);
+    let total = 0;
+    let previousEnd = start.ts;
+    for (const [left, right] of intervals) {
+      total += Math.max(0, right - Math.max(left, previousEnd));
+      previousEnd = Math.max(previousEnd, right);
+    }
+    return total;
+  }
+
+  const durationUs = end.ts - start.ts;
+  const tasks = spans.filter((event) => TASK_NAMES.has(event.name));
+  const warnings = [];
+  if (!tasks.length) {
+    warnings.push('No renderer task spans found; main-thread idle is unknown.');
+  }
+  const metrics = {
+    'Main-thread idle (%)': tasks.length
+      ? (1 - wallTime(tasks) / durationUs) * 100
+      : null,
+  };
+  for (const name of eventNames) {
+    const selected = spans.filter((event) => event.name === name);
+    metrics[`${name} (ms)`] = wallTime(selected) / 1000;
+    metrics[`${name} (calls)`] = selected.filter(
+      (event) => event.ts >= start.ts && event.ts < end.ts
+    ).length;
+  }
+  return {durationMs: durationUs / 1000, metrics, warnings};
+}
+
+function statistics(values) {
+  if (!values.length || values.some((value) => !Number.isFinite(value))) {
+    return null;
+  }
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+  const sd =
+    values.length > 1
+      ? Math.sqrt(
+          values.reduce((sum, value) => sum + (value - mean) ** 2, 0) /
+            (values.length - 1)
+        )
+      : null;
+  return {mean, sd};
+}
+
+export function comparisonRows(samples) {
+  const pairs = new Map();
+  for (const sample of samples) {
+    const pair = pairs.get(sample.pair) ?? {};
+    if (!['before', 'after'].includes(sample.side) || pair[sample.side]) {
+      throw new Error(`Invalid or duplicate side in pair ${sample.pair}.`);
+    }
+    pair[sample.side] = sample.metrics;
+    pairs.set(sample.pair, pair);
+  }
+  if (
+    !pairs.size ||
+    [...pairs.values()].some((pair) => !pair.before || !pair.after)
+  ) {
+    throw new Error('Every comparison pair needs a before and after sample.');
+  }
+  const names = [...new Set(samples.flatMap((s) => Object.keys(s.metrics)))];
+  return names.map((metric) => {
+    const ordered = [...pairs.values()];
+    return {
+      metric,
+      before: statistics(ordered.map((pair) => pair.before[metric])),
+      after: statistics(ordered.map((pair) => pair.after[metric])),
+      delta: statistics(
+        ordered.map((pair) =>
+          Number.isFinite(pair.before[metric]) &&
+          Number.isFinite(pair.after[metric])
+            ? pair.after[metric] - pair.before[metric]
+            : null
+        )
+      ),
+    };
+  });
+}
+
+export function formatStats(stats) {
+  return stats
+    ? `${stats.mean.toFixed(2)} +/- ${stats.sd?.toFixed(2) ?? 'n/a'}`
+    : 'n/a';
+}
+
+export function printComparison(rows) {
+  const table = [
+    ['Metric', 'Before', 'After', 'Paired delta (after - before)'],
+    ...rows.map((row) => [
+      row.metric,
+      formatStats(row.before),
+      formatStats(row.after),
+      formatStats(row.delta),
+    ]),
+  ];
+  const widths = table[0].map((_, index) =>
+    Math.max(...table.map((row) => row[index].length))
+  );
+  for (const row of table) {
+    console.log(
+      row.map((cell, index) => cell.padEnd(widths[index])).join('  ')
+    );
+  }
+}

--- a/tools/profile-report.test.ts
+++ b/tools/profile-report.test.ts
@@ -1,0 +1,261 @@
+// @vitest-environment node
+
+import {describe, expect, it} from 'vitest';
+import {analyzeTrace, comparisonRows, runOrder} from './profile-report.js';
+
+const marker = (name: string, ts: number) => ({
+  name: `profile:${name}`,
+  cat: 'blink.user_timing',
+  ph: 'I',
+  pid: 1,
+  tid: 2,
+  ts,
+});
+const span = (name: string, ts: number, dur: number, tid = 2) => ({
+  name,
+  ph: 'X',
+  pid: 1,
+  tid,
+  ts,
+  dur,
+});
+const bounds = [marker('start', 1000), marker('end', 11000)];
+
+describe('analyzeTrace', () => {
+  it('clips and unions nested tasks on the marked main thread only', () => {
+    const result = analyzeTrace(
+      {
+        traceEvents: [
+          ...bounds,
+          span('RunTask', 0, 3000),
+          span('ThreadControllerImpl::RunTask', 1000, 2000),
+          span('RunTask', 5000, 3000),
+          span('RunTask', 10000, 4000),
+          span('RunTask', 1000, 10000, 3),
+          {...span('RunTask', 1000, 10000), pid: 9},
+          span('RunTask', 20000, 5000),
+        ],
+      },
+      'profile',
+      []
+    );
+
+    expect(result.durationMs).toBe(10);
+    expect(result.metrics['Main-thread idle (%)']).toBe(40);
+  });
+
+  it('matches exact event names and clips their wall time', () => {
+    const result = analyzeTrace(
+      {
+        traceEvents: [
+          ...bounds,
+          span('getParameter', 0, 2000),
+          span('getParameter', 3000, 2000),
+          span('getParameter', 11000, 5000),
+          span('getParameterExtra', 6000, 1000),
+          span('getParameter', 1000, 10000, 3),
+        ],
+      },
+      'profile',
+      ['getParameter', 'absent']
+    );
+
+    expect(result.metrics['getParameter (ms)']).toBe(3);
+    expect(result.metrics['getParameter (calls)']).toBe(1);
+    expect(result.metrics['absent (ms)']).toBe(0);
+    expect(result.metrics['absent (calls)']).toBe(0);
+  });
+
+  it('handles nested B/E spans and asynchronous User Timing measures', () => {
+    const result = analyzeTrace(
+      {
+        traceEvents: [
+          ...bounds,
+          {name: 'RunTask', ph: 'B', pid: 1, tid: 2, ts: 500},
+          {name: 'other', ph: 'B', pid: 1, tid: 2, ts: 1500},
+          {ph: 'E', pid: 1, tid: 2, ts: 1800},
+          {ph: 'E', pid: 1, tid: 2, ts: 2500},
+          {
+            name: 'webgl:getParameter',
+            cat: 'blink.user_timing',
+            ph: 'b',
+            id2: {local: '7'},
+            pid: 1,
+            tid: 2,
+            ts: 4000,
+          },
+          {
+            name: 'webgl:getParameter',
+            cat: 'blink.user_timing',
+            ph: 'e',
+            id2: {local: '7'},
+            pid: 1,
+            tid: 2,
+            ts: 6000,
+          },
+        ],
+      },
+      'profile',
+      ['webgl:getParameter']
+    );
+
+    expect(result.metrics['Main-thread idle (%)']).toBe(85);
+    expect(result.metrics['webgl:getParameter (ms)']).toBe(2);
+    expect(result.metrics['webgl:getParameter (calls)']).toBe(1);
+  });
+
+  it('keeps Chrome async IDs and categories distinct', () => {
+    const result = analyzeTrace(
+      {
+        traceEvents: [
+          ...bounds,
+          {
+            name: 'measure',
+            cat: 'blink.user_timing',
+            ph: 'b',
+            id: '0x1',
+            pid: 1,
+            tid: 2,
+            ts: 2000,
+          },
+          {
+            name: 'measure',
+            cat: 'another',
+            ph: 'b',
+            id: '0x1',
+            pid: 1,
+            tid: 2,
+            ts: 2500,
+          },
+          {
+            name: 'measure',
+            cat: 'another',
+            ph: 'e',
+            id: '0x1',
+            pid: 1,
+            tid: 2,
+            ts: 3000,
+          },
+          {
+            name: 'measure',
+            cat: 'blink.user_timing',
+            ph: 'e',
+            id: '0x1',
+            pid: 1,
+            tid: 2,
+            ts: 4000,
+          },
+        ],
+      },
+      'profile',
+      ['measure']
+    );
+    expect(result.metrics['measure (ms)']).toBe(2);
+  });
+
+  it('does not call an unsupported task trace 100% idle', () => {
+    const result = analyzeTrace({traceEvents: bounds}, 'profile', []);
+    expect(result.metrics['Main-thread idle (%)']).toBeNull();
+    expect(result.warnings.join(' ')).toMatch(/task/i);
+  });
+
+  it('counts zero-duration measures and reused async IDs', () => {
+    const measure = (ph: string, ts: number) => ({
+      name: 'webgl:getParameter',
+      cat: 'blink.user_timing',
+      ph,
+      id2: {local: '0x44'},
+      pid: 1,
+      tid: 2,
+      ts,
+    });
+    const result = analyzeTrace(
+      {
+        traceEvents: [
+          ...bounds,
+          measure('b', 2000),
+          measure('e', 2000),
+          measure('b', 3000),
+          measure('e', 4000),
+          measure('n', 5000),
+        ],
+      },
+      'profile',
+      ['webgl:getParameter']
+    );
+    expect(result.metrics['webgl:getParameter (calls)']).toBe(3);
+    expect(result.metrics['webgl:getParameter (ms)']).toBe(1);
+  });
+
+  it.each([
+    {traceEvents: []},
+    {traceEvents: [marker('start', 1000)]},
+    {traceEvents: [marker('start', 2000), marker('end', 1000)]},
+    {traceEvents: [marker('start', 1000), {...marker('end', 2000), tid: 3}]},
+  ])('rejects missing or incompatible measurement bounds', ({traceEvents}) => {
+    expect(() => analyzeTrace({traceEvents}, 'profile', [])).toThrow(/marker/i);
+  });
+
+  it('rejects incomplete measured spans instead of reporting them as zero', () => {
+    expect(() =>
+      analyzeTrace(
+        {
+          traceEvents: [
+            ...bounds,
+            {name: 'RunTask', ph: 'B', pid: 1, tid: 2, ts: 2000},
+          ],
+        },
+        'profile',
+        []
+      )
+    ).toThrow(/incomplete/i);
+  });
+});
+
+describe('paired comparisons', () => {
+  it('interleaves both sides and reverses the order every other pair', () => {
+    expect(runOrder(3)).toEqual([
+      {pair: 1, side: 'before'},
+      {pair: 1, side: 'after'},
+      {pair: 2, side: 'after'},
+      {pair: 2, side: 'before'},
+      {pair: 3, side: 'before'},
+      {pair: 3, side: 'after'},
+    ]);
+  });
+
+  it('computes sample SD and deltas within pairs, not execution order', () => {
+    const rows = comparisonRows([
+      {pair: 1, side: 'before', metrics: {idle: 10}},
+      {pair: 1, side: 'after', metrics: {idle: 13}},
+      {pair: 2, side: 'after', metrics: {idle: 25}},
+      {pair: 2, side: 'before', metrics: {idle: 20}},
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].before).toEqual({mean: 15, sd: Math.sqrt(50)});
+    expect(rows[0].after).toEqual({mean: 19, sd: Math.sqrt(72)});
+    expect(rows[0].delta).toEqual({mean: 4, sd: Math.sqrt(2)});
+  });
+
+  it('reports single-sample SD and unavailable metrics as unknown', () => {
+    expect(
+      comparisonRows([
+        {pair: 1, side: 'before', metrics: {idle: 10}},
+        {pair: 1, side: 'after', metrics: {idle: null}},
+      ])
+    ).toEqual([
+      {
+        metric: 'idle',
+        before: {mean: 10, sd: null},
+        after: null,
+        delta: null,
+      },
+    ]);
+  });
+
+  it('rejects missing and duplicate members of a pair', () => {
+    const before = {pair: 1, side: 'before', metrics: {idle: 10}};
+    expect(() => comparisonRows([before])).toThrow(/pair/i);
+    expect(() => comparisonRows([before, before])).toThrow(/pair/i);
+  });
+});

--- a/tools/profile.js
+++ b/tools/profile.js
@@ -1,0 +1,578 @@
+import {spawn} from 'node:child_process';
+import {randomUUID} from 'node:crypto';
+import {mkdir, mkdtemp, open, readFile, rm, writeFile} from 'node:fs/promises';
+import {arch, platform, release, tmpdir} from 'node:os';
+import {dirname, join, resolve} from 'node:path';
+import {setTimeout as delay} from 'node:timers/promises';
+import {pathToFileURL} from 'node:url';
+import {parseArgs} from 'node:util';
+import {Cdp} from './profile-cdp.js';
+import {renderHtmlReport} from './profile-html.js';
+import {
+  analyzeTrace,
+  comparisonRows,
+  printComparison,
+  runOrder,
+} from './profile-report.js';
+
+const DEPTH_EVENTS = [
+  'webgl:getBufferSubData',
+  'webgl:getParameter',
+  'webgl:clientWaitSync',
+];
+const HELP = `Usage: node tools/profile.js --chrome <executable> <before-url> <after-url> [options]
+
+Compare two HTTP(S) pages in fresh, isolated Chrome profiles.
+Requires Node.js 22+ and an installed Chrome/Chromium. No npm dependencies.
+
+  --runs <n>          Number of pairs (default: 5; alternating AB, BA order)
+  --duration <s>      Measurement window (default: 8)
+  --warmup <s>        Warm-up after readiness (default: 3)
+  --timeout <s>       Startup, readiness and CDP timeout (default: 30)
+  --ready <expr>      JS readiness expression (default: document.readyState === "complete")
+  --out <directory>   New output directory (default: .cache/xrblocks-profile-<timestamp>)
+  --depth            Instrument getBufferSubData, getParameter and clientWaitSync
+  --event <name>     Additional exact trace event name (repeatable, main thread only)
+  --chrome-arg <arg> Extra Chrome flag (repeatable; use --chrome-arg=--flag)
+  --help, -h         Show this help
+
+Headed Chrome is the default. Use --chrome-arg=--headless=new for headless runs.
+Chrome's default frame pacing is preserved; no numeric FPS cap is set.
+For an uncapped throughput run, add --chrome-arg=--disable-frame-rate-limit.
+Depth instrumentation adds overhead. rAF callbacks/s is not displayed FPS.
+Raw traces can contain URLs and page data; keep results private.
+Each completed comparison also writes a self-contained report.html beside summary.json.
+See tools/README.md for metric definitions and an XR Blocks example.`;
+
+export function parseOptions(args) {
+  const {values, positionals} = parseArgs({
+    args,
+    allowPositionals: true,
+    options: {
+      chrome: {type: 'string'},
+      runs: {type: 'string', default: '5'},
+      duration: {type: 'string', default: '8'},
+      warmup: {type: 'string', default: '3'},
+      timeout: {type: 'string', default: '30'},
+      ready: {type: 'string', default: 'document.readyState === "complete"'},
+      out: {type: 'string'},
+      depth: {type: 'boolean', default: false},
+      event: {type: 'string', multiple: true, default: []},
+      'chrome-arg': {type: 'string', multiple: true, default: []},
+      help: {type: 'boolean', short: 'h'},
+    },
+  });
+  if (values.help) return {help: true};
+  if (!values.chrome?.trim()) throw new Error('--chrome is required.');
+  if (positionals.length !== 2) {
+    throw new Error('Supply exactly two URLs: before, then after.');
+  }
+  for (const url of positionals) {
+    if (!['http:', 'https:'].includes(new URL(url).protocol)) {
+      throw new Error('Only HTTP(S) URLs are supported.');
+    }
+  }
+  const numbers = Object.fromEntries(
+    ['runs', 'duration', 'warmup', 'timeout'].map((name) => {
+      const value = Number(values[name]);
+      if (
+        !values[name].trim() ||
+        !Number.isFinite(value) ||
+        (name === 'warmup' ? value < 0 : value <= 0)
+      ) {
+        throw new Error(`Invalid --${name}: ${values[name]}.`);
+      }
+      return [name, value];
+    })
+  );
+  if (!Number.isSafeInteger(numbers.runs)) {
+    throw new Error('--runs must be a positive integer.');
+  }
+  if (
+    (numbers.duration + numbers.timeout) * 1000 > 2147483647 ||
+    numbers.warmup * 1000 > 2147483647
+  ) {
+    throw new Error('Requested time exceeds the Node.js timer limit.');
+  }
+  if (!values.ready.trim() || values.event.some((name) => !name.trim())) {
+    throw new Error('--ready and --event must not be empty.');
+  }
+  for (const arg of values['chrome-arg']) {
+    if (
+      !arg.startsWith('--') ||
+      /^--(?:user-data-dir|profile-directory|remote-debugging[^=]*)(?:=|$)/.test(
+        arg
+      )
+    ) {
+      throw new Error(`Chrome flag would bypass profile isolation: ${arg}.`);
+    }
+  }
+  return {
+    chrome: values.chrome,
+    before: positionals[0],
+    after: positionals[1],
+    runs: numbers.runs,
+    durationMs: numbers.duration * 1000,
+    warmupMs: numbers.warmup * 1000,
+    timeoutMs: numbers.timeout * 1000,
+    ready: values.ready,
+    out: resolve(values.out ?? `.cache/xrblocks-profile-${Date.now()}`),
+    depth: values.depth,
+    eventNames: [
+      ...new Set([...(values.depth ? DEPTH_EVENTS : []), ...values.event]),
+    ],
+    chromeArgs: values['chrome-arg'],
+  };
+}
+
+// These functions are serialized into the page, so they must be self-contained.
+function installPageProbe(key, depth) {
+  if (window !== window.top) return;
+  const state = {active: false, contexts: new Set()};
+  Object.defineProperty(globalThis, key, {value: state});
+  const original = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function (...args) {
+    const context = original.apply(this, args);
+    if (
+      context &&
+      ['webgl', 'webgl2', 'experimental-webgl'].includes(args[0])
+    ) {
+      state.contexts.add(context);
+    }
+    return context;
+  };
+  if (!depth) return;
+  for (const type of [
+    globalThis.WebGLRenderingContext,
+    globalThis.WebGL2RenderingContext,
+  ]) {
+    for (const method of [
+      'getBufferSubData',
+      'getParameter',
+      'clientWaitSync',
+    ]) {
+      const native = type?.prototype[method];
+      if (!native) continue;
+      type.prototype[method] = function (...args) {
+        if (!state.active) return native.apply(this, args);
+        const start = performance.now();
+        try {
+          return native.apply(this, args);
+        } finally {
+          const name = `webgl:${method}`;
+          // Use the same reduced-precision clock at both ends of the measure.
+          performance.measure(name, {start, end: performance.now()});
+          performance.clearMeasures(name);
+        }
+      };
+    }
+  }
+}
+
+function readRenderers(key) {
+  return [...globalThis[key].contexts].map((gl) => {
+    if (gl.isContextLost())
+      throw new Error('A captured WebGL context was lost.');
+    const extension = gl.getExtension('WEBGL_debug_renderer_info');
+    return {
+      renderer: gl.getParameter(
+        extension?.UNMASKED_RENDERER_WEBGL ?? gl.RENDERER
+      ),
+      vendor: gl.getParameter(extension?.UNMASKED_VENDOR_WEBGL ?? gl.VENDOR),
+      unmasked: Boolean(extension),
+    };
+  });
+}
+
+function measurePage(key, prefix, durationMs) {
+  return new Promise((resolve) => {
+    const state = globalThis[key];
+    let rafCallbacks = 0;
+    let hidden = document.visibilityState !== 'visible';
+    const onVisibility = () => {
+      hidden ||= document.visibilityState !== 'visible';
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    let frameId;
+    const frame = () => {
+      rafCallbacks++;
+      frameId = requestAnimationFrame(frame);
+    };
+    performance.mark(`${prefix}:start`);
+    state.active = true;
+    frameId = requestAnimationFrame(frame);
+    setTimeout(() => {
+      state.active = false;
+      cancelAnimationFrame(frameId);
+      performance.mark(`${prefix}:end`);
+      document.removeEventListener('visibilitychange', onVisibility);
+      resolve({
+        rafCallbacks,
+        hidden,
+        url: location.href,
+        viewport: {
+          width: innerWidth,
+          height: innerHeight,
+          dpr: devicePixelRatio,
+        },
+      });
+    }, durationMs);
+  });
+}
+
+async function saveTrace(cdp, completion, path) {
+  if (!completion.stream)
+    throw new Error('Chrome did not return a trace stream.');
+  const file = await open(path, 'wx', 0o600);
+  try {
+    for (;;) {
+      const chunk = await cdp.send('IO.read', {handle: completion.stream});
+      await file.writeFile(
+        chunk.base64Encoded ? Buffer.from(chunk.data, 'base64') : chunk.data
+      );
+      if (chunk.eof) break;
+    }
+  } finally {
+    await file.close();
+  }
+  await cdp.send('IO.close', {handle: completion.stream});
+  if (completion.dataLossOccurred) {
+    throw new Error(`Chrome lost trace data; partial trace saved to ${path}.`);
+  }
+  return JSON.parse(await readFile(path, 'utf8'));
+}
+
+export async function cleanupProfile(profile, sampleError) {
+  try {
+    await rm(profile, {recursive: true, force: true, maxRetries: 5});
+  } catch (error) {
+    const message = `Could not remove temporary Chrome profile ${profile}: ${error.message}`;
+    if (sampleError) {
+      throw new AggregateError(
+        [sampleError, error],
+        `${sampleError.message}\n${message}`
+      );
+    }
+    throw new Error(message, {cause: error});
+  }
+}
+
+async function sample(options, run, signal) {
+  signal.throwIfAborted();
+  const profile = await mkdtemp(join(tmpdir(), 'xrblocks-profile-'));
+  const chromeArgs = [
+    `--user-data-dir=${profile}`,
+    '--remote-debugging-pipe',
+    '--no-startup-window',
+    '--no-first-run',
+    '--no-default-browser-check',
+    '--disable-default-apps',
+    '--disable-background-networking',
+    ...options.chromeArgs,
+  ];
+  const chrome = spawn(options.chrome, chromeArgs, {
+    stdio: ['ignore', 'ignore', 'pipe', 'pipe', 'pipe'],
+  });
+  const closed = new Promise((resolve) => chrome.once('close', resolve));
+  const cdp = new Cdp(chrome.stdio[3], chrome.stdio[4], options.timeoutMs);
+  let stderr = '';
+  chrome.stderr.setEncoding('utf8');
+  chrome.stderr.on('data', (data) => {
+    stderr = (stderr + data).slice(-8192);
+  });
+  chrome.on('error', (error) => cdp.fail(error));
+  chrome.on('exit', (code, signal) =>
+    cdp.fail(new Error(`Chrome exited (${signal ?? code}).`))
+  );
+  const abort = () => cdp.fail(signal.reason);
+  signal.addEventListener('abort', abort, {once: true});
+  let sampleError;
+
+  try {
+    const browser = await cdp.send('Browser.getVersion');
+    const {targetId} = await cdp.send('Target.createTarget', {
+      url: 'about:blank',
+    });
+    const {sessionId} = await cdp.send('Target.attachToTarget', {
+      targetId,
+      flatten: true,
+    });
+    const send = (method, params = {}) => cdp.send(method, params, sessionId);
+    const evaluate = async (expression, timeoutMs = options.timeoutMs) => {
+      const result = await cdp.send(
+        'Runtime.evaluate',
+        {
+          expression,
+          awaitPromise: true,
+          returnByValue: true,
+        },
+        sessionId,
+        timeoutMs
+      );
+      if (result.exceptionDetails) {
+        throw new Error(
+          result.exceptionDetails.exception?.description ??
+            result.exceptionDetails.text
+        );
+      }
+      return result.result.value;
+    };
+    const pageErrors = [];
+    const documents = new Map();
+    cdp.onEvent = (method, params, source) => {
+      if (source !== sessionId) return;
+      if (method === 'Runtime.exceptionThrown') {
+        pageErrors.push(
+          params.exceptionDetails.exception?.description ??
+            params.exceptionDetails.text
+        );
+      }
+      if (method === 'Network.responseReceived' && params.type === 'Document') {
+        documents.set(params.frameId, params.response.status);
+      }
+    };
+    const checkErrors = () => {
+      if (pageErrors.length) {
+        throw new Error(`Page threw an exception:\n${pageErrors.join('\n')}`);
+      }
+    };
+    await send('Page.enable');
+    await send('Runtime.enable');
+    await send('Network.enable');
+    await send('Emulation.setDeviceMetricsOverride', {
+      width: 1280,
+      height: 720,
+      deviceScaleFactor: 1,
+      mobile: false,
+    });
+    const key = `__xrblocksProfile_${randomUUID()}`;
+    await send('Page.addScriptToEvaluateOnNewDocument', {
+      source: `(${installPageProbe})(${JSON.stringify(key)}, ${options.depth})`,
+    });
+    const [, navigation] = await Promise.all([
+      cdp.waitFor('Page.loadEventFired', sessionId),
+      send('Page.navigate', {url: options[run.side]}).then((result) => {
+        if (result.errorText || result.isDownload) {
+          throw new Error(
+            `Navigation failed: ${result.errorText ?? 'download'}.`
+          );
+        }
+        return result;
+      }),
+    ]);
+    await send('Network.disable');
+    const httpStatus = documents.get(navigation.frameId);
+    if (httpStatus >= 400) throw new Error(`Page returned HTTP ${httpStatus}.`);
+    const deadline = Date.now() + options.timeoutMs;
+    for (;;) {
+      checkErrors();
+      const remaining = deadline - Date.now();
+      if (remaining <= 0)
+        throw new Error(`Readiness timed out: ${options.ready}`);
+      if (
+        await evaluate(
+          `(async () => Boolean(await (${options.ready})))()`,
+          remaining
+        )
+      )
+        break;
+      await delay(100, undefined, {signal});
+    }
+    await delay(options.warmupMs, undefined, {signal});
+    checkErrors();
+    const initialRenderers = await evaluate(
+      `(${readRenderers})(${JSON.stringify(key)})`
+    );
+    const prefix = `xrblocks-profile:${randomUUID()}`;
+    await cdp.send('Tracing.start', {
+      transferMode: 'ReturnAsStream',
+      streamFormat: 'json',
+      traceConfig: {
+        recordMode: 'recordUntilFull',
+        includedCategories: [
+          'toplevel',
+          'blink.user_timing',
+          'devtools.timeline',
+          'disabled-by-default-devtools.timeline',
+        ],
+        excludedCategories: ['*'],
+      },
+    });
+    const measured = await evaluate(
+      `(${measurePage})(${JSON.stringify(key)}, ${JSON.stringify(prefix)}, ${options.durationMs})`,
+      options.durationMs + options.timeoutMs
+    );
+    const [completion] = await Promise.all([
+      cdp.waitFor('Tracing.tracingComplete'),
+      cdp.send('Tracing.end'),
+    ]);
+    const traceFile = `${run.pair}-${run.side}.trace.json`;
+    const trace = await saveTrace(
+      cdp,
+      completion,
+      join(options.out, traceFile)
+    );
+    checkErrors();
+    if (measured.hidden)
+      throw new Error('Page became hidden during measurement.');
+    const report = analyzeTrace(trace, prefix, options.eventNames);
+    const renderers = await evaluate(
+      `(${readRenderers})(${JSON.stringify(key)})`
+    );
+    const warnings = [...report.warnings];
+    if (JSON.stringify(renderers) !== JSON.stringify(initialRenderers)) {
+      warnings.push(
+        'WebGL contexts changed during measurement; check readiness and warm-up.'
+      );
+    }
+    if (!renderers.length || renderers.some((renderer) => !renderer.unmasked)) {
+      warnings.push(
+        'Actual WebGL renderer is unverified (no captured context or unmasked renderer).'
+      );
+    }
+    if (
+      renderers.some(({renderer}) =>
+        /swiftshader|llvmpipe|software|basic render driver/i.test(renderer)
+      )
+    ) {
+      warnings.push(
+        'Software WebGL renderer detected; these are not hardware GPU results.'
+      );
+    }
+    if (!measured.rafCallbacks)
+      warnings.push('No animation-frame callbacks occurred.');
+    return {
+      ...run,
+      browser,
+      renderers,
+      measured,
+      httpStatus,
+      durationMs: report.durationMs,
+      metrics: {
+        'Window (ms)': report.durationMs,
+        'rAF callbacks/s': (measured.rafCallbacks * 1000) / report.durationMs,
+        ...report.metrics,
+      },
+      traceFile,
+      warnings,
+    };
+  } catch (error) {
+    const failure = signal.aborted ? signal.reason : error;
+    sampleError = new Error(
+      `Pair ${run.pair} (${run.side}): ${failure.message}${stderr && !signal.aborted ? `\nChrome stderr:\n${stderr}` : ''}`,
+      {cause: failure}
+    );
+    throw sampleError;
+  } finally {
+    signal.removeEventListener('abort', abort);
+    cdp.fail(new Error('Closing profiler Chrome instance.'));
+    if (chrome.exitCode === null && chrome.signalCode === null)
+      chrome.kill('SIGTERM');
+    const forceKill = setTimeout(() => chrome.kill('SIGKILL'), 5000);
+    await closed;
+    clearTimeout(forceKill);
+    await cleanupProfile(profile, sampleError);
+  }
+}
+
+async function writeJson(path, value) {
+  await writeFile(path, JSON.stringify(value, null, 2) + '\n', {
+    flag: 'wx',
+    mode: 0o600,
+  });
+}
+
+async function main() {
+  const options = parseOptions(process.argv.slice(2));
+  if (options.help) {
+    console.log(HELP);
+    return;
+  }
+  await mkdir(dirname(options.out), {recursive: true});
+  await mkdir(options.out, {mode: 0o700});
+  console.log(`Saving local results to ${options.out}`);
+  const environment = {
+    node: process.version,
+    platform: platform(),
+    arch: arch(),
+    osRelease: release(),
+    viewport: {width: 1280, height: 720, dpr: 1},
+    startedAt: new Date().toISOString(),
+  };
+  await writeJson(join(options.out, 'run.json'), {options, environment});
+  const controller = new AbortController();
+  const interrupt = () => controller.abort(new Error('Profiling interrupted.'));
+  process.once('SIGINT', interrupt);
+  process.once('SIGTERM', interrupt);
+  try {
+    const samples = [];
+    for (const run of runOrder(options.runs)) {
+      console.log(
+        `Pair ${run.pair}/${options.runs}: ${run.side} ${options[run.side]}`
+      );
+      const result = await sample(options, run, controller.signal);
+      await writeJson(
+        join(options.out, `${run.pair}-${run.side}.json`),
+        result
+      );
+      samples.push(result);
+      for (const warning of result.warnings)
+        console.warn(`Warning: ${warning}`);
+      console.log(
+        `Renderer: ${result.renderers.map((r) => r.renderer).join('; ') || 'unverified'}`
+      );
+    }
+    const warnings = [...new Set(samples.flatMap((sample) => sample.warnings))];
+    if (options.runs === 1)
+      warnings.push('Only one pair; sample SD is unavailable.');
+    const rendererSets = samples.map((s) =>
+      JSON.stringify([...new Set(s.renderers.map((r) => r.renderer))].sort())
+    );
+    if (
+      new Set(rendererSets).size > 1 ||
+      new Set(samples.map((s) => s.browser.product)).size > 1
+    ) {
+      warnings.push(
+        'Renderer or Chrome version changed between samples; the comparison is confounded.'
+      );
+    }
+    for (const name of options.eventNames) {
+      if (options.depth && DEPTH_EVENTS.includes(name)) continue;
+      if (samples.every((s) => s.metrics[`${name} (calls)`] === 0)) {
+        warnings.push(
+          `"${name}" was never observed; zero does not prove no calls (check Chrome event names/categories).`
+        );
+      }
+    }
+    const rows = comparisonRows(samples);
+    const summary = {
+      options,
+      environment,
+      samples,
+      rows,
+      warnings,
+    };
+    await writeJson(join(options.out, 'summary.json'), summary);
+    const reportPath = join(options.out, 'report.html');
+    await writeFile(reportPath, renderHtmlReport(summary), {
+      flag: 'wx',
+      mode: 0o600,
+    });
+    printComparison(rows);
+    for (const warning of warnings) console.warn(`Warning: ${warning}`);
+    console.log(`HTML report: ${reportPath}`);
+  } finally {
+    process.removeListener('SIGINT', interrupt);
+    process.removeListener('SIGTERM', interrupt);
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/tools/profile.test.ts
+++ b/tools/profile.test.ts
@@ -1,0 +1,196 @@
+// @vitest-environment node
+
+import {rm} from 'node:fs/promises';
+import {PassThrough} from 'node:stream';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {Cdp} from './profile-cdp.js';
+import {cleanupProfile, parseOptions} from './profile.js';
+
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:fs/promises')>()),
+  rm: vi.fn(),
+}));
+
+describe('profiler arguments', () => {
+  const base = [
+    '--chrome',
+    '/path with spaces/chrome',
+    'http://127.0.0.1:8080/',
+    'http://127.0.0.1:8081/',
+  ];
+
+  it('accepts URLs and a Chrome path without changing either URL', () => {
+    const options = parseOptions(base);
+    expect(options.before).toBe(base[2]);
+    expect(options.after).toBe(base[3]);
+    expect(options.chrome).toBe(base[1]);
+    expect(options.runs).toBe(5);
+    expect(options.durationMs).toBe(8000);
+    expect(options.warmupMs).toBe(3000);
+    expect(options.eventNames).toEqual([]);
+  });
+
+  it('keeps depth instrumentation opt-in and deduplicates selected events', () => {
+    const options = parseOptions([
+      ...base,
+      '--depth',
+      '--event=webgl:getParameter',
+      '--event=Layout',
+      '--chrome-arg=--headless=new',
+      '--warmup=0',
+    ]);
+    expect(options.depth).toBe(true);
+    expect(options.eventNames).toEqual([
+      'webgl:getBufferSubData',
+      'webgl:getParameter',
+      'webgl:clientWaitSync',
+      'Layout',
+    ]);
+    expect(options.chromeArgs).toEqual(['--headless=new']);
+    expect(options.warmupMs).toBe(0);
+  });
+
+  it.each([
+    ['--runs=0'],
+    ['--runs=1.5'],
+    ['--duration=0'],
+    ['--duration=Infinity'],
+    ['--duration=3000000'],
+    ['--warmup=-1'],
+    ['--timeout=0'],
+    ['--event='],
+    ['--ready='],
+    ['--chrome-arg=--user-data-dir=/tmp/existing-profile'],
+    ['--chrome-arg=--remote-debugging-port=9222'],
+    ['--chrome-arg=about:blank'],
+  ])('rejects invalid configuration: %s', (option) => {
+    expect(() => parseOptions([...base, option])).toThrow();
+  });
+
+  it('rejects missing arguments and non-HTTP URLs', () => {
+    expect(() => parseOptions(['--chrome=chrome'])).toThrow();
+    expect(() => parseOptions(base.slice(2))).toThrow(/chrome/i);
+    expect(() =>
+      parseOptions(['--chrome=chrome', 'file:///tmp/a', base[3]])
+    ).toThrow(/HTTP/i);
+  });
+
+  it('prints help without requiring a browser or URLs', () => {
+    expect(parseOptions(['--help']).help).toBe(true);
+  });
+});
+
+describe('CDP pipe client', () => {
+  const clients: Cdp[] = [];
+  function client() {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const cdp = new Cdp(input, output, 100);
+    clients.push(cdp);
+    return {cdp, input, output};
+  }
+
+  afterEach(() => {
+    for (const cdp of clients.splice(0)) cdp.fail(new Error('Test cleanup.'));
+    vi.useRealTimers();
+  });
+
+  it('frames commands and accepts fragmented UTF-8 replies', async () => {
+    const {cdp, input, output} = client();
+    const response = cdp.send('Browser.getVersion');
+    expect(input.read().toString()).toBe(
+      '{"id":1,"method":"Browser.getVersion","params":{}}\0'
+    );
+    const reply = Buffer.from('{"id":1,"result":{"text":"caf\u00e9"}}\0');
+    const split = reply.indexOf(Buffer.from('\u00e9')) + 1;
+    output.write(reply.subarray(0, split));
+    output.write(reply.subarray(split));
+    await expect(response).resolves.toEqual({text: 'caf\u00e9'});
+  });
+
+  it('routes responses by ID and events by page session', async () => {
+    const {cdp, output} = client();
+    const one = cdp.send('One');
+    const two = cdp.send('Two');
+    const loaded = cdp.waitFor('Page.loadEventFired', 'page');
+    output.write(
+      '{"id":2,"result":{"n":2}}\0' +
+        '{"method":"Page.loadEventFired","sessionId":"other","params":{"timestamp":1}}\0' +
+        '{"id":1,"result":{"n":1}}\0' +
+        '{"method":"Page.loadEventFired","sessionId":"page","params":{"timestamp":2}}\0'
+    );
+    await expect(one).resolves.toEqual({n: 1});
+    await expect(two).resolves.toEqual({n: 2});
+    await expect(loaded).resolves.toEqual({timestamp: 2});
+  });
+
+  it('surfaces protocol errors with the command name', async () => {
+    const {cdp, output} = client();
+    const response = cdp.send('Tracing.start');
+    output.write('{"id":1,"error":{"message":"Unsupported config"}}\0');
+    await expect(response).rejects.toThrow('Tracing.start: Unsupported config');
+  });
+
+  it('bounds waits instead of hanging on a missing response', async () => {
+    vi.useFakeTimers();
+    const {cdp} = client();
+    const response = cdp.send('Runtime.evaluate');
+    const assertion = expect(response).rejects.toThrow(
+      'Timed out waiting for Runtime.evaluate'
+    );
+    await vi.advanceTimersByTimeAsync(100);
+    await assertion;
+    expect(cdp.pending.size).toBe(0);
+  });
+
+  it('rejects all pending work and future commands on pipe failure', async () => {
+    const {cdp, output} = client();
+    const response = cdp.send('One');
+    const event = cdp.waitFor('Tracing.tracingComplete');
+    const assertions = [
+      expect(response).rejects.toThrow(/JSON/),
+      expect(event).rejects.toThrow(/JSON/),
+    ];
+    output.write('not JSON\0');
+    await Promise.all(assertions);
+    await expect(cdp.send('Two')).rejects.toThrow(/JSON/);
+  });
+});
+
+describe('temporary profile cleanup', () => {
+  afterEach(() => vi.mocked(rm).mockReset());
+
+  it('retries transient filesystem failures and tolerates an absent profile', async () => {
+    vi.mocked(rm).mockResolvedValueOnce(undefined);
+    await cleanupProfile('/tmp/test-profile', undefined);
+    expect(rm).toHaveBeenCalledWith('/tmp/test-profile', {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+    });
+  });
+
+  it('preserves the sampling failure when cleanup also fails', async () => {
+    const sampleError = new Error('Pair 1 (before): Page returned HTTP 404.');
+    const removalError = new Error('EBUSY: profile is still locked');
+    vi.mocked(rm).mockRejectedValueOnce(removalError);
+    await expect(
+      cleanupProfile('/tmp/test-profile', sampleError)
+    ).rejects.toMatchObject({
+      message: `${sampleError.message}\nCould not remove temporary Chrome profile /tmp/test-profile: ${removalError.message}`,
+      errors: [sampleError, removalError],
+    });
+  });
+
+  it('surfaces failed cleanup rather than silently leaking a profile', async () => {
+    const removalError = new Error('EPERM');
+    vi.mocked(rm).mockRejectedValueOnce(removalError);
+    await expect(
+      cleanupProfile('/tmp/test-profile', undefined)
+    ).rejects.toMatchObject({
+      message:
+        'Could not remove temporary Chrome profile /tmp/test-profile: EPERM',
+      cause: removalError,
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     },
   },
   test: {
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'tools/**/*.test.ts'],
     environment: 'jsdom',
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Description

<!-- Brief summary of changes. For new demos/samples, include the directory path (e.g., `demos/my_demo/`). -->

the before/after profiling workflow from #505 wasn't checked in, so repeating those measurements meant using an ad hoc script.

adds a dependency-free Node CLI that compares two URLs using interleaved pairs, saves raw Chrome traces, and reports means, sample SD and paired differences. includes renderer warnings and opt-in instrumentation for the WebGL depth calls. the frame metric is `rAF callbacks/s`, not displayed FPS, and normal Chrome frame pacing is preserved unless you pass override flags.

completed comparisons also write a self-contained HTML report with tables, charts, warnings and trace links. follows the system's light/dark preference. no server, report JavaScript, SDK API changes or new runtime dependencies.

## Type of Change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] New demo or sample
- [x] Documentation update

## Media / Screen Recordings & Screenshots (If Applicable)

- **Simulator Recording**: N/A (developer tooling, not a simulator scene). <!-- Attach video/GIF running in desktop simulator -->
- **Device Recording**: N/A (no on-device changes). <!-- Attach video/GIF running on physical hardware -->

## Checklist

- [ ] **Tested in simulator & device**: Verified functionality in desktop simulator and/or physical hardware (where applicable). N/A for XR simulator/device flows; exercised the CLI and reports with standalone Chrome/WebGL fixtures.
- [ ] **Large Assets ($\ge$ 1MB)**: Submitted separately to [xrblocks/proprietary-assets](https://github.com/xrblocks/proprietary-assets) via jsdelivr CDN. N/A, no large assets added.
- [ ] **SDK Dynamic Dependencies**: All new SDK dependencies are dynamically loaded at runtime. N/A, no SDK dependencies added.
- [x] **Security**: Confirmed no hardcoded API keys or secrets are committed.